### PR TITLE
Chart error scroll fix for Windows

### DIFF
--- a/sites/example-project/src/components/viz/ErrorChart.svelte
+++ b/sites/example-project/src/components/viz/ErrorChart.svelte
@@ -18,7 +18,7 @@
         font-weight: normal;
         border-radius: 4px;
         border: 1px solid #f8e9e9;
-        height: 150px;
+        min-height: 150px;
         padding: 20px 30px 20px 30px;
         margin-top: 20px;
         margin-bottom: 20px;
@@ -26,7 +26,6 @@
         grid-template-rows: auto;
         grid-template-columns: 100%;
         justify-content: center;
-        overflow: scroll;
     }
 
     .wrapper {


### PR DESCRIPTION
Including a scrollable area in the chart error component causes an error in Windows - it makes all chart errors appear with both horizontal and vertical scrollbars, even if there isn't scrollable content. 

Fixing this requires setting up custom scrollbars to work across OS/browsers (which we have in our QueryViewer component).

Easier fix for now is to extend the height of the chart error until the full error message is visible. Otherwise, the min height will be 150px (same as height of a typical working chart).