### PR TITLE
revert to previous version of docusaurus themes

### DIFF
--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.0",
     "@docusaurus/preset-classic": "2.0.0-beta.0",
-    "@docusaurus/theme-classic": "^2.0.0-beta.4",
-    "@docusaurus/theme-common": "^2.0.0-beta.4",
+    "@docusaurus/theme-classic": "2.0.0-beta.4",
+    "@docusaurus/theme-common": "2.0.0-beta.4",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Docusaurus release updated parts of theme-common which broke our build of our docs site. Reverting to previous versions of theme-classic and theme-common to ensure the docs build correctly.