### PR TITLE
Extend formatting system to chart tooltips

### DIFF
--- a/.changeset/lovely-items-kneel.md
+++ b/.changeset/lovely-items-kneel.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': minor
+---
+
+Adds value and column title formatting to chart tooltips, with revised tooltips for scatter, bubble, and histogram charts

--- a/sites/example-project/src/components/modules/formatValue.js
+++ b/sites/example-project/src/components/modules/formatValue.js
@@ -1,6 +1,10 @@
 
 export default function(value, columnFormat, columnUnits) {
 
+  if(value == undefined){
+      value = "-"
+  }
+  
   let suffix;
   switch(columnUnits){
         case "B":

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -89,6 +89,9 @@
          },
          xAxis: {
              boundaryGap: [xType === "time" ? '2%' : '1%', '2%']
+         },
+         tooltip: {
+             trigger: "item"
          }
     }
 
@@ -101,9 +104,11 @@
             if(swapXY){
                 d.yAxis = {...d.yAxis, ...chartOverrides.xAxis};
                 d.xAxis = {...d.xAxis, ...chartOverrides.yAxis};
+                d.tooltip = {...d.tooltip, ...chartOverrides.tooltip};
             } else {
                 d.yAxis = {...d.yAxis, ...chartOverrides.yAxis};
                 d.xAxis = {...d.xAxis, ...chartOverrides.xAxis};
+                d.tooltip = {...d.tooltip, ...chartOverrides.tooltip};
             }
             return d})
     }

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -95,10 +95,16 @@
         tooltipOpts = {
             tooltip: {
                 formatter: function(params) {
-                    tooltipOutput = multiSeries ? `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>` : '';
-                    tooltipOutput = tooltipOutput + `${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                    ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                    ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                    if(multiSeries){
+                        tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
+                        ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                        ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                        ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                    } else {
+                        tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                        <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                        <span style='font-weight: 600;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                    }
                     return tooltipOutput
                 }
             }

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -34,6 +34,8 @@
     let chartType = "Bubble Chart";
     let bubble = true;
 
+    let useTooltip = true;
+
 </script>
 
 <Chart
@@ -66,5 +68,6 @@
         {outlineColor}
         {outlineWidth}
         {scaleTo}
+        {useTooltip}
     />
 </Chart>

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -308,7 +308,7 @@ try{
     // ---------------------------------------------------------------------------------------
     // Add props to store to let child components access them
     // ---------------------------------------------------------------------------------------
-        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xMismatch, size, yMin, columnSummary}});
+        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xFormat, yFormat, xMismatch, size, yMin, columnSummary}});
 
     // ---------------------------------------------------------------------------------------
     // Axis Configuration
@@ -512,14 +512,18 @@ try{
             },
             tooltip: {
                 trigger: "axis",
-                valueFormatter: function(value) {
-                    let formatted;
-                    try {
-                        formatted = formatValue(value, yFormat)
-                    } catch(e) {
-                        return "-"
+                formatter: function(params){
+                    let output
+                    console.log(params)
+                    if(params.length > 1){
+                        output = `<span style='font-weight: 600;'>${formatValue(params[0].value[0], xFormat)}</span>`
+                        for(let i = params.length - 1; i >= 0; i--){
+                            output = output + `<br> ${params[i].marker} ${params[i].seriesName} <span style='float:right; margin-left: 10px;'>${formatValue(params[i].value[1], yFormat)}</span>`
+                        }
+                    } else {
+                        output = `<span style='font-weight: 600;'>${formatValue(params[0].value[0], xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(params[0].value[1], yFormat)}</span>`
                     }
-                    return formatted
+                    return output
                 },
                 confine: true,
                 axisPointer: {
@@ -583,4 +587,3 @@ try{
 <ErrorChart {error} {chartType}/>
 
 {/if}
-

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -517,12 +517,13 @@ try{
             },
             tooltip: {
                 trigger: "axis",
+                // formatter function is overridden in ScatterPlot, BubbleChart, and Histogram
                 formatter: function(params){
                     let output
                     let xVal
                     let yVal
-                    console.log(xType)
                     if(params.length > 1){
+                        // If multi-series, add series name as title of tooltip
                         xVal = params[0].value[swapXY ? 1 : 0]
                         output = `<span style='font-weight: 600;'>${formatValue(xVal, xFormat)}</span>`
                         for(let i = params.length - 1; i >= 0; i--){
@@ -530,10 +531,12 @@ try{
                             output = output + `<br> ${params[i].marker} ${params[i].seriesName} <span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
                         }
                     } else if(xType === "value"){
+                        // If single-series and a numerical x-axis, include x column as a normal column rather than title (so as not to show a number as the title)
                         xVal = params[0].value[swapXY ? 1 : 0]
                         yVal = params[0].value[swapXY ? 0 : 1]
-                        output = `<span>${formatTitle(x, xFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(xVal, xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
+                        output = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(xVal, xFormat)}</span><br/><span style='font-weight: 600;'>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
                     } else {
+                        // If single series and categorical or date x-axis, use x value as title of tooltip
                         xVal = params[0].value[swapXY ? 1 : 0]
                         yVal = params[0].value[swapXY ? 0 : 1]
                         output = `<span style='font-weight: 600;'>${formatValue(xVal, xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -88,6 +88,7 @@
         let xMismatch;
         let xFormat;
         let yFormat;
+        let sizeFormat;
         let xUnits;
         let yUnits;       
         let xDistinct;
@@ -283,6 +284,10 @@ try{
             }
         }
 
+        if(size){
+            sizeFormat = columnSummary[size].format;
+        }
+
         xUnits = columnSummary[x].units;
         
         if(!y){yUnits = ''} else {
@@ -308,7 +313,7 @@ try{
     // ---------------------------------------------------------------------------------------
     // Add props to store to let child components access them
     // ---------------------------------------------------------------------------------------
-        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xFormat, yFormat, xMismatch, size, yMin, columnSummary}});
+        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xFormat, yFormat, sizeFormat, xMismatch, size, yMin, columnSummary, xAxisTitle, yAxisTitle}});
 
     // ---------------------------------------------------------------------------------------
     // Axis Configuration
