### PR TITLE
Fix sorting side-effects issue

### DIFF
--- a/.changeset/mean-squids-film.md
+++ b/.changeset/mean-squids-film.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Fix sorting bug that caused side effects from components sorting datasets

--- a/sites/example-project/src/components/modules/getSortedData.js
+++ b/sites/example-project/src/components/modules/getSortedData.js
@@ -1,5 +1,5 @@
 export default function getSortedData(data, col, isAsc) {
-    return data.sort((a, b) => {
+    return [...data].sort((a, b) => {
         return (a[col] < b[col] ? -1 : 1) * (isAsc ? 1 : -1)
     });
 }

--- a/sites/example-project/src/components/viz/Bar.svelte
+++ b/sites/example-project/src/components/viz/Bar.svelte
@@ -55,7 +55,7 @@
             }
 
             sortOrder = stackedData.map(d => d[x]);
-            data.sort(function (a, b) {
+            data = [...data].sort(function (a, b) {
                 return sortOrder.indexOf(a[x]) - sortOrder.indexOf(b[x]);
             });
         }

--- a/sites/example-project/src/components/viz/BarChart.svelte
+++ b/sites/example-project/src/components/viz/BarChart.svelte
@@ -38,9 +38,7 @@
 
     let chartType = "Bar Chart";
 
-
-    export let annotate = true;
- </script>
+</script>
 
 <Chart
     {data}


### PR DESCRIPTION
Currently, the `getSortedData()` function sorts a dataset without making a copy of it, meaning the original dataset shown in the query viewer is altered.

This PR changes the sort behaviour so that sort is only applied to a copy of the dataset within the component sorting it. This will make the query viewer table respect the `order by` statement in SQL rather than reflecting however a component was sorting the data.