### PR TITLE
indicate types, fix boolean styling

### DIFF
--- a/.changeset/kind-steaks-laugh.md
+++ b/.changeset/kind-steaks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Indicate the data type that evidence has identified in the queryviewer data table

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -87,6 +87,14 @@
               evidenceTypeFidelity="{column.evidenceColumnType?.typeFidelity || 'unavailable'}"> {column.id} </th>
           {/each}
         <tr/>
+        <tr class=type-indicator>
+          <th class="index type-indicator" style="width:10%"></th>
+          {#each columnSummary as column}
+          <th class="{column.type} type-indicator" style="width:{columnWidths}%" 
+              evidenceType="{column.evidenceColumnType?.evidenceType || 'unavailable'}"
+              evidenceTypeFidelity="{column.evidenceColumnType?.typeFidelity || 'unavailable'}"> {column.type} </th>
+          {/each}
+        <tr/>
       </thead>
           <tbody>
               {#each dataPage as row, i}
@@ -120,6 +128,12 @@
                             {cell || "Ø"}                       
                         </div>
                       </td>
+                    {:else if columnSummary[j].type === 'boolean'}
+                    <td class="boolean" style="width:{columnWidths}%" title={cell}>
+                      <div >
+                          {cell ?? "Ø"}                       
+                      </div>
+                    </td>
                     {:else}
                       <td class="other" style="width:{columnWidths}%">
                             {cell || "Ø"}                       
@@ -294,6 +308,10 @@
     text-align: right;
   }
 
+  .boolean{
+    text-align: left; 
+  }
+
   .null{
     color: var(--grey-300);
   }
@@ -306,5 +324,15 @@
 
   .results-pane {
     margin-bottom: 40px;
+  }
+
+  th.type-indicator {
+    color:var(--grey-400);
+    font-weight:normal;
+    font-style: italic;
+  }
+
+  tr.type-indicator { 
+    border-bottom: 1px solid var(--grey-100)
   }
 </style>

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -271,6 +271,7 @@
     font-size: calc(1em - 4px);
     border-collapse: collapse;
     font-family: var(--ui-font-family);
+    font-variant-numeric: tabular-nums;
   }
 
   th{


### PR DESCRIPTION
Happy to look at an icon in the future, but I think this is probably the most straightforward for now, and doesn't require a tooltip. I also think we can add a few additional "sub-header" rows like these to display a couple other things in the future: extents, distributions, central tendency, that type of thing. 

- also cleans up formatting of boolean (and treatment of "false") 
- ~~we should switch to a tabular font in here (compare the widths of the two gdp figures). I'll open an issue for this.~~ [edit: done]

<img width="681" alt="CleanShot 2022-06-20 at 11 25 28@2x" src="https://user-images.githubusercontent.com/6857673/174636009-d62033eb-40df-477a-91eb-8f0334facd84.png">
