### PR TITLE
Fix missing gitignore error in settings

### DIFF
--- a/.changeset/lucky-tigers-swim.md
+++ b/.changeset/lucky-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Bug fix for settings page when gitignore file is missing

--- a/.changeset/tiny-maps-cheer.md
+++ b/.changeset/tiny-maps-cheer.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Avoids creating gitignore file when gitignore not selected

--- a/sites/example-project/src/components/ui/Databases/SqliteForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SqliteForm.svelte
@@ -4,7 +4,7 @@
 	export let credentials;
 	export let existingCredentials;
     export let gitIgnore;
-    existingCredentials.gitignoreSqlite = gitIgnore.match(/\n.db(?=\n|$)/) && gitIgnore.match(/\n.sqlite3(?=\n|$)/) && gitIgnore.match(/\n.sqlite(?=\n|$)/)
+    existingCredentials.gitignoreSqlite = gitIgnore ? gitIgnore.match(/\n.db(?=\n|$)/) && gitIgnore.match(/\n.sqlite3(?=\n|$)/) && gitIgnore.match(/\n.sqlite(?=\n|$)/) : false;
     export let disableSave;
 
 	credentials = { ...existingCredentials };

--- a/sites/example-project/src/pages/api/settings.json.js
+++ b/sites/example-project/src/pages/api/settings.json.js
@@ -46,7 +46,13 @@ export function post(request) {
     const {settings} = JSON.parse(request.body)
     fs.writeFileSync('evidence.settings.json', JSON.stringify(settings));
     if(settings.database === "sqlite"){
-        let gitIgnore = fs.readFileSync('../../.gitignore', 'utf8')
+        let gitIgnore;
+        if(fs.existsSync('../../.gitignore')){
+            gitIgnore = fs.readFileSync('../../.gitignore', 'utf8')
+        } else {
+            gitIgnore = ""
+            fs.writeFileSync('../../.gitignore', gitIgnore)
+        }
         let extensions = [".db", ".sqlite", ".sqlite3"]
         if(settings.credentials.gitignoreSqlite === false){
             let regex

--- a/sites/example-project/src/pages/api/settings.json.js
+++ b/sites/example-project/src/pages/api/settings.json.js
@@ -47,24 +47,22 @@ export function post(request) {
     fs.writeFileSync('evidence.settings.json', JSON.stringify(settings));
     if(settings.database === "sqlite"){
         let gitIgnore;
-        if(fs.existsSync('../../.gitignore')){
-            gitIgnore = fs.readFileSync('../../.gitignore', 'utf8')
-        } else {
-            gitIgnore = ""
-            fs.writeFileSync('../../.gitignore', gitIgnore)
-        }
+        let hasGitIgnore = fs.existsSync('../../.gitignore');
+        gitIgnore = hasGitIgnore ? fs.readFileSync('../../.gitignore', 'utf8') : "";
         let extensions = [".db", ".sqlite", ".sqlite3"]
         if(settings.credentials.gitignoreSqlite === false){
             let regex
-            extensions.forEach(ext => {
-                // Find newline plus extension and only match those strings which are directly
-                // followed by either a new line or the end of the file contents
-                // (stops the issue of matching .sqlite within the .sqlite3 string)
-                // g means global match - same behaviour as replaceAll
-                regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
-                gitIgnore = gitIgnore.replace(regex, "")
-            })
-            fs.writeFileSync('../../.gitignore', gitIgnore)
+            if(hasGitIgnore){
+                extensions.forEach(ext => {
+                    // Find newline plus extension and only match those strings which are directly
+                    // followed by either a new line or the end of the file contents
+                    // (stops the issue of matching .sqlite within the .sqlite3 string)
+                    // g means global match - same behaviour as replaceAll
+                    regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
+                    gitIgnore = gitIgnore.replace(regex, "")
+                })
+                fs.writeFileSync('../../.gitignore', gitIgnore)
+            }
         } else if(settings.credentials.gitignoreSqlite === true){
             extensions.forEach(ext => {
                 regex = new RegExp(`\n${ext}(?=\n|$)`, "g")


### PR DESCRIPTION
## Current
If your project doesn't have a `.gitignore` file:
 - Selecting SQLite as your database on the Settings page throws an error.

## After Fix
If your project doesn't have a `.gitignore` file:

 - Selecting SQLite as your database does not throw an error.

 - If you save a SQLite database on your Settings page and set "Gitignore All SQLite Files" to `true`, Evidence will create a new `.gitignore` file in the root of your project and add SQLite extensions to it.

 - If you set "Gitignore All SQLite Files" to false, Evidence will save the database, but will not create a `.gitignore` file