### PR TITLE
Improving dev server behavior

### DIFF
--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -2,7 +2,7 @@
   "name": "@evidence-dev/components",
   "version": "1.1.1",
   "scripts": {
-    "dev": "svelte-kit package && svelte-kit dev",
+    "dev": "svelte-kit package && svelte-kit dev -o",
     "build": "svelte-kit build",
     "preview": "svelte-kit preview",
     "package": "svelte-kit package && pnpm clean-package",

--- a/sites/example-project/svelte.config.js
+++ b/sites/example-project/svelte.config.js
@@ -22,6 +22,9 @@ const config = {
 				include: ['echarts-stat'],
 				exclude: ['@evidence-dev/components']
 			},
+			server: {
+				strictPort: false,
+			},
 			ssr: {
 				external: ['@evidence-dev/db-orchestrator']
 			},


### PR DESCRIPTION
### Aims:
Comparable products often do two things Evidence does not, for ease of use:
1. **Default to another port**, if the targeted port is in use (rather than fail)
2. **Automatically launch a browser tab** when the dev server is started

### Implementation options: 
(See [Svelte Kit docs](https://kit.svelte.dev/docs/cli#svelte-kit-dev))
1. **Default to another port**: Seems like editing `config.kit.vite.server.strictPort` option to `false` will do the trick
2. **Automatically launch a browser tab**: It seems like you need to pass the `-o` flag to `svelte-kit dev`. If so there are a few places we could do this. In order of distance from user (and therefore how easy it is for the user to disable if desired)
     1. **In the docs**, we could recommend people run: `npm run dev -o`
     2. **In the template project**, we could change [package.json](https://github.com/evidence-dev/template/blob/main/package.json) to run: `"dev": "evidence dev -o",`
     3. **In the evidence repo**, we could change the package.json to (I think the [package.json in example project](https://github.com/evidence-dev/evidence/blob/main/sites/example-project/package.json)) to `"dev": "svelte-kit package && svelte-kit dev",`


### Questions:
- Are there any reasons either 1 or 2 would be undesirable behaviour?
- If we are to do **Automatically launch a browser tab**, which is the best place to add the behaviour?
    - I quite like ii. as it doesn't pollute the command line UX too much with stuff we need to explain, and it also can be disabled by an intermediate user from within their Evidence project. I could imagine getting frustrated with too many tabs open if i end up restarting the server frequently