### PR TITLE
255 settings telemetry opt out

### DIFF
--- a/.changeset/big-pears-laugh.md
+++ b/.changeset/big-pears-laugh.md
@@ -1,0 +1,8 @@
+---
+'@evidence-dev/evidence': patch
+'@evidence-dev/telemetry': patch
+'evidence-docs': patch
+'@evidence-dev/components': patch
+---
+
+Add telemetry options to the development mode settings page.

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -14,9 +14,9 @@ const populateTemplate = function() {
 
     fs.ensureDirSync("./.evidence/template/")
 
-    // empty the template directory, except any local settings that already exist. 
+    // empty the template directory, except any local settings, or telemetry profile that already exist. 
     fs.readdirSync("./.evidence/template/").forEach(file => {
-      if(file != "evidence.settings.json")
+      if(file != "evidence.settings.json" && file != ".profile.json")
         fs.removeSync(path.join("./.evidence/template/", file))
       }
     )

--- a/packages/telemetry/index.cjs
+++ b/packages/telemetry/index.cjs
@@ -32,8 +32,9 @@ const getProfile = async () => {
 
 const logEvent = async (eventName, dev, settings) => {
     try {
-        const track = (settings ? settings.send_anonymous_usage_stats : process.env["SEND_ANONYMOUS_USAGE_STATS"] || process.env["send_anonymous_usage_stats"]) ?? true
-        if(track){
+        let usageStats = settings ? settings.database : process.env["SEND_ANONYMOUS_USAGE_STATS"] ?? process.env["send_anonymous_usage_stats"]
+        usageStats = usageStats ?? 'true' //optout
+        if(usageStats === 'true'){
             projectProfile = await getProfile()
             var analytics = new Analytics(wK);
             analytics.track({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5555,7 +5555,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: false
 
   /debug/4.3.4_supports-color@6.1.0:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}

--- a/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
@@ -1,0 +1,129 @@
+<script>
+    export let settings
+    let usageStats = settings.send_anonymous_usage_stats
+
+    async function save() {
+        settings.send_anonymous_usage_stats = usageStats
+        const submitted = await fetch("/api/settings.json", {
+			method: "POST",
+			body: JSON.stringify({
+                settings
+			})
+		})
+        // reset the state of settings 
+        settings = await submitted.json()
+        existingCredentials = settings.credentials
+    }
+</script>
+
+<form>
+<div class=container>
+    <div class=panel> 
+        <label class="switch">
+            <input type="checkbox" bind:checked={usageStats} on:change={save}/>
+            <span class="slider" />
+        </label>
+    </div>
+
+    {settings.send_anonymous_usage_stats}
+
+</div>
+<footer>
+    <span>Learn more about <a class=docs-link href="https://docs.evidence.dev/deployment/deployment-overview">Deploying your Project &rarr;</a></span>
+</footer>
+</form>
+<style>
+    .container {
+        margin-top: 2em;
+        border-top: 1px solid var(--grey-200);
+        border-left: 1px solid var(--grey-200);
+        border-right: 1px solid var(--grey-200);
+        border-radius: 5px 5px 0 0;
+        font-size: 14px; 
+        font-family: var(--ui-font-family);
+    }   
+
+    .panel {
+        border-top: 1px solid var(--grey-200);
+        padding:1.0em;
+    }
+
+    .panel:first-of-type {
+        border-top:none;
+    }
+
+    footer {
+        border: 1px solid var(--grey-200);
+        border-radius: 0 0 5px 5px;
+        background-color: var(--grey-100);
+        padding:1.0em;
+        display:flex;
+        font-size: 14px;
+        align-items: center;
+        font-family: var(--ui-font-family);
+    }
+
+    .docs-link {
+        color: var(--blue-600);
+        text-decoration: none;
+    }
+
+    .docs-link:hover {
+        color: var(--blue-800);
+    }
+
+
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 2.8rem;
+      height: 1.75rem;
+      margin-left: auto;
+      margin-right: 2px;
+      user-select: none;
+    }
+  
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+  
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 25px;
+    }
+  
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 1.25rem;
+      width: 1.25rem;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 50%;
+      box-shadow: 0px 1px 2px var(--grey-500);
+
+    }
+  
+    input:checked + .slider {
+      background-color: var(--green-500);
+    }
+
+    input:checked + .slider:before {
+      -webkit-transform: translateX(1.1rem);
+      -ms-transform: translateX(1.1rem);
+      transform: translateX(1.1rem);
+    }
+</style>

--- a/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
@@ -19,17 +19,33 @@
 <form>
 <div class=container>
     <div class=panel> 
-        <label class="switch">
-            <input type="checkbox" bind:checked={usageStats} on:change={save}/>
-            <span class="slider" />
-        </label>
+        <h1>Telemetry</h1>
+        <p>Evidence collects anonymous usage data to help us understand how often the tool is being used.</p>
+        <p>Each time you run a query, we get three pieces of information:
+        </p>
+        <ol>
+            <li>A random identifier that is stored in <code>.evidence/template/.profile.json</code></li>
+            <li>Whether your project is running in development or build mode</li>
+            <li>Whether your query returned from the cache, from your database, or returned an error</li>
+        </ol>
+        <p>Sharing anonymous usage data is one of the best ways you can support Evidence.</p>
+        <div class=input-item>
+            <label for='telemetry-toggle'>
+                Share anonymous usage data
+            </label>
+            <label class="switch">
+                <input type="checkbox" bind:checked={usageStats} on:change={save} id='telemetry-toggle'/>
+                <span class="slider" />
+            </label>
+
+        </div>
+
     </div>
 
-    {settings.send_anonymous_usage_stats}
 
 </div>
 <footer>
-    <span>Learn more about <a class=docs-link href="https://docs.evidence.dev/deployment/deployment-overview">Deploying your Project &rarr;</a></span>
+    <span>The source code for our telemetry can be <a class=docs-link href="https://github.com/evidence-dev/evidence/blob/main/packages/telemetry/index.cjs">found here &rarr;</a></span>
 </footer>
 </form>
 <style>
@@ -125,5 +141,25 @@
       -webkit-transform: translateX(1.1rem);
       -ms-transform: translateX(1.1rem);
       transform: translateX(1.1rem);
+    }
+
+    label {
+        width: 30%;
+        text-transform: uppercase;
+        font-weight: normal;
+        font-size: 14px;
+        color: var(--grey-800);
+        white-space: nowrap;
+    }
+
+    div.input-item{
+        font-family: var(--ui-font-family);
+        color: var(--grey-999);
+        font-size: 16px;
+        margin-top: 1.25em;
+        display:flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
     }
 </style>

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -31,7 +31,7 @@
     import DatabaseSettingsPanel from '@evidence-dev/components/ui/Databases/DatabaseSettingsPanel.svelte';
     import VersionControlPanel from '@evidence-dev/components/ui/VersionControl/VersionControlPanel.svelte'
     import DeploySettingsPanel from '@evidence-dev/components/ui/Deployment/DeploySettingsPanel.svelte'
-    import TelemetrySettingsPanel from '@evidence-dev/components/TelemetryOptOut/TelemetrySettingsPanel.svelte';
+    import TelemetrySettingsPanel from '@evidence-dev/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte';
     
 </script>
 

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -31,7 +31,7 @@
     import DatabaseSettingsPanel from '@evidence-dev/components/ui/Databases/DatabaseSettingsPanel.svelte';
     import VersionControlPanel from '@evidence-dev/components/ui/VersionControl/VersionControlPanel.svelte'
     import DeploySettingsPanel from '@evidence-dev/components/ui/Deployment/DeploySettingsPanel.svelte'
-    import TelemetrySettingsPanel from '$lib/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte';
+    import TelemetrySettingsPanel from '@evidence-dev/components/TelemetryOptOut/TelemetrySettingsPanel.svelte';
     
 </script>
 

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -31,12 +31,15 @@
     import DatabaseSettingsPanel from '@evidence-dev/components/ui/Databases/DatabaseSettingsPanel.svelte';
     import VersionControlPanel from '@evidence-dev/components/ui/VersionControl/VersionControlPanel.svelte'
     import DeploySettingsPanel from '@evidence-dev/components/ui/Deployment/DeploySettingsPanel.svelte'
+    import TelemetrySettingsPanel from '$lib/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte';
+    
 </script>
 
 {#if dev}
 <DatabaseSettingsPanel {settings} {gitIgnore}/> 
 <VersionControlPanel {settings}/>
 <DeploySettingsPanel {settings} /> 
+<TelemetrySettingsPanel {settings} />
 <br/>
 {:else}
 <p>Settings are only available in development mode.</p>


### PR DESCRIPTION
Closes #255, adds a panel to the development settings page with information on what data we're collecting, and the option to toggle off telemetry. 