### PR TITLE
Hide the show/hide queries button if no queries on page

### DIFF
--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -34,7 +34,7 @@ const createModuleContext = function(filename){
                 }
             }
             `
-    }
+        }
     return moduleContext
 } 
 
@@ -43,6 +43,7 @@ const createDefaultProps = function(filename, componentDevelopmentMode){
     let routeHash = getRouteHash(filename)
     let defaultProps = `
         import { page } from '$app/stores';
+        import { pageHasQueries } from '$lib/ui/stores.js';
         import BigLink from '${componentSource}/ui/BigLink.svelte';
         import Value from '${componentSource}/viz/Value.svelte';
         import Chart from '${componentSource}/viz/Chart.svelte';
@@ -66,9 +67,15 @@ const createDefaultProps = function(filename, componentDevelopmentMode){
     if(hasQueries(filename)){
         defaultProps = `
             export let data
+            pageHasQueries.update(value => value = true)
             import QueryViewer from '${componentSource}/ui/QueryViewer.svelte';
             ${defaultProps}
         `
+    } else {
+        defaultProps = `
+        pageHasQueries.update(value => value = false)
+        ${defaultProps}
+    `
     }
     return defaultProps
 }

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -43,7 +43,7 @@ const createDefaultProps = function(filename, componentDevelopmentMode){
     let routeHash = getRouteHash(filename)
     let defaultProps = `
         import { page } from '$app/stores';
-        import { pageHasQueries } from '$lib/ui/stores.js';
+        import { pageHasQueries } from '@evidence-dev/components/ui/stores';
         import BigLink from '${componentSource}/ui/BigLink.svelte';
         import Value from '${componentSource}/viz/Value.svelte';
         import Chart from '${componentSource}/viz/Chart.svelte';
@@ -68,7 +68,7 @@ const createDefaultProps = function(filename, componentDevelopmentMode){
         defaultProps = `
             export let data
             pageHasQueries.update(value => value = true)
-            import QueryViewer from '${componentSource}/ui/QueryViewer.svelte';
+            import QueryViewer from '@evidence-dev/components/ui/QueryViewer.svelte';
             ${defaultProps}
         `
     } else {

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -1,8 +1,8 @@
 <script>
     import { page } from '$app/stores';
     import { showQueries } from './stores.js'
-    export let pageHasQueries;
-    
+    import { pageHasQueries } from './stores.js'
+
     $: pathArray = $page.path.split('/').slice(1)
 
     const buildCrumbs = function (pathArray) {

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -1,7 +1,8 @@
 <script>
     import { page } from '$app/stores';
     import { showQueries } from './stores.js'
-
+    export let pageHasQueries;
+    
     $: pathArray = $page.path.split('/').slice(1)
 
     const buildCrumbs = function (pathArray) {
@@ -47,10 +48,12 @@
             {/each}
         </span>
         <span>
-            {#if $showQueries}
-            <span class="dev-controls hide" on:click={toggleQueries}>Hide Queries</span>
-            {:else}
-            <span class="dev-controls show" on:click={toggleQueries}>Show Queries</span>
+            {#if $pageHasQueries}
+                {#if $showQueries}
+                <span class="dev-controls hide" on:click={toggleQueries}>Hide Queries</span>
+                {:else}
+                <span class="dev-controls show" on:click={toggleQueries}>Show Queries</span>
+                {/if}
             {/if}
         </span>
     </span>

--- a/sites/example-project/src/components/ui/Header.svelte
+++ b/sites/example-project/src/components/ui/Header.svelte
@@ -1,11 +1,10 @@
 <script>
     import BreadCrumbs from './BreadCrumbs.svelte';
-    export let pageHasQueries;
 </script>
 
 <header>
     <div class="breadcrumb-container">
-        <BreadCrumbs {pageHasQueries}/>
+        <BreadCrumbs/>
     </div>
 </header>
 

--- a/sites/example-project/src/components/ui/Header.svelte
+++ b/sites/example-project/src/components/ui/Header.svelte
@@ -1,10 +1,11 @@
 <script>
     import BreadCrumbs from './BreadCrumbs.svelte';
+    export let pageHasQueries;
 </script>
 
 <header>
     <div class="breadcrumb-container">
-        <BreadCrumbs/>
+        <BreadCrumbs {pageHasQueries}/>
     </div>
 </header>
 

--- a/sites/example-project/src/components/ui/stores.js
+++ b/sites/example-project/src/components/ui/stores.js
@@ -2,3 +2,4 @@ import { dev } from '$app/env';
 import { writable } from 'svelte/store';
 
 export const showQueries = writable(dev);
+export const pageHasQueries = writable();

--- a/sites/example-project/src/components/viz/BarChart.svelte
+++ b/sites/example-project/src/components/viz/BarChart.svelte
@@ -38,6 +38,8 @@
 
     let chartType = "Bar Chart";
 
+
+    export let annotate = true;
  </script>
 
 <Chart

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -4,7 +4,8 @@
 	import "../app.css"
 	import { navigating } from '$app/stores';
 	import { blur } from "svelte/transition";
-	import { page } from "$app/stores"
+	import { page } from "$app/stores";
+	import { pageHasQueries } from '$lib/ui/stores.js';
 
 	import TableOfContents from "@evidence-dev/components/TableOfContents.svelte";
 	import Header from '@evidence-dev/components/ui/Header.svelte'
@@ -25,7 +26,7 @@
 
 <div class="grid">
 	{#if $page.path !== '/settings'}
-		<Header/>
+		<Header {pageHasQueries}/>
 	{/if}
 	<Sidebar bind:open/> 
 	<Hamburger bind:open/>

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -5,7 +5,6 @@
 	import { navigating } from '$app/stores';
 	import { blur } from "svelte/transition";
 	import { page } from "$app/stores";
-	import { pageHasQueries } from '$lib/ui/stores.js';
 
 	import TableOfContents from "@evidence-dev/components/TableOfContents.svelte";
 	import Header from '@evidence-dev/components/ui/Header.svelte'
@@ -26,7 +25,7 @@
 
 <div class="grid">
 	{#if $page.path !== '/settings'}
-		<Header {pageHasQueries}/>
+		<Header/>
 	{/if}
 	<Sidebar bind:open/> 
 	<Hamburger bind:open/>


### PR DESCRIPTION
At the moment, all pages display the show/hide queries button. This change removes the button if there are no queries on the page.

The way this works is:
 - New variable `pageHasQueries` is added to the same store used by `showQueries`
 - In the `preprocess` package, the `hasQueries()` function is used to determine if a page has queries or not
 - Based on the result of that function, `pageHasQueries` store value is updated
 - In `Breadcrumbs.svelte`, the button is not shown if `pageHasQueries` is `false`

This also fixes an issue where the show/hide query button was not working in `example-project`