### PR TITLE
Misc UI fixes

### DIFF
--- a/sites/example-project/src/components/ui/ChevronToggle.svelte
+++ b/sites/example-project/src/components/ui/ChevronToggle.svelte
@@ -4,12 +4,8 @@
     export let size = 10
 </script>
 
-<span>
-{#if toggled}
-<svg viewBox="0 0 16 16" width={size} height={size}><path fill={color} fill-rule="evenodd" d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"></path></svg>
-{:else}
-<svg viewBox="0 0 16 16" width={size} height={size}><path fill={color} fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg> 
-{/if}
+<span aria-expanded="{toggled}">
+    <svg viewBox="0 0 16 16" width={size} height={size}><path fill={color} fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg> 
 </span>
 
 <style>
@@ -17,6 +13,11 @@
     svg{
         display: inline-block;
         vertical-align: middle;
+        transition: transform 0.15s ease-in;
+    }
+
+    [aria-expanded=true] svg { 
+        transform: rotate(0.25turn); 
     }
 
 </style>

--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -23,7 +23,7 @@
   let showCompilerToggle = (queries[0].compiled && queries[0].compileError === undefined)
   let showCompiled = showCompilerToggle
       // Pre-calculate the container height for smooth slide transition 
-  let codeContainerHeight =  Math.min(Math.max(compiledQuery.split(/\r\n|\r|\n/).length, inputQuery.split(/\r\n|\r|\n/).length)*1.5 +1, 30) 
+  let codeContainerHeight =  Math.min(Math.max(compiledQuery.split(/\r\n|\r|\n/).length, inputQuery.split(/\r\n|\r|\n/).length)*1.5 +1, 30)
 
   // Status Bar & Results Toggle 
   let error = queryResult.error
@@ -51,6 +51,7 @@
  {#if $showQueries}
     <!-- Title -->
     <div class="container" transition:slide|local>
+      <div class="container-a">
         <div on:click={toggleSQL} class="title">
           <span><ChevronToggle toggled={showSQL}/> {queryID}</span>
         </div>
@@ -68,6 +69,7 @@
               {/if}
             </div>  
           {/if}
+      </div>
       <!-- Status -->
       <div class = {"status-bar" + (error ? " error": " success") + (showResults ? " open": " closed")} on:click={toggleResults}>  
         <span> 
@@ -83,7 +85,7 @@
       </div>
         {#if queryResult.length > 0 && !error && showResults}
             <DataTable data={queryResult}/>
-        {/if}
+            {/if}
     </div>
  {/if}
 </div>
@@ -170,7 +172,7 @@
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;
         transition:400ms;
-        transition-delay: 400ms 
+        transition-delay: 400ms; 
         /* 400ms is the default duration for the slide */
     }
 
@@ -222,4 +224,13 @@
         font-size: 0.8em;
         margin-top:0.75em;
     }
+
+    .container-a {
+      background-color: var(--grey-100);
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px;
+      box-sizing: border-box;
+    }
+    /* container-a avoids whitespace appearing in the slide transition */
+
 </style>

--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -1,5 +1,6 @@
 <script>
   import { slide } from 'svelte/transition';
+  import { dev } from '$app/env';
   import DataTable from './QueryViewerSupport/QueryDataTable.svelte'
   import ChevronToggle from "./ChevronToggle.svelte"
   import Prism from "./QueryViewerSupport/Prismjs.svelte";
@@ -74,7 +75,12 @@
       <div class = {"status-bar" + (error ? " error": " success") + (showResults ? " open": " closed")} on:click={toggleResults}>  
         <span> 
           {#if error}
-            {error.message} 
+            {#if dev && error.message === "Missing database credentials"}
+              {error.message}.
+              <a class=credentials-link href='/settings'> Add credentials here</a>
+            {:else}
+              {error.message} 
+            {/if}
           {:else if nRecords > 0}
             <ChevronToggle toggled={showResults} color="#3488e9"/> {nRecords.toLocaleString()} {nRecords > 1 ? "records" : "record"} with {nProperties.toLocaleString()} {nProperties > 1 ? "properties" : "property"} 
           {:else}

--- a/sites/example-project/src/components/ui/QueryViewerSupport/Prismjs.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/Prismjs.svelte
@@ -72,7 +72,7 @@
   });
 
 </script>
-  <pre in:blur|local>
+  <pre in:blur>
     <code class="language-{language}">{code}</code>
   </pre>
 <style>

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <div class="container"  transition:slide|local>
-  <table >
+  <table in:blur>
       <thead>
         <tr>
           <th class="index" style="width:10%"></th>
@@ -76,7 +76,7 @@
 </div>   
 
 {#if max > 0}
-<div class="pagination">
+<div class="pagination" transition:slide>
   <input type="range" max={max} step=1 bind:value={index} on:input={slice} class="slider">
   <span style="padding-top: 1px;">
   {(index+size).toLocaleString()} of {(max+size).toLocaleString()} 
@@ -93,6 +93,7 @@
     align-content: center;
     border-bottom: 1px solid var(--grey-200);   
     height: 1.5em;
+    background-color: white;
   }
 
   .slider {
@@ -164,6 +165,7 @@
     border-bottom: 1px solid var(--grey-200);   
     scrollbar-width: thin; 
     scrollbar-color: var(--scrollbar-color) var(--scrollbar-track-color);
+    background-color: white;
   }
 
     .container::-webkit-scrollbar {


### PR DESCRIPTION
 - Remove whitespace in transition of query viewer closing
 - Add transition for query viewer chevron when opening and closing
 - Make transition smooth for pagination portion of query data table - previously was snapping shut later than the rest of the table
 - Add blur transition to SQL code to cover flash of unstyled code when opening the code pane of the query viewer
 - Add blur transition to table when opening the data table pane
 - Add a link to the settings page when user receives `Missing database credentials` error