### PR TITLE
Download chart to PNG

### DIFF
--- a/.changeset/shiny-walls-shout.md
+++ b/.changeset/shiny-walls-shout.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': minor
+---
+
+Adds chart download feature to generate a PNG of a chart

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"@sveltejs/adapter-static": "1.0.0-next.22",
 		"@sveltejs/kit": "1.0.0-next.202",
 		"@tidyjs/tidy": "2.4.4",
-		"echarts": "5.2.2",
+		"echarts": "5.3.2",
 		"echarts-stat": "1.2.0",
 		"svelte-icons": "2.1.0",
 		"svelte": "3.44.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,7 @@ importers:
   sites/example-project:
     specifiers:
       '@tidyjs/tidy': 2.4.4
+      downloadjs: 1.4.7
       echarts: 5.3.2
       echarts-stat: 1.2.0
       fs-extra: ^10.0.1
@@ -219,6 +220,7 @@ importers:
       svelte-icons: 2.1.0
     dependencies:
       '@tidyjs/tidy': 2.4.4
+      downloadjs: 1.4.7
       echarts: 5.3.2
       echarts-stat: 1.2.0
       git-remote-origin-url: 4.0.0
@@ -5883,6 +5885,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-obj: 2.0.0
+    dev: false
+
+  /downloadjs/1.4.7:
+    resolution: {integrity: sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=}
     dev: false
 
   /duplexer/0.1.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@sveltejs/adapter-static': 1.0.0-next.22
       '@sveltejs/kit': 1.0.0-next.202
       '@tidyjs/tidy': 2.4.4
-      echarts: 5.2.2
+      echarts: 5.3.2
       echarts-stat: 1.2.0
       git-remote-origin-url: 4.0.0
       svelte: 3.44.3
@@ -30,7 +30,7 @@ importers:
       '@sveltejs/adapter-static': 1.0.0-next.22
       '@sveltejs/kit': 1.0.0-next.202_svelte@3.44.3
       '@tidyjs/tidy': 2.4.4
-      echarts: 5.2.2
+      echarts: 5.3.2
       echarts-stat: 1.2.0
       git-remote-origin-url: 4.0.0
       svelte: 3.44.3
@@ -212,14 +212,14 @@ importers:
   sites/example-project:
     specifiers:
       '@tidyjs/tidy': 2.4.4
-      echarts: 5.2.2
+      echarts: 5.3.2
       echarts-stat: 1.2.0
       fs-extra: ^10.0.1
       git-remote-origin-url: 4.0.0
       svelte-icons: 2.1.0
     dependencies:
       '@tidyjs/tidy': 2.4.4
-      echarts: 5.2.2
+      echarts: 5.3.2
       echarts-stat: 1.2.0
       git-remote-origin-url: 4.0.0
       svelte-icons: 2.1.0
@@ -5924,11 +5924,11 @@ packages:
   /echarts-stat/1.2.0:
     resolution: {integrity: sha512-zLd7Kgs+tuTSeaK0VQEMNmnMivEkhvHIk1gpBtLzpRerfcIQ+Bd5XudOMmtwpaTc1WDZbA7d1V//iiBccR46Qg==}
 
-  /echarts/5.2.2:
-    resolution: {integrity: sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==}
+  /echarts/5.3.2:
+    resolution: {integrity: sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==}
     dependencies:
       tslib: 2.3.0
-      zrender: 5.2.1
+      zrender: 5.3.1
 
   /ee-first/1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
@@ -13686,8 +13686,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zrender/5.2.1:
-    resolution: {integrity: sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==}
+  /zrender/5.3.1:
+    resolution: {integrity: sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==}
     dependencies:
       tslib: 2.3.0
 

--- a/sites/example-project/package-lock.json
+++ b/sites/example-project/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@evidence-dev/components",
-  "version": "1.0.0-next.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@evidence-dev/components",
-      "version": "1.0.0-next.2",
+      "version": "1.0.3",
       "dependencies": {
         "@tidyjs/tidy": "2.4.4",
+        "downloadjs": "^1.4.7",
         "echarts": "5.3.2",
         "echarts-stat": "1.2.0",
-        "git-remote-origin-url": "^4.0.0",
+        "git-remote-origin-url": "4.0.0",
         "svelte-icons": "2.1.0"
       },
       "devDependencies": {
@@ -37,63 +38,23 @@
         "webpack-link": "^0.2.0"
       }
     },
