### PR TITLE
Added another root cause to common error

### DIFF
--- a/sites/docs/docs/troubleshooting.md
+++ b/sites/docs/docs/troubleshooting.md
@@ -12,7 +12,8 @@ If you have a specific question and cannot go through Slack or GitHub, please em
 <!-- ## Installation
 
 ## Offset is longer than source length
-If you have single quotes in your SQL query, this is a known issue - for now, change your quotes to double quotes and the query should run.
+- If you have single quotes in your SQL query, this is a known issue - for now, change your quotes to double quotes and the query should run.
+- This error can also happen if your query identifier starts with a number.  Please start all query names (the first line in the markdown codeblock that defines a query) with alphabetics.
 
 ### NPM Init Error
 


### PR DESCRIPTION
"offset is longer than source length" can also occur if the query identifier in the markdown block starts with a number.