### PR TITLE
Extension + Doc changes for referencing queries without having to reference the `data` object

### DIFF
--- a/packages/evidence-vscode/snippets/emd.code-snippets
+++ b/packages/evidence-vscode/snippets/emd.code-snippets
@@ -6,52 +6,52 @@
 	},
 	"Insert <Chart>": {
 		"prefix": "Chart",
-		"body": ["<Chart data={data.${1:query_name}} x=${2:column} y=${3:column}>\n\t${4:}\n</Chart>\n\n"],
+		"body": ["<Chart data={${1:query_name}} x=${2:column} y=${3:column}>\n\t${4:}\n</Chart>\n\n"],
 		"description": "Insert Chart"
 	},
 	"Insert <LineChart/>": {
 		"prefix": "LineChart",
-		"body": ["<LineChart\n\tdata={data.${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
+		"body": ["<LineChart\n\tdata={${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
 		"description": "Insert LineChart"
 	},
 	"Insert <AreaChart/>": {
 		"prefix": "AreaChart",
-		"body": ["<AreaChart\n\tdata={data.${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
+		"body": ["<AreaChart\n\tdata={${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
 		"description": "Insert AreaChart"
 	},
     "Insert <BarChart/>": {
 		"prefix": "BarChart",
-		"body": ["<BarChart\n\tdata={data.${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
+		"body": ["<BarChart\n\tdata={${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
 		"description": "Insert BarChart"
 	},
 	"Insert <ScatterPlot/>": {
 		"prefix": "ScatterPlot",
-		"body": ["<ScatterPlot\n\tdata={data.${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
+		"body": ["<ScatterPlot\n\tdata={${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n/>\n\n"],
 		"description": "Insert ScatterPlot"
 	},
 	"Insert <BubbleChart/>": {
 		"prefix": "BubbleChart",
-		"body": ["<BubbleChart\n\tdata={data.${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n\tsize=${4:column}\n/>\n\n"],
+		"body": ["<BubbleChart\n\tdata={${1:query_name}}\n\tx=${2:column}\n\ty=${3:column}\n\tsize=${4:column}\n/>\n\n"],
 		"description": "Insert BubbleChart"
 	},
 	"Insert <Histogram/>": {
 		"prefix": "Histogram",
-		"body": ["<Histogram data={data.${1:query_name}} x=${2:column}/>\n\n"],
+		"body": ["<Histogram data={${1:query_name}} x=${2:column}/>\n\n"],
 		"description": "Insert Histogram"
 	},
 	"Insert <DataTable/>": {
 		"prefix": "DataTable",
-		"body": ["<DataTable data={data.${1:query_name}}/>\n\n"],
+		"body": ["<DataTable data={${1:query_name}}/>\n\n"],
 		"description": "Insert DataTable"
 	},
 	"Insert <Value/>": {
 		"prefix": "Value",
-		"body": ["<Value data={data.${1:query_name}}/>\n\n"],
+		"body": ["<Value data={${1:query_name}}/>\n\n"],
 		"description": "Insert Value"
 	},
 	"Insert Each Block": {
 		"prefix": "Each Block",
-		"body": ["{#each data.${1:query_name} as ${2:row_name}}\n\n\t${4:}\n\n{/each}\n\n"],
+		"body": ["{#each ${1:query_name} as ${2:row_name}}\n\n\t${4:}\n\n{/each}\n\n"],
 		"description": "Insert Each Block"
 	},
 	"Insert If Block": {

--- a/sites/docs/docs/features/advanced/parameterized-pages.md
+++ b/sites/docs/docs/features/advanced/parameterized-pages.md
@@ -22,7 +22,7 @@ Adding this to a normal `<Value/>` component gives us the following:
 
 ```html
 <Value 
-    data={data.your_query_name.filter(d => d.your_column_name === $page.params.your_parameter_name)} 
+    data={your_query_name.filter(d => d.your_column_name === $page.params.your_parameter_name)} 
     column=your_column_name
 />
 ```

--- a/sites/docs/docs/features/advanced/templating.md
+++ b/sites/docs/docs/features/advanced/templating.md
@@ -10,11 +10,11 @@ In Evidence, curly braces like these `{...}` evaluate javascript. In most cases,
 #### Examples
 
 * Doing math: `{5+5}` will show up as "10" in your report. 
-* Dynamically getting the number of records from a query result: `{data.example_query.length}` will display the number of rows returned by `example_query`.
+* Dynamically getting the number of records from a query result: `{example_query.length}` will display the number of rows returned by `example_query`.
 * Using a [conditional](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) to create a colloquial explanation of what's going on: 
 
 ```
-We are {data.revenue_growth[0].projected_vs_target >= 0 ? "on track for " : "behind"} our revenue growth target.
+We are {revenue_growth[0].projected_vs_target >= 0 ? "on track for " : "behind"} our revenue growth target.
 ```
 
 Will resolve to "We are on track for our revenue growth target." or "We are behind our revenue growth target." depending on the results of the `revenue_growth` query. 
@@ -47,13 +47,13 @@ Finally, this last piece of content.
 Imagine you wanted to encourage your sales leaders "up-sell" low margin customers, but only when there were enough low-margin customers to do that work in-bulk. You could use a conditional to do something like this: 
 
 ```markdown
-{#if data.low_margin_customers.length > 15}
+{#if low_margin_customers.length > 15}
 
 The following customers are generating low margins. 
 
 Consider re-allocating an account management call block to up-sell these customers. 
 
-<Table data={data.low_margin_customers/>
+<Table data={low_margin_customers}/>
 
 {:else }
 
@@ -68,7 +68,7 @@ There are fewer than fifteen low margin customers, which is not enough to fill a
 Loops enable you to iterate over the rows in a query result, and reference the row using an alias of your choosing. 
 
 ```markdown
-{#each data.query as alias}
+{#each query_name as alias}
 
 {alias.column_name}
 
@@ -95,7 +95,7 @@ By using an `{#each}` block, we can iterate over each of the rows in `location_s
 ```markdown 
 Daily sales: 
 
-{#each data.location_summary as location}
+{#each location_summary as location}
 
 ## {location.name} 
 

--- a/sites/docs/docs/features/charts/area-chart.md
+++ b/sites/docs/docs/features/charts/area-chart.md
@@ -48,7 +48,7 @@ hide_table_of_contents: false
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/area-chart.md
+++ b/sites/docs/docs/features/charts/area-chart.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <AreaChart 
-    data={data.query_name} 
+    data={query_name} 
     x=column_x 
     y=column_y
 />
@@ -25,7 +25,7 @@ hide_table_of_contents: false
 
 ```markdown
 <AreaChart 
-    data={data.fed_reserve_district_sf} 
+    data={fed_reserve_district_sf} 
     x=established_date 
     y=banks_created
 />
@@ -36,7 +36,7 @@ hide_table_of_contents: false
 
 ```markdown
 <AreaChart 
-    data={data.fed_reserve_district}  
+    data={fed_reserve_district}  
     x=established_date 
     y=banks_created
     series=fed_reserve_district

--- a/sites/docs/docs/features/charts/bar-chart.md
+++ b/sites/docs/docs/features/charts/bar-chart.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.query_name} 
+    data={query_name} 
     x=column_x 
     y=column_y
 />
@@ -24,7 +24,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.value_by_region} 
+    data={value_by_region} 
     x=region
     y=value 
     xAxisTitle=Region
@@ -36,7 +36,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.value_by_region}
+    data={value_by_region}
     x=country 
     y=value 
     swapXY=true
@@ -48,7 +48,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.annual_value_by_region} 
+    data={annual_value_by_region} 
     x=year 
     y=value 
     series=region
@@ -60,7 +60,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.annual_value_by_region} 
+    data={annual_value_by_region} 
     swapXY=true 
     x=year 
     y=value 
@@ -75,7 +75,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.annual_value_by_region} 
+    data={annual_value_by_region} 
     x=year 
     y=value 
     series=region 
@@ -88,7 +88,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BarChart 
-    data={data.annual_value_by_region} 
+    data={annual_value_by_region} 
     swapXY=true 
     x=year 
     y=value 

--- a/sites/docs/docs/features/charts/bar-chart.md
+++ b/sites/docs/docs/features/charts/bar-chart.md
@@ -118,7 +118,7 @@ If you create a bar chart with many x-axis items (e.g., names of departments), E
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/bubble-chart.md
+++ b/sites/docs/docs/features/charts/bubble-chart.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BubbleChart 
-    data={data.query_name} 
+    data={query_name} 
     x=column_x 
     y=column_y
     size=column_size
@@ -25,7 +25,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BubbleChart 
-    data={data.simple_example} 
+    data={simple_example} 
     x=x 
     y=y 
     size=size 
@@ -39,7 +39,7 @@ hide_table_of_contents: false
 
 ```markdown
 <BubbleChart 
-    data={data.scores_by_region} 
+    data={scores_by_region} 
     x=score_a 
     y=score_b 
     size=size 

--- a/sites/docs/docs/features/charts/bubble-chart.md
+++ b/sites/docs/docs/features/charts/bubble-chart.md
@@ -54,7 +54,7 @@ hide_table_of_contents: false
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/histogram.md
+++ b/sites/docs/docs/features/charts/histogram.md
@@ -34,7 +34,7 @@ hide_table_of_contents: false
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column which contains the data you want to summarize</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 </table>						
 

--- a/sites/docs/docs/features/charts/histogram.md
+++ b/sites/docs/docs/features/charts/histogram.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <Histogram
-    data={data.query_name} 
+    data={query_name} 
     x=column_x 
 />
 ```
@@ -23,7 +23,7 @@ hide_table_of_contents: false
 
 ```markdown
 <Histogram 
-    data={data.complaints_by_day_dept} 
+    data={complaints_by_day_dept} 
     x=complaints 
     xAxisTitle="Daily Calls"
 />

--- a/sites/docs/docs/features/charts/line-chart.md
+++ b/sites/docs/docs/features/charts/line-chart.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <LineChart 
-    data={data.query_name}  
+    data={query_name}  
     x=column_x 
     y=column_y
 />
@@ -24,7 +24,7 @@ hide_table_of_contents: false
 
 ```markdown
 <LineChart 
-    data={data.daily_complaints} 
+    data={daily_complaints} 
     x=date 
     y=number_of_complaints 
     yAxisTitle="calls to Austin 311 per day"
@@ -36,7 +36,7 @@ hide_table_of_contents: false
 
 ```markdown
 <LineChart 
-    data={data.daily_volume_yoy} 
+    data={daily_volume_yoy} 
     x=day_of_year 
     y=cum_vol 
     series=year 
@@ -50,7 +50,7 @@ hide_table_of_contents: false
 
 ```markdown
 <LineChart 
-    data={data.fda_recalls}  
+    data={fda_recalls}  
     x=year
     y={["voluntary_recalls", "fda_recalls"]}
 />
@@ -59,7 +59,7 @@ hide_table_of_contents: false
 Because x is the first column in the dataset and we want to plot all the remaining numerical columns in the table, we can simplify our code down to:
 
 ```markdown
-<LineChart data={data.fda_recalls}/>
+<LineChart data={fda_recalls}/>
 ```
 
 Evidence will automatically pick the first column as `x` and use all other numerical columns for `y`.

--- a/sites/docs/docs/features/charts/line-chart.md
+++ b/sites/docs/docs/features/charts/line-chart.md
@@ -69,7 +69,7 @@ Evidence will automatically pick the first column as `x` and use all other numer
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/mixed-type-charts.md
+++ b/sites/docs/docs/features/charts/mixed-type-charts.md
@@ -18,7 +18,7 @@ This example uses multiple y columns and multiple series types (bar and line)
 ![composable](/img/exg-composable-multi-type-nt.svg) 
 
 ```markdown
-<Chart data={data.fda_recalls}>
+<Chart data={fda_recalls}>
     <Bar y=voluntary_recalls/>
     <Line y=fda_recalls/>
 </Chart>
@@ -31,7 +31,7 @@ This structure also gives you control over the individual series on your chart. 
 ![composable-name-override](/img/exg-composable-name-override-nt.svg)
 
 ```markdown
-<Chart data={data.fda_recalls}>
+<Chart data={fda_recalls}>
     <Bar y=voluntary_recalls/>
     <Line y=fda_recalls name="FDA Recalls"/>
 </Chart>
@@ -39,7 +39,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ## Chart `<Chart>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     Insert primitives here
 </Chart>
 ```
@@ -76,7 +76,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Line `<Line/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Line/>
 </Chart>
 ```
@@ -99,7 +99,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Area `<Area/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Area/>
 </Chart>
 ```
@@ -118,7 +118,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Bar `<Bar/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Bar/>
 </Chart>
 ```
@@ -139,7 +139,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Scatter `<Scatter/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Scatter/>
 </Chart>
 ```
@@ -160,7 +160,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Bubble `<Bubble/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Bubble/>
 </Chart>
 ```
@@ -183,7 +183,7 @@ This structure also gives you control over the individual series on your chart. 
 
 ### Hist `<Hist/>`
 ```markdown
-<Chart data={data.query_name}>
+<Chart data={query_name}>
     <Hist/>
 </Chart>
 ```

--- a/sites/docs/docs/features/charts/mixed-type-charts.md
+++ b/sites/docs/docs/features/charts/mixed-type-charts.md
@@ -47,7 +47,7 @@ This structure also gives you control over the individual series on your chart. 
 #### Data Props
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/scatter-plot.md
+++ b/sites/docs/docs/features/charts/scatter-plot.md
@@ -51,7 +51,7 @@ hide_table_of_contents: false
 ### Data
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
-<tr>	<td>data</td>	<td>Query name, referenced as a subset of Evidence's data object</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>data object</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/scatter-plot.md
+++ b/sites/docs/docs/features/charts/scatter-plot.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <ScatterPlot 
-    data={data.query_name} 
+    data={query_name} 
     x=column_x 
     y=column_y
 />
@@ -24,7 +24,7 @@ hide_table_of_contents: false
 
 ```markdown
 <ScatterPlot 
-    data={data.census} 
+    data={census} 
     y=median_rent_usd 
     x=income_per_capita_usd 
     xAxisTitle="Income Per Capita" 
@@ -37,7 +37,7 @@ hide_table_of_contents: false
 
 ```markdown
 <ScatterPlot 
-    data={data.scores_by_region} 
+    data={scores_by_region} 
     x=score_a 
     y=score_b 
     series=region 

--- a/sites/docs/docs/features/data-table.md
+++ b/sites/docs/docs/features/data-table.md
@@ -15,7 +15,7 @@ hide_table_of_contents: false
 />
 ```
 ### Required Props
-* **data** - query name, referenced as a subset of Evidence's **`data`** object
+* **data** - query name, wrapped in curly braces
 
 ### Optional Props
 * **rows** - # of rows to show in the table before paginating results. Default is 5 rows

--- a/sites/docs/docs/features/data-table.md
+++ b/sites/docs/docs/features/data-table.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 
 ```markdown
 <DataTable
-    data={data.query_name} 
+    data={query_name} 
 />
 ```
 ### Required Props

--- a/sites/docs/docs/features/markdown/value.md
+++ b/sites/docs/docs/features/markdown/value.md
@@ -34,7 +34,7 @@ when there were <Value data={monthly_orders} column=orders/> orders.
 ## Options
 
 ### Showing Data from a Query Result
-* **data** - query name, referenced as a subset of Evidence's **`data`** object
+* **data** - query name, wrapped in curly braces
 * **column** - column name to pull values from
 * **row** - (Optional) specific row number to display
 

--- a/sites/docs/docs/features/markdown/value.md
+++ b/sites/docs/docs/features/markdown/value.md
@@ -11,7 +11,7 @@ In Evidence, you can include data directly in text by using the **<span class="g
 
 ```markdown
 <Value 
-    data={data.query_name} 
+    data={query_name} 
     column=your_column_name
     row=your_row_number
     value=pass_in_specific_value
@@ -24,8 +24,8 @@ In Evidence, you can include data directly in text by using the **<span class="g
 **Markdown:**
 
 ```markdown
-The most recent month of data began <Value data={data.monthly_orders} fmt=date/>, 
-when there were <Value data={data.monthly_orders} column=orders/> orders.
+The most recent month of data began <Value data={monthly_orders} fmt=date/>,
+when there were <Value data={monthly_orders} column=orders/> orders.
 ```
 
 **Result on Webpage:**

--- a/sites/docs/docs/features/queries/sql-queries.md
+++ b/sites/docs/docs/features/queries/sql-queries.md
@@ -11,16 +11,20 @@ When you open a page in dev mode, Evidence runs all of the queries on the page. 
 You can include SQL queries in your page using a markdown code block (starting and ending with 3 backticks). Evidence requires a query name to be supplied directly after the first 3 backticks.
 
 ````markdown
-```data_sample
+```sales_by_country
 select country, sum(sales) as sales
 from international_transactions 
 ```
 ````
 
 ## Using Query Results
-All query results on a page are returned to a single object called `data`. To use a query result, you need to reference the query name as a subset of that `data` object. These references can be used in any of the components from our built-in library.
+All query results on a page are returned to a single object called `data`. To use a query result, you can to reference  a subset of the `data` object. For instance if your query is named `sales_by_country`, you can reference the results using `data.sales_by_country`.  For convinience, Evidence also exposes each query result by it's own name, e.g `sales_by_country`.  These references can be used in any of the components from our built-in library.
 
 For example, if your query name was `sales_by_country`:
+```markdown
+<LineChart data={sales_by_country}/>
+```
+or alternatively,
 ```markdown
 <LineChart data={data.sales_by_country}/>
 ```

--- a/sites/docs/docs/features/queries/sql-queries.md
+++ b/sites/docs/docs/features/queries/sql-queries.md
@@ -18,7 +18,7 @@ from international_transactions
 ````
 
 ## Using Query Results
-All query results on a page are returned to a single object called `data`. To use a query result, you can to reference  a subset of the `data` object. For instance if your query is named `sales_by_country`, you can reference the results using `data.sales_by_country`.  For convinience, Evidence also exposes each query result by it's own name, e.g `sales_by_country`.  These references can be used in any of the components from our built-in library.
+Reference a query in a component using `data={query_name}`
 
 For example, if your query name was `sales_by_country`:
 ```markdown

--- a/sites/docs/docs/getting-started/edit-your-project.md
+++ b/sites/docs/docs/getting-started/edit-your-project.md
@@ -73,12 +73,12 @@ Evidence supports extremely large queries, but they can be slow to run in develo
 ## Components
 You can include query results on your page using Evidence's built-in component library. Evidence components include things like charts, tables, and graphs. 
 
-All query results on a page are returned to a single object called `data`. To use a query result, you need to reference the query name as a subset of that `data` object. These references can be used in any of the components from our built-in library.
+You can use a query result in a component with `data={query_name}`
 
 For example, if your query name was `regional_sales_change`, you could include a bar chart like this:
 ```markdown
 <BarChart 
-    data={data.regional_sales_change}
+    data={regional_sales_change}
     x=region
     y=sales_change
 />

--- a/sites/docs/docs/tutorial/add-a-chart.md
+++ b/sites/docs/docs/tutorial/add-a-chart.md
@@ -13,21 +13,21 @@ To do this, add an [<span class="gradient">**&lt;AreaChart/>**</span>](/features
 ```markdown title="Add to the bottom of business-performance.md:"
 ## Monthly Sales
 <AreaChart 
-    data={data.monthly_orders} 
+    data={monthly_orders} 
     x=order_month
     y=sales_usd
 />
 
 ## Monthly Orders
 <LineChart 
-    data={data.monthly_orders} 
+    data={monthly_orders} 
     x=order_month
     y=orders
 />
 
 ## Basket Size
 <BarChart 
-    data={data.monthly_orders} 
+    data={monthly_orders} 
     x=order_month
     y=basket_size_usd
 />

--- a/sites/docs/docs/tutorial/advanced-loops.md
+++ b/sites/docs/docs/tutorial/advanced-loops.md
@@ -42,7 +42,7 @@ order by orders
 ```
 
 <AreaChart
-    data={data.orders_by_channel}
+    data={orders_by_channel}
     x=order_month
     y=orders
     series=channel
@@ -84,14 +84,14 @@ Loops are achieved through an **`each block`**.
 Let's use an each block to list the names of all the channel.
 
 ```json title="Add to bottom of marketing-performance.md:"
-{#each data.channel_cpa as channel}
+{#each channel_cpa as channel}
 
 {channel.marketing_channel}
 
 {/each}
 ```
 #### How does this work? 
-In the each block, we're passing in the query name `data.channel_cpa` and giving it an "alias" of `channel` to reference inside the each block. You **must** alias the query in the each block.
+In the each block, we're passing in the query name `channel_cpa` and giving it an "alias" of `channel` to reference inside the each block. You **must** alias the query in the each block.
 
 The each block loops through every row of the table and displays whatever is included in the middle of the block. In this case, we're displaying the `marketing_channel` column of the `channel` dataset.
 
@@ -109,7 +109,7 @@ We'll use a `<Value/>` component for this. You could do this with a bare referen
 When used inside an **each block**, the `<Value/>` component only requires a reference to the column it needs to display.
 
 ```json {3} title="Change the highlighted line below:"
-{#each data.channel_cpa as channel}
+{#each channel_cpa as channel}
 
 **{channel.marketing_channel} CPA was <Value value={channel.cpa} fmt=usd/>**, with a spend of <Value value={channel.total_spend} fmt=usd/>, bringing in <Value value={channel.total_orders}/> orders.
 

--- a/sites/docs/docs/tutorial/advanced-parameterized-pages.md
+++ b/sites/docs/docs/tutorial/advanced-parameterized-pages.md
@@ -41,7 +41,7 @@ from orders
 group by item
 ```
 
-{#each data.product_list as product}
+{#each product_list as product}
     
 [{product.item}](/product-performance/{product.item})
 
@@ -74,7 +74,7 @@ group by order_month,item
 
 <BarChart 
     title='Orders per week'
-    data={data.monthly_item_sales.filter(d => d.item === $page.params.product)} 
+    data={monthly_item_sales.filter(d => d.item === $page.params.product)}
     x=order_month 
     y=orders
 />
@@ -106,7 +106,7 @@ Adding this to a normal `<BarChart/>` component gives us the following:
 ```html
 <BarChart 
     title='Orders per week'
-    data={data.monthly_item_sales.filter(d => d.item === $page.params.product)} 
+    data={monthly_item_sales.filter(d => d.item === $page.params.product)}
     x=order_month 
     y=orders
 />

--- a/sites/docs/docs/tutorial/use-query-results-in-text.md
+++ b/sites/docs/docs/tutorial/use-query-results-in-text.md
@@ -13,8 +13,8 @@ Evidence's [<span class="gradient">**&lt;Value/>**</span>](/features/markdown/va
 Copy and paste the sentence below into your markdown file.
 
 ```markdown title="Add to business-performance.md below the 'monthly_orders' query:"
-The most recent month of data began <Value data={data.monthly_orders} fmt=date/>, 
-when there were <Value data={data.monthly_orders} column=orders/> orders.
+The most recent month of data began <Value data={monthly_orders} fmt=date/>,
+when there were <Value data={monthly_orders} column=orders/> orders.
 ```
 
 **Result:**

--- a/sites/docs/docs/walkthroughs/evidence-chart-library.md
+++ b/sites/docs/docs/walkthroughs/evidence-chart-library.md
@@ -29,7 +29,7 @@ While our library offers a lot of customizable features, our defaults let you cr
 ## Data Structure
 
 **Data**
-- All charts require a data prop, which should contain a query result (e.g., `data={data.query_name}`)
+- All charts require a data prop, which should contain a query result (e.g., `data={query_name}`)
 
 **x and y**
 - All charts in our library today are x-y coordinate charts (AKA Cartesian), meaning they require `x` and `y` columns to create the axes and scales for the chart
@@ -63,14 +63,14 @@ A composable chart consists of a `<Chart>` component and **primitives**, which a
 
 This structure lets you build simple charts...
 ```html
-<Chart data={data.query_name} x=date y=sales>
+<Chart data={query_name} x=date y=sales>
     <Line/>
 </Chart>
 ```
 
 ...or more complex charts with multiple series types:
 ```html
-<Chart data={data.query_name} x=date>
+<Chart data={query_name} x=date>
     <Bar y=sales/>
     <Line y=gross_profit/>
 </Chart>
@@ -79,7 +79,7 @@ This structure lets you build simple charts...
 Composable charts manage prop conflicts and allow for prop overrides. Props can be defined in both the `<Chart>` component and primitive components, and Evidence will use whichever prop is scoped more specifically. For example, in the code below, the line will plot `gross_profit` instead of `sales`:
 
 ```html
-<Chart data={data.financial_results} x=month y=sales>
+<Chart data={financial_results} x=month y=sales>
     <Line y=gross_profit/>
 </Chart>
 ```
@@ -91,19 +91,19 @@ The easiest way to build a chart in Evidence is by using Quick Charts. Quick Cha
 
 For example, instead of writing this...
 ```markdown
-<Chart data={data.query_name} x=date y=sales>
+<Chart data={query_name} x=date y=sales>
     <Line/>
 </Chart>
 ```
 
 ...you can write this...
 ```markdown
-<LineChart data={data.query_name} x=date y=sales/>
+<LineChart data={query_name} x=date y=sales/>
 ```
 
 ...and if your query columns are organized as described in the data section above, you can simplify it to this:
 ```markdown
-<LineChart data={data.query_name}/>
+<LineChart data={query_name}/>
 ```
 
 #### Available Quick Charts

--- a/sites/docs/package-lock.json
+++ b/sites/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evidence-docs",
-  "version": "1.0.0-next.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evidence-docs",
-      "version": "1.0.0-next.0",
+      "version": "1.0.2",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.0",
         "@docusaurus/preset-classic": "2.0.0-beta.0",

--- a/sites/example-project/package-lock.json
+++ b/sites/example-project/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evidence-dev/components",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@evidence-dev/components",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "dependencies": {
         "@tidyjs/tidy": "2.4.4",
         "downloadjs": "1.4.7",


### PR DESCRIPTION
Took a quick look at how the docs would need to change to reflect that queries can be referenced directly.  It was mostly a search and replace so I just opened a PR (with the exception of sql-queries.md).  Opening this for feedback.