### PR TITLE
Fix xAxisTitle text anchor by adding separate text tag

### DIFF
--- a/packages/components/viz/XAxis.svelte
+++ b/packages/components/viz/XAxis.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
   import formatAxisLabel from '../modules/formatAxisLabel.js'
-	const { width, height, xScale, xDomain, yRange, padding, yDomain} = getContext('LayerCake');
+	const { width, height, xScale, xDomain, xRange, yRange, padding, yDomain} = getContext('LayerCake');
   
   // "ticks" is the number of ticks to add to the x axis
   // by default, d3 uses 10 ticks unless overridden
@@ -66,9 +66,9 @@
 		if (i === 0) {
 		  return 'start';
 		}
-		if (i === tickVals.length - 1) {
-		  return 'end';
-		}
+    if (i === tickVals.length - 1){
+      return 'end'
+    }
 	  }
 	  return 'middle';
 	}
@@ -134,11 +134,22 @@
           font-size='{labelSize}'
           >
           {#if i + 1 === tickVals.length}
-          {formatAxisLabel(tick, xFormat, xUnits, "firstTick") + (reverseAxes ? " " + axisTitle : "")}
+          {formatAxisLabel(tick, xFormat, xUnits, "firstTick")}
           {:else}
           {formatAxisLabel(tick, xFormat, xUnits)}
           {/if}
         </text>
+        {#if reverseAxes && i + 1 === tickVals.length}
+        <text
+          x="{(formatAxisLabel(tick).length/2) * 18}"
+          y='{axisPosition === "top" ? -$yRange[0] - 8 : yTick}'
+          text-anchor='start'
+          fill='{labelColor}'
+          font-size='{labelSize}'
+        >
+          {axisTitle}
+        </text>
+        {/if}
       {/if}
     {/if}
 

--- a/sites/components-workspace/src/components/viz/XAxis.svelte
+++ b/sites/components-workspace/src/components/viz/XAxis.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
   import formatAxisLabel from '../modules/formatAxisLabel.js'
-	const { width, height, xScale, xDomain, yRange, padding, yDomain} = getContext('LayerCake');
+	const { width, height, xScale, xDomain, xRange, yRange, padding, yDomain} = getContext('LayerCake');
   
   // "ticks" is the number of ticks to add to the x axis
   // by default, d3 uses 10 ticks unless overridden
@@ -66,9 +66,9 @@
 		if (i === 0) {
 		  return 'start';
 		}
-		if (i === tickVals.length - 1) {
-		  return 'end';
-		}
+    if (i === tickVals.length - 1){
+      return 'end'
+    }
 	  }
 	  return 'middle';
 	}
@@ -134,11 +134,22 @@
           font-size='{labelSize}'
           >
           {#if i + 1 === tickVals.length}
-          {formatAxisLabel(tick, xFormat, xUnits, "firstTick") + (reverseAxes ? " " + axisTitle : "")}
+          {formatAxisLabel(tick, xFormat, xUnits, "firstTick")}
           {:else}
           {formatAxisLabel(tick, xFormat, xUnits)}
           {/if}
         </text>
+        {#if reverseAxes && i + 1 === tickVals.length}
+        <text
+          x="{(formatAxisLabel(tick).length/2) * 18}"
+          y='{axisPosition === "top" ? -$yRange[0] - 8 : yTick}'
+          text-anchor='start'
+          fill='{labelColor}'
+          font-size='{labelSize}'
+        >
+          {axisTitle}
+        </text>
+        {/if}
       {/if}
     {/if}
 

--- a/sites/components-workspace/src/pages/index.svelte
+++ b/sites/components-workspace/src/pages/index.svelte
@@ -34,7 +34,7 @@ This is a value component: <Value data={[{"date":"2020-05-07"}]}/> and this is a
 
 <h2>Bar Chart</h2>
 <BarChart data={testData} x=x y=y/>
-<BarChart data={countries} x=year y=value series=country/>
+<BarChart data={countries} x=year y=value series=country units="long units string"/>
 
 <h2>Column Chart</h2>
 <ColumnChart data={testData} x=x y=y/>


### PR DESCRIPTION
Fixes #65  

Adds a separate text tag for the xAxisTitle of reverse axis charts (e.g., the "units" prop of BarChart).

New text tag is positioned to the right of the tick label on the furthest right. Padding between tick label and new text tag is based on a rough string length approximation.