### PR TITLE
Persistent query show/hide states

### DIFF
--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -13,10 +13,13 @@
   export let pageQueries
   export let queryResult;
 
-  // Title & Query Toggle 
-  let showSQL = false
+  // Title & Query Toggle
+  // Create a copy of the showSQL variable in the local storage, for each query. Access this to determine state of each query dropdown.
+  let showSQL = writable(browser && (localStorage.getItem('showSQL_'.concat(queryID))==='true'  || false));
+  showSQL.subscribe((value) => browser && (localStorage.setItem('showSQL_'.concat(queryID),(value))));
+  
   const toggleSQL = function() {
-    showSQL = !showSQL
+    $showSQL = !$showSQL
   }
 
   // Query text & Compiler Toggle 
@@ -59,14 +62,14 @@
     <div class="container" transition:slide|local>
       <div class="container-a">
         <div on:click={toggleSQL} class="title">
-          <span><ChevronToggle toggled={showSQL}/> {queryID}</span>
+          <span><ChevronToggle toggled={$showSQL}/> {queryID}</span>
         </div>
         <!-- Compile Toggle  -->
-          {#if showSQL && showCompilerToggle}
+          {#if $showSQL && showCompilerToggle}
             <CompilerToggle bind:showCompiled = {showCompiled}/>
           {/if }
           <!-- Query Display -->
-          {#if showSQL}
+          {#if $showSQL}
             <div class=code-container transition:slide|local style={`height: ${codeContainerHeight}em;`}>
               {#if showCompiled}
                 <Prism language="sql" code={compiledQuery}/>

--- a/sites/example-project/src/components/ui/stores.js
+++ b/sites/example-project/src/components/ui/stores.js
@@ -1,5 +1,8 @@
 import { dev } from '$app/env';
 import { writable } from 'svelte/store';
+import { browser } from '$app/env';
 
-export const showQueries = writable(dev);
+// Persist ShowQueries user choice
+export const showQueries = writable(dev && browser && (localStorage.getItem('showQueries')==='true'  || false ));
+showQueries.subscribe((value) => browser && (localStorage.setItem('showQueries',(value))));
 export const pageHasQueries = writable();


### PR DESCRIPTION
As a user in dev mode, it's frustrating that query results collapse every time the page reloads.

Desired behaviour: 
- The query results are kept as shown / hidden based on what the state was before reload

Rough approach
- Store the state of each query in local storage, and read from there on reload

Questions
- This seems like a weird implementation of storage - I feel like you typically put svelte store variables in store.js?
- But since (I think) you want to control each query independently, you'd perhaps need to independently make variables for each query - and you don't know how many there are before the queries are compiled. So I put them in the component instead.

Next
- It would seem logical to also include the show/hide state of the query text itself, once we've worked out the best approach for this