-    "../../node_modules/.pnpm/echarts@5.2.2/node_modules/echarts": {
-      "version": "5.2.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "5.2.1"
-      },
-      "devDependencies": {
-        "@babel/code-frame": "7.10.4",
-        "@babel/core": "7.3.4",
-        "@babel/types": "7.10.5",
-        "@definitelytyped/typescript-versions": "0.0.64",
-        "@definitelytyped/utils": "0.0.64",
-        "@lang/rollup-plugin-dts": "2.0.2",
-        "@microsoft/api-extractor": "7.7.2",
-        "@rollup/plugin-commonjs": "^17.0.0",
-        "@rollup/plugin-node-resolve": "^11.0.0",
-        "@rollup/plugin-replace": "^2.3.4",
-        "@types/jest": "^26.0.14",
-        "@typescript-eslint/eslint-plugin": "^4.29.2",
-        "@typescript-eslint/parser": "^4.9.1",
-        "chalk": "^3.0.0",
-        "commander": "2.11.0",
-        "cwebp-bin": "^6.1.1",
-        "dtslint": "^4.0.5",
-        "esbuild": "^0.8.39",
-        "eslint": "^7.15.0",
-        "fs-extra": "^10.0.0",
-        "glob": "7.0.0",
-        "globby": "11.0.0",
-        "husky": "^4.2.5",
-        "jest": "^26.6.1",
-        "jest-canvas-mock": "^2.2.0",
-        "jshint": "2.10.2",
-        "magic-string": "^0.25.7",
-        "open": "6.4.0",
-        "pixelmatch": "5.0.2",
-        "pngjs": "3.4.0",
-        "rollup": "2.34.2",
-        "rollup-plugin-terser": "^7.0.2",
-        "seedrandom": "3.0.3",
-        "semver": "6.3.0",
-        "serve-handler": "6.1.1",
-        "slugify": "1.3.4",
-        "socket.io": "2.2.0",
-        "terser": "^5.3.8",
-        "ts-jest": "^26.4.3",
-        "typescript": "4.3.5"
-      }
-    },
     "node_modules/@tidyjs/tidy": {
       "resolved": "../../node_modules/.pnpm/@tidyjs+tidy@2.4.4/node_modules/@tidyjs/tidy",
       "link": true
     },
+    "node_modules/downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
+    },
     "node_modules/echarts": {
-      "resolved": "../../node_modules/.pnpm/echarts@5.2.2/node_modules/echarts",
-      "link": true
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.2.tgz",
+      "integrity": "sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.3.1"
+      }
     },
     "node_modules/echarts-stat": {
       "resolved": "../../node_modules/.pnpm/echarts-stat@1.2.0/node_modules/echarts-stat",
@@ -163,6 +124,11 @@
       "resolved": "https://registry.npmjs.org/svelte-icons/-/svelte-icons-2.1.0.tgz",
       "integrity": "sha512-rHPQjweEc9fGSnvM0/4gA3pDHwyZyYsC5KhttCZRhSMJfLttJST5Uq0B16Czhw+HQ+HbSOk8kLigMlPs7gZtfg=="
     },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -170,6 +136,14 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.1.tgz",
+      "integrity": "sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     }
   },
@@ -182,51 +156,18 @@
         "ts-toolbelt": "^8.0.7"
       }
     },
