### PR TITLE
Devmode showhide fix

### DIFF
--- a/.changeset/cuddly-news-film.md
+++ b/.changeset/cuddly-news-film.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Fixing default showQueries behaviour to be true by default in dev

--- a/sites/example-project/src/components/ui/stores.js
+++ b/sites/example-project/src/components/ui/stores.js
@@ -3,6 +3,6 @@ import { writable } from 'svelte/store';
 import { browser } from '$app/env';
 
 // Persist ShowQueries user choice
-export const showQueries = writable(dev && browser && (localStorage.getItem('showQueries')==='true'  || false ));
+export const showQueries = writable(dev && browser && (localStorage.getItem('showQueries')!='false'));
 showQueries.subscribe((value) => browser && (localStorage.setItem('showQueries',(value))));
 export const pageHasQueries = writable();


### PR DESCRIPTION
Discussed in #260
- Fixing the behaviour so that in dev mode queries are shown by default.