### PR TITLE
Bubble chart fixes

### DIFF
--- a/.changeset/grumpy-cats-accept.md
+++ b/.changeset/grumpy-cats-accept.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/evidence': patch
+'@evidence-dev/components': patch
+---
+
+Fix BubbleChart scaling function

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -3,6 +3,19 @@
   "version": "0.1.17",
   "description": "dependencies for evidence projects",
   "type": "module",
+  "keywords": [
+    "analytics",
+    "business-intelligence",
+    "data",
+    "sql",
+    "markdown",
+    "svelte",
+    "data-visualization",
+    "visualization",
+    "data-viz",
+    "charts",
+    "echarts"
+  ],
   "author": "",
   "license": "MIT",
   "devDependencies": {

--- a/sites/docs/docs/components/charts/bubble-chart.md
+++ b/sites/docs/docs/components/charts/bubble-chart.md
@@ -36,8 +36,7 @@ hide_table_of_contents: false
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
 <tr>	<td>shape</td>	<td>Options for which shape to use for bubble points</td>	<td class='tcenter'>-</td>	<td class='tcenter'>circle | emptyCircle | rect | triangle | diamond</td>	<td class='tcenter'>circle</td>	</tr>
-<tr>	<td>minSize</td>	<td>Minimum bubble size</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>10</td>	</tr>
-<tr>	<td>maxSize</td>	<td>Maximum bubble size</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>35</td>	</tr>
+<tr>	<td>scaleTo</td>	<td>Scale the size of the bubbles by this factor (e.g., 2 will double the size)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>1</td>	</tr>
 <tr>	<td>opacity</td>	<td>% of the full color that should be rendered, with remainder being transparent</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number (0 to 1)</td>	<td class='tcenter'>0.7</td>	</tr>
 <tr>	<td>fillColor</td>	<td>Color to override default series color. Only accepts a single color.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>CSS name | hexademical | RGB | HSL</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>outlineWidth</td>	<td>Width of line surrounding each shape</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>0</td>	</tr>

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -17,8 +17,9 @@
     export let outlineColor = undefined;
     export let outlineWidth = undefined;
 
-    export let minSize = 10;
-    export let maxSize = 35;
+    let maxSize = 35;
+    export let scaleTo = 1;
+    maxSize = maxSize * (scaleTo / 1);
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
     let data = $props.data;
@@ -42,18 +43,18 @@
 
     // Determine bubble sizes:
     let sizeExtents = getColumnExtents(data, size);
-    let dataRange = sizeExtents[1] - sizeExtents[0];
-    let minData = sizeExtents[0];
-    let minSizeSq;
-    let maxSizeSq;
+    let maxData = sizeExtents[1];
+    let maxSizeSq = Math.pow(maxSize, 2);
+
+    // Maximum point in dataset is assigned the maximum point area on the graph. Other
+    // points are assigned based on their proportion to the maximum point. 
+    // E.g., if max point in dataset is 100 and we want to plot 45 as the next point,
+    // we will be drawing a point that is 45% of the area of the max point
+
     function bubbleSize(newPoint){
-        minSizeSq = Math.pow(minSize, 2);
-        maxSizeSq = Math.pow(maxSize, 2);
-        let sizeRange = maxSizeSq - minSizeSq;
-        
-        return Math.sqrt(((newPoint - minData) / dataRange) * sizeRange + minSize)
+        const newPointSize = data.filter(d => d[x] === newPoint[0] && d[y] === newPoint[1])[0][size]
+        return Math.sqrt((newPointSize / maxData) * maxSizeSq)
     }
-    
 
     let baseConfig = {
             type: "scatter",
@@ -65,7 +66,7 @@
                 focus: "series",
             },
             symbolSize: function (data) {
-                return bubbleSize(data[1]);
+                return bubbleSize(data);
             },
             symbol: shape,
             itemStyle: {

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -27,8 +27,7 @@
     export let opacity = undefined; // opacity of both fill and outline (ECharts limitation)
     export let outlineColor = undefined;
     export let outlineWidth = undefined;
-    export let minSize = undefined;
-    export let maxSize = undefined;
+    export let scaleTo = undefined;
 
     export let sort = undefined;
 
@@ -66,7 +65,6 @@
         {opacity}
         {outlineColor}
         {outlineWidth}
-        {minSize}
-        {maxSize}
+        {scaleTo}
     />
 </Chart>


### PR DESCRIPTION
BubbleChart's scaling function contained a bug that was making the bubble areas not proportional to one another. This PR makes each bubble the correct area relative to other points in the dataset. This also includes a `scaleTo` prop, which allows you to increase or decrease the size of the largest bubble (similar to Excel's functionality for bubble charts).