+    "downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
+    },
     "echarts": {
-      "version": "file:../../node_modules/.pnpm/echarts@5.2.2/node_modules/echarts",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.2.tgz",
+      "integrity": "sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==",
       "requires": {
-        "@babel/code-frame": "7.10.4",
-        "@babel/core": "7.3.4",
-        "@babel/types": "7.10.5",
-        "@definitelytyped/typescript-versions": "0.0.64",
-        "@definitelytyped/utils": "0.0.64",
-        "@lang/rollup-plugin-dts": "2.0.2",
-        "@microsoft/api-extractor": "7.7.2",
-        "@rollup/plugin-commonjs": "^17.0.0",
-        "@rollup/plugin-node-resolve": "^11.0.0",
-        "@rollup/plugin-replace": "^2.3.4",
-        "@types/jest": "^26.0.14",
-        "@typescript-eslint/eslint-plugin": "^4.29.2",
-        "@typescript-eslint/parser": "^4.9.1",
-        "chalk": "^3.0.0",
-        "commander": "2.11.0",
-        "cwebp-bin": "^6.1.1",
-        "dtslint": "^4.0.5",
-        "esbuild": "^0.8.39",
-        "eslint": "^7.15.0",
-        "fs-extra": "^10.0.0",
-        "glob": "7.0.0",
-        "globby": "11.0.0",
-        "husky": "^4.2.5",
-        "jest": "^26.6.1",
-        "jest-canvas-mock": "^2.2.0",
-        "jshint": "2.10.2",
-        "magic-string": "^0.25.7",
-        "open": "6.4.0",
-        "pixelmatch": "5.0.2",
-        "pngjs": "3.4.0",
-        "rollup": "2.34.2",
-        "rollup-plugin-terser": "^7.0.2",
-        "seedrandom": "3.0.3",
-        "semver": "6.3.0",
-        "serve-handler": "6.1.1",
-        "slugify": "1.3.4",
-        "socket.io": "2.2.0",
-        "terser": "^5.3.8",
-        "ts-jest": "^26.4.3",
         "tslib": "2.3.0",
-        "typescript": "4.3.5",
-        "zrender": "5.2.1"
+        "zrender": "5.3.1"
       }
     },
     "echarts-stat": {
@@ -289,11 +230,24 @@
       "resolved": "https://registry.npmjs.org/svelte-icons/-/svelte-icons-2.1.0.tgz",
       "integrity": "sha512-rHPQjweEc9fGSnvM0/4gA3pDHwyZyYsC5KhttCZRhSMJfLttJST5Uq0B16Czhw+HQ+HbSOk8kLigMlPs7gZtfg=="
     },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
+    },
+    "zrender": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.1.tgz",
+      "integrity": "sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==",
+      "requires": {
+        "tslib": "2.3.0"
+      }
     }
   }
 }

