### PR TITLE
Mobile Hamburger configuration

### DIFF
--- a/.changeset/rich-cows-rescue.md
+++ b/.changeset/rich-cows-rescue.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+moving mobile hamburger to top right

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -156,7 +156,7 @@ code {
 
 :root {
 	/* Layout header height */
-	--header-height: 2.5rem; 
+	--header-height: 3.5rem; 
 	/* Font stacks */
 	--monospace-font-family:  Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace;
 	--ui-font-family: "SF Display", -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; 

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -29,8 +29,8 @@
 		grid-column: auto;
 		z-index: 5;
         position:fixed;
-        left: 0;
-        bottom: 0; 
+        right: 0;
+        top: 0; 
         margin: 1.0em;
         border: none;
         color: none;

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -39,7 +39,6 @@
         text-decoration: none;
         font-size: 16px;
         background-color: hsla(217, 33%, 97%, 0);
-		backdrop-filter: blur(20px) saturate(1.8);
         border-radius: 4px;
 	}
 	

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -34,14 +34,14 @@
         margin: 1.0em;
         border: none;
         color: none;
-        padding: 14px 11px 14px 11px;
+        padding: 0px 11px 14px 11px;
         text-align: center;
         text-decoration: none;
         font-size: 16px;
-        background-color: hsla(217, 33%, 97%, .83);
+        background-color: hsla(217, 33%, 97%, 0);
 		-webkit-backdrop-filter: blur(20px) saturate(1.8);
 		backdrop-filter: blur(20px) saturate(1.8);
-		border: 1px solid var(--grey-300);	
+		
         border-radius: 4px;
 	}
 	

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -39,9 +39,7 @@
         text-decoration: none;
         font-size: 16px;
         background-color: hsla(217, 33%, 97%, 0);
-		-webkit-backdrop-filter: blur(20px) saturate(1.8);
 		backdrop-filter: blur(20px) saturate(1.8);
-		
         border-radius: 4px;
 	}
 	

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -410,8 +410,8 @@ span.alert-icon {
 		position: fixed;
 		height: 100%;
 		width: 100%; 
-		left: -100%;
-		transition: left 0.3s ease-in-out; 	
+		left: 100%;
+		transition: all 0.3s ease-in-out; 	
 		background-color: hsla(217, 33%, 97%, .83);
 		-webkit-backdrop-filter: blur(20px) saturate(1.8);
 		backdrop-filter: blur(20px) saturate(1.8);

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -410,8 +410,8 @@ span.alert-icon {
 		position: fixed;
 		height: 100%;
 		width: 100%; 
-		left: 100%;
-		transition: all 0.3s ease-in-out; 	
+		left: -100%;
+		transition: left 0.3s ease-in-out; 	
 		background-color: hsla(217, 33%, 97%, .83);
 		-webkit-backdrop-filter: blur(20px) saturate(1.8);
 		backdrop-filter: blur(20px) saturate(1.8);


### PR DESCRIPTION
**Why**
The mobile hamburger is currently in an unexpected location (bottom-left)
This makes it hard to find, and can also mean it is not clear when evidence is in "mobile" mode.

**What is best practice?**
When you look at most modern websites and apps, the mobile hamburger menu is either in the top left (eg Github - this page, https://www.adidas.ca/), or top right (eg https://getbootstrap.com/, https://www.nike.com).

**Potential solution**
- This PR includes a top right positioning.
  - This is a pretty easy implementation as it doesn't block the current nav items.
  - This can be done with the slide-in as is, from the left, or altering the slide-in to be from the right. See gifs below. 
  - Personally prefer the slide from the left as before, but keen to hear other views



**From Left** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **From Right**
<img src=https://user-images.githubusercontent.com/58074498/180832623-6abf33aa-7698-4237-9e10-99010d6c6c44.gif height=500>                 <img src=https://user-images.githubusercontent.com/58074498/180832315-8c789649-91bd-42a3-b3f8-f267f6e61b30.gif height=500>

**Other thoughts**
Most implementations have a full top navbar which *includes* a hamburger, rather than a floating hamburger button. This might be a better option, but does reduce screen space?
<img width="449" alt="image" src="https://user-images.githubusercontent.com/58074498/180833630-664be8ce-f1b7-45e5-8b6a-9ddcf88f1979.png">


