### PR TITLE
Turn on quote formatting in mdsvex

### DIFF
--- a/.changeset/lovely-maps-love.md
+++ b/.changeset/lovely-maps-love.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/preprocess": patch
+---
+
+Turns on quote formatting

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -256,7 +256,7 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false){
         mdsvex.mdsvex(
             {extensions: [".md"],
             smartypants: {
-                quotes: false,
+                quotes: true,
                 ellipses: true,
                 backticks: true,
                 dashes: 'oldschool',


### PR DESCRIPTION
Turns on styling for quotes, so when you save a quote in your `.md` file, it includes curly quotes on your webpage.

## Before
<img width="403" alt="CleanShot 2022-07-11 at 17 03 44@2x" src="https://user-images.githubusercontent.com/12602440/178358890-5e1288f8-2b23-4fb3-8faa-1b2866c1e606.png">
<img width="185" alt="CleanShot 2022-07-11 at 17 03 49@2x" src="https://user-images.githubusercontent.com/12602440/178358889-70e963a1-f779-4778-ad80-5c3b694feb7e.png">

## After
<img width="395" alt="CleanShot 2022-07-11 at 17 02 03@2x" src="https://user-images.githubusercontent.com/12602440/178358894-ca69d482-9588-4153-a4bf-b22523cd0744.png">
<img width="182" alt="CleanShot 2022-07-11 at 17 02 33@2x" src="https://user-images.githubusercontent.com/12602440/178358892-ce2daf41-8718-4653-a8e8-4c3a7696eb3c.png">

Quotes included in SQL queries appear the same way (as straight quotes rather than curly).