--- a/sites/example-project/package-lock.json
+++ b/sites/example-project/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-next.2",
       "dependencies": {
         "@tidyjs/tidy": "2.4.4",
-        "echarts": "5.2.2",
+        "echarts": "5.3.2",
         "echarts-stat": "1.2.0",
         "git-remote-origin-url": "^4.0.0",
         "svelte-icons": "2.1.0"

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "dependencies": {
     "@tidyjs/tidy": "2.4.4",
-    "echarts": "5.2.2",
+    "echarts": "5.3.2",
     "echarts-stat": "1.2.0",
     "git-remote-origin-url": "4.0.0",
     "svelte-icons": "2.1.0"

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "dependencies": {
     "@tidyjs/tidy": "2.4.4",
+    "downloadjs": "1.4.7",
     "echarts": "5.3.2",
     "echarts-stat": "1.2.0",
     "git-remote-origin-url": "4.0.0",

--- a/sites/example-project/src/components/modules/echarts-canvas.js
+++ b/sites/example-project/src/components/modules/echarts-canvas.js
@@ -1,0 +1,465 @@
+import * as echarts from 'echarts';
+import download from 'downloadjs';
+import {colours} from './colours'
+
+
+export default(node, option, renderer) => {
+
+	echarts.registerTheme('evidence-light', {
+        "grid": {
+            "left": "0%",
+            "right": "4%",
+            "bottom": "0%",
+            "top": "15%",
+            "containLabel": true,
+        },
+        "color": [
+            "hsla(207, 65%, 39%, 1)", // Navy
+            "hsla(195, 49%, 51%, 1)", // Teal 
+            "hsla(207, 69%, 79%, 1)", // Light Blue 
+            "hsla(202, 28%, 65%, 1)", // Grey
+            "hsla(179, 37%, 65%, 1)", // Light Green 
+            "hsla(40, 30%, 75%, 1)", // Tan 
+            "hsla(38, 89%, 62%, 1)", // Yellow 
+            "hsla(342, 40%, 40%, 1)", // Maroon 
+            "hsla(207, 86%, 70%, 1)", // Blue 
+            "hsla(160, 40%, 46%, 1)", // Green 
+            // Grey Scale
+            '#71777d', '#7e848a', '#8c9196', '#9a9fa3', '#a8acb0', '#b7babd', '#c5c8ca', '#d4d6d7', '#e3e4e5', '#f3f3f3'
+        ],
+        "backgroundColor": "rgba(255, 255, 255, 0)",
+        "textStyle": {
+            "fontFamily": "sans-serif"
+        },
+        "title": {
+            "padding": 0,
+            "itemGap": 7,
+            "textStyle": {
+                "fontSize": 14,
+                "color": colours.grey700
+            },
+            "subtextStyle": {
+                "fontSize": 13,
+                "color": colours.grey600,
+                "overflow": "break"
+            },
+            "top": '0%'
+        },
+        "line": {
+            "itemStyle": {
+                "borderWidth": 0
+            },
+            "lineStyle": {
+                "width": 2,
+                "join": 'round'
+            },
+            "symbolSize": 0,
+            "symbol": "circle",
+            "smooth": false
+        },
+        "radar": {
+            "itemStyle": {
+                "borderWidth": 0
+            },
+            "lineStyle": {
+                "width": 2
+            },
+            "symbolSize": 0,
+            "symbol": "circle",
+            "smooth": false
+        },
+        "bar": {
+            "itemStyle": {
+                "barBorderWidth": 1,
+                "barBorderColor": "#cccccc"
+            },
+        },
+        "pie": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "scatter": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "boxplot": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "parallel": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "sankey": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "funnel": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "gauge": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            }
+        },
+        "candlestick": {
+            "itemStyle": {
+                "color": "#eb5454",
+                "color0": "#47b262",
+                "borderColor": "#eb5454",
+                "borderColor0": "#47b262",
+                "borderWidth": 1
+            }
+        },
+        "graph": {
+            "itemStyle": {
+                "borderWidth": 0,
+                "borderColor": "#cccccc"
+            },
+            "lineStyle": {
+                "width": 1,
+                "color": "#aaaaaa"
+            },
+            "symbolSize": 0,
+            "symbol": "circle",
+            "smooth": false,
+            "color": [
+                "#923d59",
+                "#488f96",
+                "#518eca",
+                "#b3a9a0",
+                "#ffc857",
+                "#495867",
+                "#bfdbf7",
+                "#bc4749",
+                "#eeebd0"
+            ],
+            "label": {
+                "color": "#f2f2f2"
+            }
+        },
+        "map": {
+            "itemStyle": {
+                "areaColor": "#eee",
+                "borderColor": "#444",
+                "borderWidth": 0.5
+            },
+            "label": {
+                "color": "#000"
+            },
+            "emphasis": {
+                "itemStyle": {
+                    "areaColor": "rgba(255,215,0,0.8)",
+                    "borderColor": "#444",
+                    "borderWidth": 1
+                },
+                "label": {
+                    "color": "rgb(100,0,0)"
+                }
+            }
+        },
+        "geo": {
+            "itemStyle": {
+                "areaColor": "#eee",
+                "borderColor": "#444",
+                "borderWidth": 0.5
+            },
+            "label": {
+                "color": "#000"
+            },
+            "emphasis": {
+                "itemStyle": {
+                    "areaColor": "rgba(255,215,0,0.8)",
+                    "borderColor": "#444",
+                    "borderWidth": 1
+                },
+                "label": {
+                    "color": "rgb(100,0,0)"
+                }
+            }
+        },
+        "categoryAxis": {
+            "axisLine": {
+                "show": true,
+                "lineStyle": {
+                    "color": colours.grey500
+                }
+			            },
+            "axisTick": {
+                "show": false,
+                "lineStyle": {
+                    "color": colours.grey500
+                },
+                "length": 3,
+                "alignWithLabel": true
+            },
+            "axisLabel": {
+                "show": true,
+                "color": colours.grey500
+            },
+            "splitLine": {
+                "show": false,
+                "lineStyle": {
+                    "color": [
+                        colours.grey200
+                    ]
+                }
+            },
+            "splitArea": {
+                "show": false,
+                "areaStyle": {
+                    "color": [
+                        "rgba(250,250,250,0.2)",
+                        "rgba(210,219,238,0.2)"
+                    ]
+                }
+            }
+        },
+        "valueAxis": {
+            "axisLine": {
+                "show": false,
+                "lineStyle": {
+                    "color": colours.grey500
+                }
+            },
+            "axisTick": {
+                "show": false,
+                "lineStyle": {
+                    "color": colours.grey500
+                },
+                "length": 2
+            },
+            "axisLabel": {
+                "show": true,
+                "color": colours.grey500
+            },
+            "splitLine": {
+                "show": true,
+                "lineStyle": {
+                    "color": [
+                        colours.grey200
+                    ],
+					"width": 1
+                }
+            },
+            "splitArea": {
+                "show": false,
+                "areaStyle": {
+                    "color": [
+                        "rgba(250,250,250,0.2)",
+                        "rgba(210,219,238,0.2)"
+                    ]
+                }
+            }
+        },
+        "logAxis": {
+            "axisLine": {
+                "show": false,
+                "lineStyle": {
+                    "color": colours.grey500
+                }
+            },
+            "axisTick": {
+                "show": false,
+                "lineStyle": {
+                    "color": colours.grey500
+                },
+                "length": 2
+            },
+            "axisLabel": {
+                "show": true,
+                "color": colours.grey500
+            },
+            "splitLine": {
+                "show": true,
+                "lineStyle": {
+                    "color": [
+                        colours.grey200
+                    ]
+                }
+            },
+            "splitArea": {
+                "show": false,
+                "areaStyle": {
+                    "color": [
+                        "rgba(250,250,250,0.2)",
+                        "rgba(210,219,238,0.2)"
+                    ]
+                }
+            }
+        },
+        "timeAxis": {
+            "axisLine": {
+                "show": true,
+                "lineStyle": {
+                    "color": colours.grey500
+                }
+            },
+            "axisTick": {
+                "show": true,
+                "lineStyle": {
+                    "color": colours.grey500
+                },
+                "length": 3
+            },
+            "axisLabel": {
+                "show": true,
+                "color": colours.grey500
+            },
+            "splitLine": {
+                "show": false,
+                "lineStyle": {
+                    "color": [
+                        colours.grey200
+                    ]
+                }
+            },
+            "splitArea": {
+                "show": false,
+                "areaStyle": {
+                    "color": [
+                        "rgba(250,250,250,0.2)",
+                        "rgba(210,219,238,0.2)"
+                    ]
+                }
+            }
+        },
+        "toolbox": {
+            "iconStyle": {
+                "borderColor": "#999999"
+            },
+            "emphasis": {
+                "iconStyle": {
+                    "borderColor": "#459cde"
+                }
+            }
+        },
+        "legend": {
+            "textStyle": {
+                "padding": [0,0,0,-7],
+                "color": colours.grey500
+            },
+            // "padding": [15,0,0,0],
+            "icon": "circle",
+            "pageIcons": {
+                "horizontal": ['M 17 3 h 2 c 0.386 0 0.738 0.223 0.904 0.572 s 0.115 0.762 -0.13 1.062 L 11.292 15 l 8.482 10.367 c 0.245 0.299 0.295 0.712 0.13 1.062 S 19.386 27 19 27 h -2 c -0.3 0 -0.584 -0.135 -0.774 -0.367 l -9 -11 c -0.301 -0.369 -0.301 -0.898 0 -1.267 l 9 -11 C 16.416 3.135 16.7 3 17 3 Z', 
+                'M 12 27 h -2 c -0.386 0 -0.738 -0.223 -0.904 -0.572 s -0.115 -0.762 0.13 -1.062 L 17.708 15 L 9.226 4.633 c -0.245 -0.299 -0.295 -0.712 -0.13 -1.062 S 9.614 3 10 3 h 2 c 0.3 0 0.584 0.135 0.774 0.367 l 9 11 c 0.301 0.369 0.301 0.898 0 1.267 l -9 11 C 12.584 26.865 12.3 27 12 27 Z']
+            },
+            "pageIconColor": colours.grey600,
+            "pageIconSize": 12,
+            "pageTextStyle": {
+                "color": "grey",
+            },
+            "pageButtonItemGap": -2,
+            "animationDurationUpdate": 300
+        },
+        "tooltip": {
+            "axisPointer": {
+                "lineStyle": {
+                    "color": "#cccccc",
+                    "width": 1
+                },
+                "crossStyle": {
+                    "color": "#cccccc",
+                    "width": 1
+                }
+            }
+        },
+        "timeline": {
+            "lineStyle": {
+                "color": "#e3e3e3",
+                "width": 2
+            },
+            "itemStyle": {
+                "color": "#d6d6d6",
+                "borderWidth": 1
+            },
+            "controlStyle": {
+                "color": "#bfbfbf",
+                "borderColor": "#bfbfbf",
+                "borderWidth": 1
+            },
+            "checkpointStyle": {
+                "color": "#8f8f8f",
+                "borderColor": "#ffffff"
+            },
+            "label": {
+                "color": "#c9c9c9"
+            },
+            "emphasis": {
+                "itemStyle": {
+                    "color": "#9c9c9c"
+                },
+                "controlStyle": {
+                    "color": "#bfbfbf",
+                    "borderColor": "#bfbfbf",
+                    "borderWidth": 1
+                },
+                "label": {
+                    "color": "#c9c9c9"
+                }
+            }
+        },
+        "visualMap": {
+            "color": [
+                "#c41621",
+                "#e39588",
+                "#f5ed98"
+            ]
+        },
+        "dataZoom": {
+            "handleSize": "undefined%",
+            "textStyle": {}
+        },
+        "markPoint": {
+            "label": {
+                "color": "#f2f2f2"
+            },
+            "emphasis": {
+                "label": {
+                    "color": "#f2f2f2"
+                }
+            }
+        }
+    });
+
+    const chart = echarts.init(node, 'evidence-light', {renderer: 'canvas'});   
+
+	chart.setOption(option);
+
+    // window.addEventListener("resize", () => { chart.resize();});
+    // var img = new Image();
+    let src = chart.getConnectedDataURL({
+        type: 'png',
+        pixelRatio: 3,
+        backgroundColor: '#fff',
+        excludeComponents: ['toolbox']
+    });
+
+    download(src, "evidence-chart.png")
+
+    return {
+		// update(option){
+		// 	chart.update(option, true, true);
+		// },
+		destroy() {
+			chart.dispose();
+		}
+	};
+}
+
+

--- a/sites/example-project/src/components/modules/echartsCanvasDownload.js
+++ b/sites/example-project/src/components/modules/echartsCanvasDownload.js
@@ -444,6 +444,7 @@ export default(node, option, renderer) => {
     let src = chart.getConnectedDataURL({
         type: 'png',
         pixelRatio: 3,
+        backgroundColor: "white",
         excludeComponents: ['toolbox']
     });
 

--- a/sites/example-project/src/components/modules/echartsCanvasDownload.js
+++ b/sites/example-project/src/components/modules/echartsCanvasDownload.js
@@ -441,8 +441,6 @@ export default(node, option, renderer) => {
 
 	chart.setOption(option);
 
-    // window.addEventListener("resize", () => { chart.resize();});
-    // var img = new Image();
     let src = chart.getConnectedDataURL({
         type: 'png',
         pixelRatio: 3,
@@ -451,10 +449,9 @@ export default(node, option, renderer) => {
 
     download(src, "evidence-chart.png")
 
+    chart.dispose();
+
     return {
-		// update(option){
-		// 	chart.update(option, true, true);
-		// },
 		destroy() {
 			chart.dispose();
 		}

--- a/sites/example-project/src/components/modules/echartsCanvasDownload.js
+++ b/sites/example-project/src/components/modules/echartsCanvasDownload.js
@@ -446,7 +446,6 @@ export default(node, option, renderer) => {
     let src = chart.getConnectedDataURL({
         type: 'png',
         pixelRatio: 3,
-        backgroundColor: '#fff',
         excludeComponents: ['toolbox']
     });
 

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -534,27 +534,6 @@ try{
                 type: "scroll",
                 top: legendTop,
                 padding: [0, 0, 0, 0]
-            },       
-            toolbox: {
-                show: true,
-                showTitle: false, // hide the default text so they don't overlap each other
-                feature: {
-                    saveAsImage: {
-                        show: true,
-                        title: 'Save As Image',
-                        icon: 'path://M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5',
-                        iconStyle: {
-                            borderWidth: 1.5,
-                            borderColor: "var(--grey-400)"
-                        },
-                        emphasis: {
-                            iconStyle: {
-                                borderColor: "var(--grey-500)"
-                            }
-                        },
-                        pixelRatio: 1
-                    }
-                },
             },
             grid: {
                 left: "0.5%",

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -489,7 +489,7 @@ try{
                 style: {
                     text: horizAxisTitle,
                     textAlign: 'right',
-                    fill: '#6E7079',
+                    fill: colours.grey500,
                 },
                 cursor: 'auto',
                 // Positioning (if swapXY, top right; otherwise bottom right)

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -535,6 +535,27 @@ try{
                 top: legendTop,
                 padding: [0, 0, 0, 0]
             },       
+            toolbox: {
+                show: true,
+                showTitle: false, // hide the default text so they don't overlap each other
+                feature: {
+                    saveAsImage: {
+                        show: true,
+                        title: 'Save As Image',
+                        icon: 'path://M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5',
+                        iconStyle: {
+                            borderWidth: 1.5,
+                            borderColor: "var(--grey-400)"
+                        },
+                        emphasis: {
+                            iconStyle: {
+                                borderColor: "var(--grey-500)"
+                            }
+                        },
+                        pixelRatio: 1
+                    }
+                },
+            },
             grid: {
                 left: "0.5%",
                 right: swapXY ? "4%" : "3%",

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -27,7 +27,7 @@
     use:echarts={config}
 />
 
-<span class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false }, 3000);}}>
+<span class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false }, 1000);}}>
   <span>Download</span>
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
 </span>

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -1,12 +1,19 @@
 <script>
     import echarts from "$lib/modules/echarts";
+    import echartsCanvas from "$lib/modules/echarts-canvas";
+
     export let config = undefined;    
+    let newConfig = config;
+    newConfig.animation = false;
 
     export let height = '291px'
     export let width = '100%'
 
+    let downloadChart = false;
+
 </script>
 
+<div class=other>
 <div 
     class="chart" 
     style="
@@ -14,11 +21,36 @@
         width: {width};
         margin-left: 0;
         margin-top: 15px;
-        margin-bottom: 15px;
+        margin-bottom: 10px;
         overflow: visible;
     "
     use:echarts={config}
 />
+
+<span class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false }, 3000);}}>
+  <span>Download</span>
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
+</span>
+
+
+</div>
+
+{#if downloadChart}
+<div 
+    class="chart" 
+    style="
+        display: none;
+        visibility: visible;
+        height: {height};
+        width: 666px;
+        margin-left: 0;
+        margin-top: 15px;
+        margin-bottom: 15px;
+        overflow: visible;
+    "
+    use:echartsCanvas={newConfig}
+/>
+{/if}
 
 <style>
   @media print {
@@ -32,4 +64,46 @@
     -ms-user-select: none;
     user-select: none;
   }
+
+  .other {
+    padding-bottom: 30px;
+  }
+
+  .other:hover .download-icon {
+    visibility: visible;
+  }
+
+
+  svg {
+      stroke: var(--grey-400);
+      margin-top: auto;
+      margin-bottom: auto;
+  }
+
+  .download-icon {
+      visibility: hidden;
+      display: grid;
+      grid-row: auto;
+      grid-template-columns: auto auto;
+      gap: 3px;
+      float: right;
+      /* margin-left: 5px; */
+      margin-top: -10px;
+      margin-right: 16px;
+      cursor: pointer;
+      font-family: sans-serif;
+      font-size: 0.7rem;
+      color: var(--grey-400);
+      vertical-align: text-top;
+      justify-items: center;
+      position:relative;
+  }
+
+  .download-icon:hover {
+      color: var(--grey-500);
+  }
+  .download-icon:hover svg {
+      stroke: var(--grey-500);
+  }
+
 </style>

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -13,7 +13,7 @@
 
 </script>
 
-<div class=other>
+<div class=chart-container>
 <div 
     class="chart" 
     style="
@@ -65,11 +65,11 @@
     user-select: none;
   }
 
