### PR TITLE
Added ssf dependency to the component project

### DIFF
--- a/.changeset/serious-bottles-study.md
+++ b/.changeset/serious-bottles-study.md
@@ -1,0 +1,6 @@
+---
+"@evidence-dev/evidence": minor
+"@evidence-dev/components": minor
+---
+
+Fixed a dependency issue with the ssf library

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -40,7 +40,7 @@ fs.outputFileSync('./template/svelte.config.js',
             },
             vite: {
                 optimizeDeps: {
-                    include: ['echarts-stat', 'export-to-csv', 'downloadjs'],
+                    include: ['echarts-stat', 'export-to-csv', 'ssf', 'downloadjs'],
                     exclude: ['@evidence-dev/components']
                 },
                 ssr: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,7 @@ importers:
       export-to-csv: 0.2.1
       fs-extra: ^10.0.1
       git-remote-origin-url: 4.0.0
+      ssf: ^0.11.2
       svelte-icons: 2.1.0
     dependencies:
       '@tidyjs/tidy': 2.4.4
@@ -266,6 +267,7 @@ importers:
       echarts-stat: 1.2.0
       export-to-csv: 0.2.1
       git-remote-origin-url: 4.0.0
+      ssf: 0.11.2
       svelte-icons: 2.1.0
     devDependencies:
       fs-extra: 10.0.1
@@ -7261,7 +7263,6 @@ packages:
   /frac/1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
-    dev: true
 
   /fraction.js/4.1.1:
     resolution: {integrity: sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==}
@@ -12475,7 +12476,6 @@ packages:
     engines: {node: '>=0.8'}
     dependencies:
       frac: 1.1.2
-    dev: true
 
   /sshpk/1.16.1:
     resolution: {integrity: sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==}

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -17,7 +17,8 @@
     "echarts-stat": "1.2.0",
     "export-to-csv": "0.2.1",
     "git-remote-origin-url": "4.0.0",
-    "svelte-icons": "2.1.0"
+    "svelte-icons": "2.1.0",
+    "ssf": "^0.11.2"
   },
   "publishConfig": {
     "directory": "../../packages/components"


### PR DESCRIPTION
The ssf library was needed from code in the components.
It seems to that it is the `package.json` in the example project that gets copied as the package.json in the components package, so I added the dependency there.  However, I still noticed that the dependency has to be listed on the top level package.json file for the example project to work. 