@@ -514,14 +519,24 @@ try{
                 trigger: "axis",
                 formatter: function(params){
                     let output
-                    console.log(params)
+                    let xVal
+                    let yVal
+                    console.log(xType)
                     if(params.length > 1){
-                        output = `<span style='font-weight: 600;'>${formatValue(params[0].value[0], xFormat)}</span>`
+                        xVal = params[0].value[swapXY ? 1 : 0]
+                        output = `<span style='font-weight: 600;'>${formatValue(xVal, xFormat)}</span>`
                         for(let i = params.length - 1; i >= 0; i--){
-                            output = output + `<br> ${params[i].marker} ${params[i].seriesName} <span style='float:right; margin-left: 10px;'>${formatValue(params[i].value[1], yFormat)}</span>`
+                            yVal = params[i].value[swapXY ? 0 : 1]
+                            output = output + `<br> ${params[i].marker} ${params[i].seriesName} <span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
                         }
+                    } else if(xType === "value"){
+                        xVal = params[0].value[swapXY ? 1 : 0]
+                        yVal = params[0].value[swapXY ? 0 : 1]
+                        output = `<span>${formatTitle(x, xFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(xVal, xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
                     } else {
-                        output = `<span style='font-weight: 600;'>${formatValue(params[0].value[0], xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(params[0].value[1], yFormat)}</span>`
+                        xVal = params[0].value[swapXY ? 1 : 0]
+                        yVal = params[0].value[swapXY ? 0 : 1]
+                        output = `<span style='font-weight: 600;'>${formatValue(xVal, xFormat)}</span><br/><span>${formatTitle(y, yFormat)}: </span><span style='float:right; margin-left: 10px;'>${formatValue(yVal, yFormat)}</span>`
                     }
                     return output
                 },

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -10,6 +10,7 @@
         import getSortedData from '../modules/getSortedData.js';
         import formatAxisLabel from '../modules/formatAxisLabel';
         import formatTitle from '../modules/formatTitle.js';
+        import formatValue from '../modules/formatValue.js';
         import ErrorChart from './ErrorChart.svelte';
         import checkInputs from '../modules/checkInputs';
         import {colours} from '../modules/colours'
@@ -511,6 +512,12 @@ try{
             },
             tooltip: {
                 trigger: "axis",
+                // formatter: function (params) {
+                    // console.log(params[0])
+                    // return params[1].marker + params[1].seriesId
+                    // return "<strong>" + formatTitle(x, xFormat) + ": </strong>  " + " <span style='float:right'>" + formatValue(params[0].value[0], xFormat) + "</span><br/> " + formatTitle(y, yFormat) + ": " + "<span style='float:right'>" + formatValue(params[0].value[1], yFormat) + "</span>"
+//                 }
+// ,
                 confine: true,
                 axisPointer: {
                     // Use axis to trigger tooltip 

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -512,12 +512,15 @@ try{
             },
             tooltip: {
                 trigger: "axis",
-                // formatter: function (params) {
-                    // console.log(params[0])
-                    // return params[1].marker + params[1].seriesId
-                    // return "<strong>" + formatTitle(x, xFormat) + ": </strong>  " + " <span style='float:right'>" + formatValue(params[0].value[0], xFormat) + "</span><br/> " + formatTitle(y, yFormat) + ": " + "<span style='float:right'>" + formatValue(params[0].value[1], yFormat) + "</span>"
-//                 }
-// ,
+                valueFormatter: function(value) {
+                    let formatted;
+                    try {
+                        formatted = formatValue(value, yFormat)
+                    } catch(e) {
+                        return "-"
+                    }
+                    return formatted
+                },
                 confine: true,
                 axisPointer: {
                     // Use axis to trigger tooltip 
@@ -532,7 +535,8 @@ try{
                 extraCssText: 'box-shadow: 0 3px 6px rgba(0,0,0,.15); box-shadow: 0 2px 4px rgba(0,0,0,.12); z-index: 1;',
                 textStyle: {
                     color: colours.grey900,
-                    fontSize: 12
+                    fontSize: 12,
+                    fontWeight: 400
                 },
                 order:'valueDesc'
             },

--- a/sites/example-project/src/components/viz/Hist.svelte
+++ b/sites/example-project/src/components/viz/Hist.svelte
@@ -2,6 +2,7 @@
     import { props, config } from '$lib/modules/stores.js';   
     import ecStat from 'echarts-stat';
     import getDistinctValues from '$lib/modules/getDistinctValues.js';
+    import formatValue from '../modules/formatValue';
 
     export let x = undefined;
 
@@ -11,6 +12,8 @@
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
     let data = $props.data;
     x = x ?? $props.x;
+    let xFormat = $props.xFormat;
+    let yFormat = $props.yFormat;
 
     // Determine right method to use based on distinct x values (echarts-stat limitation causes some errors otherwise)
     let method;
@@ -66,8 +69,19 @@
         },
         data: histData.data,
         encode: {
-            tooltip: [1],
-            itemName: 4
+            tooltip: [1], // y column from shape{} above,
+            itemName: 4 // data at index 4 of api.value() - min and max of bin separated by hyphen
+        },
+        tooltip: {
+            formatter: function(params){
+                // params.value[0] = bin midpoint
+                // params.value[1] = frequency (count)
+                // params.value[2] = bin min
+                // params.value[3] = bin max
+                // params.value[4] = string of bin range - min and max separated by hyphen
+
+                return `<span style='font-weight:600;'>${formatValue(params.value[2],xFormat)} - ${formatValue(params.value[3],xFormat)}</span> <span style='margin-left: 10px;'> ${params.value[1]}</span>`
+           }
         }
     }
 

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -72,9 +72,14 @@
         tooltipOpts = {
             tooltip: {
                 formatter: function(params) {
-                    tooltipOutput = multiSeries ? `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>` : '';
-                    tooltipOutput = tooltipOutput + `${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                    ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                    if(multiSeries){
+                        tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
+                        ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                        ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                    } else {
+                        tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                        <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                    }
                     return tooltipOutput
                 }
             }

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -69,6 +69,9 @@
          },
          xAxis: {
              boundaryGap: [xType === "time" ? '2%' : '1%', '2%']
+         },
+         tooltip: {
+             trigger: "item"
          }
      }
 
@@ -77,9 +80,11 @@
             if(swapXY){
                 d.yAxis = {...d.yAxis, ...chartOverrides.xAxis};
                 d.xAxis = {...d.xAxis, ...chartOverrides.yAxis};
+                d.tooltip = {...d.tooltip, ...chartOverrides.tooltip};
             } else {
                 d.yAxis = {...d.yAxis, ...chartOverrides.yAxis};
                 d.xAxis = {...d.xAxis, ...chartOverrides.xAxis};
+                d.tooltip = {...d.tooltip, ...chartOverrides.tooltip};
             }
             return d})
     }

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -32,6 +32,8 @@
 
     let chartType = "Scatter Plot";
 
+    let useTooltip = true;
+
 </script>
 
 <Chart
@@ -62,5 +64,6 @@
         {outlineColor}
         {outlineWidth}
         {pointSize}
+        {useTooltip}
     />
 </Chart>

--- a/sites/example-project/src/pages/newpage.md
+++ b/sites/example-project/src/pages/newpage.md
@@ -1,0 +1,70 @@
+
+```census
+select median_rent as median_rent_usd, income_per_capita as income_per_capita_usd
+from `bigquery-public-data.census_bureau_acs.state_2017_1yr`
+```
+
+<ScatterPlot data={census} y=median_rent_usd x=income_per_capita_usd size=income_per_capita_usd yAxisTitle="Median Rent" xAxisTitle="Income Per Capita"/>
+
+
+```census2
+select 'Product A' as product, 371 as median_rent_usd, 12279 as income_per_capita_usd,  union all
+select 'Product B' as product, 1434 as median_rent_usd, 33882 as income_per_capita_usd,  union all
+select 'Product C' as product, 698 as median_rent_usd, 26386 as income_per_capita_usd,  union all
+select 'Product D' as product, 1085 as median_rent_usd, 34222 as income_per_capita_usd,  union all
+select 'Product E' as product, 523 as median_rent_usd, 24478 as income_per_capita_usd,  union all
+select 'Product F' as product, 844 as median_rent_usd, 32443 as income_per_capita_usd,  union all
+select 'Product G' as product, 703 as median_rent_usd, 30883 as income_per_capita_usd,  union all
+select 'Product H' as product, 720 as median_rent_usd, 31088 as income_per_capita_usd,  union all
+select 'Product I' as product, 548 as median_rent_usd, 25316 as income_per_capita_usd,  union all
+select 'Product J' as product, 693 as median_rent_usd, 34041 as income_per_capita_usd,  union all
+select 'Product K' as product, 574 as median_rent_usd, 23121 as income_per_capita_usd,  union all
+select 'Product L' as product, 667 as median_rent_usd, 29428 as income_per_capita_usd,  union all
+select 'Product M' as product, 621 as median_rent_usd, 29611 as income_per_capita_usd,  union all
+select 'Product N' as product, 697 as median_rent_usd, 25311 as income_per_capita_usd,  union all
+select 'Product O' as product, 633 as median_rent_usd, 28323 as income_per_capita_usd,  union all
+select 'Product P' as product, 571 as median_rent_usd, 26779 as income_per_capita_usd,  union all
+select 'Product Q' as product, 1408 as median_rent_usd, 52500 as income_per_capita_usd,  union all
+select 'Product R' as product, 843 as median_rent_usd, 29525 as income_per_capita_usd,  union all
+select 'Product S' as product, 666 as median_rent_usd, 28764 as income_per_capita_usd,  union all
+select 'Product T' as product, 858 as median_rent_usd, 29420 as income_per_capita_usd,  union all
+select 'Product U' as product, 1116 as median_rent_usd, 37156 as income_per_capita_usd,  union all
+select 'Product V' as product, 852 as median_rent_usd, 34196 as income_per_capita_usd,  union all
+select 'Product W' as product, 628 as median_rent_usd, 30865 as income_per_capita_usd,  union all
+select 'Product X' as product, 1151 as median_rent_usd, 40567 as income_per_capita_usd,  union all
+select 'Product Y' as product, 865 as median_rent_usd, 28085 as income_per_capita_usd,  union all
+select 'Product Z' as product, 903 as median_rent_usd, 30166 as income_per_capita_usd,  union all
+select 'Product AA' as product, 699 as median_rent_usd, 31998 as income_per_capita_usd,  union all
+select 'Product AB' as product, 628 as median_rent_usd, 29438 as income_per_capita_usd,  union all
+select 'Product AC' as product, 1125 as median_rent_usd, 36345 as income_per_capita_usd,  union all
+select 'Product AD' as product, 678 as median_rent_usd, 25885 as income_per_capita_usd,  union all
+select 'Product AE' as product, 975 as median_rent_usd, 29838 as income_per_capita_usd,  union all
+select 'Product AF' as product, 620 as median_rent_usd, 26472 as income_per_capita_usd,  union all
+select 'Product AG' as product, 627 as median_rent_usd, 30038 as income_per_capita_usd,  union all
+select 'Product AH' as product, 636 as median_rent_usd, 30146 as income_per_capita_usd,  union all
+select 'Product AI' as product, 1193 as median_rent_usd, 39960 as income_per_capita_usd,  union all
+select 'Product AJ' as product, 935 as median_rent_usd, 33887 as income_per_capita_usd,  union all
+select 'Product AK' as product, 935 as median_rent_usd, 31950 as income_per_capita_usd,  union all
+select 'Product AL' as product, 953 as median_rent_usd, 38237 as income_per_capita_usd,  union all
+select 'Product AM' as product, 565 as median_rent_usd, 26498 as income_per_capita_usd,  union all
+select 'Product AN' as product, 698 as median_rent_usd, 29560 as income_per_capita_usd,  union all
+select 'Product AO' as product, 963 as median_rent_usd, 42029 as income_per_capita_usd,  union all
+select 'Product AP' as product, 1084 as median_rent_usd, 41821 as income_per_capita_usd,  union all
+select 'Product AQ' as product, 657 as median_rent_usd, 30915 as income_per_capita_usd,  union all
+select 'Product AR' as product, 832 as median_rent_usd, 34511 as income_per_capita_usd,  union all
+select 'Product AS' as product, 665 as median_rent_usd, 27909 as income_per_capita_usd,  union all
+select 'Product AT' as product, 693 as median_rent_usd, 30488 as income_per_capita_usd,  union all
+select 'Product AU' as product, 782 as median_rent_usd, 29668 as income_per_capita_usd,  union all
+select 'Product AV' as product, 1087 as median_rent_usd, 36975 as income_per_capita_usd,  union all
+select 'Product AW' as product, 1005 as median_rent_usd, 37442 as income_per_capita_usd,  union all
+select 'Product AX' as product, 859 as median_rent_usd, 36156 as income_per_capita_usd,  union all
+select 'Product AY' as product, 743 as median_rent_usd, 32711 as income_per_capita_usd,  union all
+select 'Product AZ' as product, 1320 as median_rent_usd, 35046 as income_per_capita_usd, 
+```
+
+<ScatterPlot
+    data={data.census2}
+    x=income_per_capita_usd
+    y=median_rent_usd
+/>
+


### PR DESCRIPTION
This PR adds value and column title formatting to chart tooltips.

It includes:
 - ECharts custom `formatter` function to pull in value and title formats as specified through column format tags
 - Specific tooltip formats for `<ScatterPlot/>`, `<BubbleChart/>`, and `<Histogram/>` which override the default chart tooltip

## Before
<img width="587" alt="CleanShot 2022-06-20 at 10 09 13@2x" src="https://user-images.githubusercontent.com/12602440/174621233-1bff6145-6b6d-49c7-89da-7b17d27452e8.png">
<img width="582" alt="CleanShot 2022-06-20 at 10 09 57@2x" src="https://user-images.githubusercontent.com/12602440/174621263-0e0ab449-059c-455e-986f-0d38eeb720b6.png">
<img width="593" alt="CleanShot 2022-06-20 at 10 10 59@2x" src="https://user-images.githubusercontent.com/12602440/174621291-6b56ed76-3dec-4cc9-ae30-b9f39a5b4cf9.png">

## After
<img width="590" alt="CleanShot 2022-06-20 at 10 06 26@2x" src="https://user-images.githubusercontent.com/12602440/174621137-08f48fe8-c8d7-4497-99e4-df9fb24b4990.png">
<img width="590" alt="CleanShot 2022-06-20 at 10 06 48@2x" src="https://user-images.githubusercontent.com/12602440/174621186-0acea05f-5360-4d3f-bd5c-f32bb84b0f16.png">
<img width="585" alt="CleanShot 2022-06-20 at 10 11 28@2x" src="https://user-images.githubusercontent.com/12602440/174621306-f991a74c-a016-4081-87eb-bb64f0cca5c5.png">

# Future Improvements
 - Add more columns to the tooltips for `<ScatterPlot/>` and `<BubbleChart/>`
    - These should include at least one identifier column (e.g., Product Name)
    - The right behaviour might be to include all columns from the query result in the tooltip to start, then provide an option to exclude specific columns
    - If we add these options, we should probably also include a prop where you can specify exactly which column(s) you would like to appear in the tooltip
 - Add back the feature to sort tooltip series based on value (max on top of list, min at bottom)
    - This PR breaks the behaviour of multi-series line chart tooltips, where the tooltip would reorder the series shown in the tooltip to match the position of the series at that point in the chart (max on top, min on bottom)
    - To add this functionality back, we will need to add a sort function to the `formatter` definition
 - Make histogram tooltip support multiple series
    - Histogram tooltips work well for a single series, but when we add the ability to plot multi-series histograms, we will need to revisit the tooltip design and examine the data structure that ECharts returns to our component
 - Axis title override behaviour
    - You can change the label that appears for the x-axis or y-axis on your chart, but at the moment these labels do not replace the column titles shown in the tooltip
    - For example, if a column name is `gdp_usd`, it will be formatted as "Gdp ($)". 
       - You can override the axis label to show "GDP", but the tooltip will still show "Gdp ($)"     