### PR TITLE
Table scroll and spacing fix

### DIFF
--- a/.changeset/breezy-worms-sniff.md
+++ b/.changeset/breezy-worms-sniff.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Fixes scroll and spacing issues in DataTable

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -206,6 +206,7 @@
   .container{
     width:100%;
     overflow-x: auto;
+    overflow-y: hidden;
     border-bottom: 2px solid rgb(235, 238, 240); 
   }
 

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -127,7 +127,7 @@
   {#if max > 0}
   <div class="pagination">
     <input type="range" max={max} step=1 bind:value={index} on:input={slice} class="slider">
-    <span>
+    <span style="line-height: 2em;">
     {(index+size).toLocaleString()} of {(max+size).toLocaleString()} 
     </span>
   </div>

--- a/sites/example-project/src/pages/query-chain-test.md
+++ b/sites/example-project/src/pages/query-chain-test.md
@@ -10,7 +10,6 @@ select
 from `bigquery-public-data.austin_311.311_service_requests` 
 where created_date >= timestamp_sub(current_timestamp(), interval 180 day)
 group by 1,2 
-limit 5
 ```
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 


### PR DESCRIPTION
Fixes bug introduced by the CSV export PR, where a new container div was causing the table inside the container to scroll. Also adjusts spacing in the pagination section, where the scrubber bar and the page labels were out of alignment