### PR TITLE
Snowflake connector update

### DIFF
--- a/.changeset/curvy-frogs-check.md
+++ b/.changeset/curvy-frogs-check.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/snowflake': patch
+'@evidence-dev/components': patch
+---
+
+Adding a database and warehouse field to the Snowflake connector. Without these it is difficult to run queries in a Snowflake DB.

--- a/packages/snowflake/index.cjs
+++ b/packages/snowflake/index.cjs
@@ -41,7 +41,9 @@ const runQuery = async (queryString, database) => {
         var connection = createConnection.createConnection({
             account:  database ? database.account : process.env["SNOWFLAKE_ACCOUNT"] || process.env["account"] || process.env["ACCOUNT"],
             username:  database ? database.username : process.env["SNOWFLAKE_USERNAME"] || process.env["username"] || process.env["USERNAME"],
-            password:  database ? database.password : process.env["SNOWFLAKE_PASSWORD"] || process.env["password"] || process.env["PASSWORD"]
+            password:  database ? database.password : process.env["SNOWFLAKE_PASSWORD"] || process.env["password"] || process.env["PASSWORD"],
+            database:  database ? database.database : process.env["SNOWFLAKE_DATABASE"] || process.env["database"] || process.env["DATABASE"],
+            warehouse:  database ? database.warehouse : process.env["SNOWFLAKE_WAREHOUSE"] || process.env["warehouse"] || process.env["WAREHOUSE"]
         });
 
         const result = await execute(connection, queryString)

--- a/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
@@ -28,8 +28,23 @@
             type: "password", 
             optional: false,
             override: false,
-            value: credentials.password
-        }
+            value: credentials.password},
+        {
+            id: "database", 
+            label: "Database", 
+            type: "text", 
+            optional: false,
+            override: false,
+            placeholder: "my-database",
+            value: credentials.warehouse},
+        {
+            id: "warehouse", 
+            label: "Warehouse", 
+            type: "text", 
+            optional: false,
+            override: false,
+            placeholder: "my_wh",
+            value: credentials.warehouse}
     ]
 
     import GenericForm from './GenericForm.svelte'


### PR DESCRIPTION
## Issue
- The snowflake connector does not have fields for warehouse and database name. 
- This means `select 10 as num` works - it does not need to find a database. This is what we use to test the connection.
- However if you `select * from database_name` you get the error:
![image](https://user-images.githubusercontent.com/58074498/172634946-0113f2bc-5633-44b3-a012-13de7edcfd5b.png)

## Proposed solution
- Add (mandatory) warehouse and database name fields to the snowflake connector form.
<img width="650" alt="image" src="https://user-images.githubusercontent.com/58074498/172634998-43370fe3-a40b-44ef-8ff6-94760a814d01.png">

## Results
<img width="700" alt="image" src="https://user-images.githubusercontent.com/58074498/172635021-3cae83e7-d126-4f2f-ace7-9d1e635918fe.png">

## Questions
- Are there any other files we need to update? (I think no, but can't tell)
- Is there any reason we would not want these fields to be mandatory?
- Where in the css can you change the grey colour of the placeholder text, I think users are finding it a bit dark and assuming it's filled in.