### PR TITLE
fix gitignore filepath and gitignore check for sqlite extensions

### DIFF
--- a/sites/example-project/src/components/ui/Databases/SqliteForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SqliteForm.svelte
@@ -4,7 +4,7 @@
 	export let credentials;
 	export let existingCredentials;
     export let gitIgnore;
-    existingCredentials.gitignoreSqlite = gitIgnore.includes("\n.db") && gitIgnore.includes("\n.sqlite3") && gitIgnore.includes("\n.sqlite")
+    existingCredentials.gitignoreSqlite = gitIgnore.match(/\n.db(?=\n|$)/) && gitIgnore.match(/\n.sqlite3(?=\n|$)/) && gitIgnore.match(/\n.sqlite(?=\n|$)/)
     export let disableSave;
 
 	credentials = { ...existingCredentials };

--- a/sites/example-project/src/pages/api/settings.json.js
+++ b/sites/example-project/src/pages/api/settings.json.js
@@ -13,8 +13,8 @@ export async function get() {
         if (fs.existsSync('evidence.settings.json')) {
             settings = JSON.parse(fs.readFileSync('evidence.settings.json', 'utf8'));
         }
-        if (fs.existsSync('.gitignore')) {
-            gitIgnore = fs.readFileSync('.gitignore', 'utf8')
+        if (fs.existsSync('../../.gitignore')) {
+            gitIgnore = fs.readFileSync('../../.gitignore', 'utf8')
         }
         return {
             header: "accept: application/json",
@@ -32,7 +32,7 @@ export function post(request) {
     const {settings} = JSON.parse(request.body)
     fs.writeFileSync('evidence.settings.json', JSON.stringify(settings));
     if(settings.database === "sqlite"){
-        let gitIgnore = fs.readFileSync('.gitignore', 'utf8')
+        let gitIgnore = fs.readFileSync('../../.gitignore', 'utf8')
         let extensions = [".db", ".sqlite", ".sqlite3"]
         if(settings.credentials.gitignoreSqlite === false){
             let regex
@@ -44,7 +44,7 @@ export function post(request) {
                 regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
                 gitIgnore = gitIgnore.replace(regex, "")
             })
-            fs.writeFileSync('.gitignore', gitIgnore)
+            fs.writeFileSync('../../.gitignore', gitIgnore)
         } else if(settings.credentials.gitignoreSqlite === true){
             extensions.forEach(ext => {
                 regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
@@ -52,7 +52,7 @@ export function post(request) {
                     gitIgnore = gitIgnore + ("\n" + ext)
                 }
             })
-            fs.writeFileSync('.gitignore', gitIgnore)
+            fs.writeFileSync('../../.gitignore', gitIgnore)
         }
     }
     return {


### PR DESCRIPTION
- Change gitignore filepath to reference two directories above the current directory (to reference the root directory of the proejct)
    - This references the root gitignore for the example-project, which is not the correct one for running that project, but does allow us to test that the functionality of editing the gitignore file in a user's project root will work.
- Change check of sqlite extensions in gitignore to use regex (account for "sqlite" being contained in "sqlite3")