-  .other {
-    padding-bottom: 30px;
+  .chart-container {
+    padding-bottom: 15px;
   }
 
-  .other:hover .download-icon {
+  .chart-container:hover .download-icon {
     visibility: visible;
   }
 

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -1,10 +1,10 @@
 <script>
     import echarts from "$lib/modules/echarts";
-    import echartsCanvas from "$lib/modules/echarts-canvas";
+    import echartsCanvasDownload from "$lib/modules/echartsCanvasDownload";
 
     export let config = undefined;    
-    let newConfig = config;
-    newConfig.animation = false;
+    let downloadConfig = config;
+    downloadConfig.animation = false;
 
     export let height = '291px'
     export let width = '100%'
@@ -48,7 +48,7 @@
         margin-bottom: 15px;
         overflow: visible;
     "
-    use:echartsCanvas={newConfig}
+    use:echartsCanvasDownload={downloadConfig}
 />
 {/if}
 


### PR DESCRIPTION
This PR adds a feature to download a chart to a PNG file with one click. The download button appears at the bottom right of the chart on hover.

### Details
 - File name of exported file is `evidence-chart.png`
 - Background of the image is white
 - Pixel ratio is 3x, which seems to generate crisp images across devices

### Outstanding issues
 - Background colour to be changed to transparent in future iterations (pending fix of y-axis title background issue)
 - This does not handle situations where the legend is paginated
 - It would be preferable for the file name to contain some more descriptive info (query name, chart type, etc.)

### Download Function
![CleanShot 2022-05-18 at 09 02 27](https://user-images.githubusercontent.com/12602440/169327582-ff9d2bbd-1829-4996-abf7-642267da0eb9.gif)

### Output
![evidence-chart (18)](https://user-images.githubusercontent.com/12602440/169327556-f7218043-4348-498f-b870-d0188fe5af76.png)


