### PR TITLE
Fix markdown preview shortcuts for VSCode

### DIFF
--- a/packages/evidence-vscode/package.json
+++ b/packages/evidence-vscode/package.json
@@ -105,6 +105,20 @@
         "language": "javascript",
         "path": "./snippets/js.code-snippets"
       }
+    ],
+    "keybindings": [
+      {
+          "command": "markdown.showPreview",
+          "key": "shift+ctrl+v",
+          "mac": "shift+cmd+v",
+          "when": "!notebookEditorFocused && editorLangId == 'emd'"
+      },
+      { 
+        "command": "markdown.showPreviewToSide",
+        "key": "ctrl+k v",
+        "mac": "cmd+k v",             
+        "when": "!notebookEditorFocused && editorLangId == 'emd'" }
+
     ]
   },
   "scripts": {


### PR DESCRIPTION
**Problem**
- Currently the Evidence VSCode Extension conflicts with standard shortcuts when using markdown files - see #229 

**Desired behaviour**
- Shortcuts work as expected: 
   - shift+cmd+v: showPreview
   - ctrl+k v: showPreviewToSide

**Solution**
- Add keybindings to the evidence package that provide the normal functionality.
- These follow exactly the same logic as in the standard shortcuts, but rather than checking for the 'markdown' editorlLanguageId, it checks for 'emd' (Evidence Markdown)
   - (This prevents the keys launching preview when in non markdown files)
