### PR TITLE
Settings formatting nits

### DIFF
--- a/.changeset/cold-timers-swim.md
+++ b/.changeset/cold-timers-swim.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Updates to settings page layout

--- a/sites/example-project/src/components/ui/Formatting/BuiltInFormatGrid.svelte
+++ b/sites/example-project/src/components/ui/Formatting/BuiltInFormatGrid.svelte
@@ -4,8 +4,7 @@
   export let formats;
 </script>
 
-<div class="tableContainer">
-<table class="formatTable" width="100%">
+<table>
   <thead>
     <th class="align_left narrow_column">Format Tag</th>
     <th class="align_left wide_column">Format Code</th>
@@ -29,16 +28,5 @@
     </tr>
   {/each}
 </table>
-</div>
 
-<style>
-  .formatTable {
-    font-size: 12px;
-  }
 
-  .tableContainer {
-    border: 1px solid var(--gray-light, #eee);
-    border-radius: 4px;
-    padding: 8px 4px 8px 4px;
-  }
-</style>

--- a/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
@@ -34,16 +34,18 @@
   }
 
   button {
+    font-size: 14px;
     background-color: var(--grey-100);
     border-radius: 4px;
-    color: var(--gray-darkest, #282828);
+    color: var(--gray-999);
     display: flex;
     justify-content: space-between;
     width: 100%;
     border: none;
     margin: 0;
-    padding: 0.4em 0.5em;
+    padding: 0.5em 0.5em;
     cursor: pointer;
+    /* border: 1px solid var(--grey-200); */
   }
 
   button[area-expanded="true"] .vert {
@@ -57,10 +59,7 @@
   }
  
   .collapsibleContents {
-    /* border: 1px solid var(--gray-light, #eee); */
-    padding-top: 5px;
-    padding-bottom: 5px;
-    margin: 0 0.5em 0.5em 0.5em;
+    padding: 0.5em 0.5em 1.5em 0.5em;
   }
   .collapsibleSection {
     padding: 0px;

--- a/sites/example-project/src/components/ui/Formatting/CurrencyFormatGrid.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CurrencyFormatGrid.svelte
@@ -8,14 +8,13 @@
 </script>
 
 <select bind:value={selectedCurrency}>
+  <option>Choose a currency</option>
   ${#each SUPPORTED_CURRENCIES as currency}
     <option name={currency.primaryCode} id={currency.primaryCode} value={currency.primaryCode}>{currency.displayName}</option>
   {/each}
-
 </select>
-
-<div class="tableContainer">
-<table class="formatTable" width="100%" transition:blur>
+{#if selectedCurrency != 'Choose a currency'}
+<table transition:blur>
   <thead>
     <th class="align_left narrow_column">Format Tag</th>
     <th class="align_left wide_column">Format Code</th>
@@ -23,7 +22,7 @@
     <th class="align_right wide_column">Example Output</th>
   </thead>
   {#each formats.filter(d => d.parentFormat === selectedCurrency) as format}
-    <tr>
+    <tr transition:blur>
       <td transition:blur>{format.formatTag} </td>
       <td transition:blur>{format.formatCode} </td>
       <td transition:blur>
@@ -39,41 +38,28 @@
     </tr>
   {/each}
 </table>
-</div>
+{/if}
 
 <style>
-  .formatTable {
-    font-size: 12px;
-  }
-
-  .tableContainer {
-    border: 1px solid var(--gray-light, #eee);
-    border-radius: 4px;
-    padding: 8px 4px 8px 4px;
-  }
-
   select {
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;   
-        padding:0.75em;
-        width: 100%;
-        border: 1px solid var(--grey-200); 
-        font-family: var(--ui-font-family);
-        color: var(--grey-800); 
-        margin: 0.5em 0 1.5em 0;
-        transition: all 400ms;
-        cursor: pointer;
-    }
-
-        select:hover{
-            border: 1px solid var(--grey-300);
-            transition: all 400ms;
-            box-shadow: 0 5px 5px 2px hsl(0deg 0% 97%);
-    }
-
-        select:focus {
-            outline: none;
-
-    }
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;   
+    padding:0.75em;
+    width: calc(100% + 14px);
+    border: 1px solid var(--grey-200); 
+    font-family: var(--ui-font-family);
+    color: var(--grey-800); 
+    margin: 0.5em 0 1.5em -7px;
+    transition: all 400ms;
+    cursor: pointer;
+  }
+  select:hover{
+      border: 1px solid var(--grey-300);
+      transition: all 400ms;
+      box-shadow: 0 5px 5px 2px hsl(0deg 0% 97%);
+  }
+  select:focus {
+      outline: none;
+  }
 </style>

--- a/sites/example-project/src/components/ui/Formatting/CurrencyFormatGrid.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CurrencyFormatGrid.svelte
@@ -1,10 +1,10 @@
 <script>
   import "./format-grid.css";
-  import { blur } from 'svelte/transition';
+  import { blur, slide } from 'svelte/transition';
   import { SUPPORTED_CURRENCIES } from "$lib/modules/builtInFormats";
   import { defaultExample, formatExample } from "$lib/modules/formatting";
   export let formats;
-  let selectedCurrency;
+  let selectedCurrency = 'Choose a currency';
 </script>
 
 <select bind:value={selectedCurrency}>
@@ -14,30 +14,32 @@
   {/each}
 </select>
 {#if selectedCurrency != 'Choose a currency'}
-<table transition:blur>
-  <thead>
-    <th class="align_left narrow_column">Format Tag</th>
-    <th class="align_left wide_column">Format Code</th>
-    <th class="align_left wide_column">Example Input</th>
-    <th class="align_right wide_column">Example Output</th>
-  </thead>
-  {#each formats.filter(d => d.parentFormat === selectedCurrency) as format}
-    <tr transition:blur>
-      <td transition:blur>{format.formatTag} </td>
-      <td transition:blur>{format.formatCode} </td>
-      <td transition:blur>
-        <input
-          id="id_format_row{format.formatTag}"
-          placeholder={format.exampleInput || defaultExample(format.valueType)}
-          bind:value={format.userInput}
-          on:blur={(format.userInput = undefined)}
-          class="align_left input_box"
-        />
-      </td>
-      <td class="align_right" transition:blur>{formatExample(format)}</td>
-    </tr>
-  {/each}
-</table>
+<div transition:slide>
+  <table>
+    <thead>
+      <th class="align_left narrow_column">Format Tag</th>
+      <th class="align_left wide_column">Format Code</th>
+      <th class="align_left wide_column">Example Input</th>
+      <th class="align_right wide_column">Example Output</th>
+    </thead>
+    {#each formats.filter(d => d.parentFormat === selectedCurrency) as format (format.formatTag)}
+      <tr>
+        <td in:blur|local>{format.formatTag} </td>
+        <td in:blur|local>{format.formatCode} </td>
+        <td>
+          <input
+            id="id_format_row{format.formatTag}"
+            placeholder={format.exampleInput || defaultExample(format.valueType)}
+            bind:value={format.userInput}
+            on:blur={(format.userInput = undefined)}
+            class="align_left input_box"
+          />
+        </td>
+        <td class="align_right" in:blur|local >{formatExample(format)}</td>
+      </tr>
+    {/each}
+  </table>
+</div>
 {/if}
 
 <style>

--- a/sites/example-project/src/components/ui/Formatting/CustomFormatGrid.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CustomFormatGrid.svelte
@@ -6,21 +6,18 @@
   export let deleteHandler;
 </script>
 
-<div class="tableContainer">
-<table width="100%" class=formatTable>
+<table>
   <thead>
     <th class="align_left narrow_column">Format Tag</th>
-    <th class="align_left medium_column">Format Code</th>
-    <th class="align_left narrow_column">Type</th>
-    <th class="align_left medium_column">Example Input</th>
-    <th class="align_right medium_column">Example Output</th>
+    <th class="align_left wide_column">Format Code</th>
+    <th class="align_left wide_column">Example Input</th>
+    <th class="align_right wide_column">Example Output</th>
     <th><!--actions --></th>
   </thead>
   {#each formats as format}
     <tr>
       <td>{format.formatTag} </td>
       <td>{format.formatCode} </td>
-      <td>{format.valueType}</td>
       <td>
         <input
           id="id_format_row{format.formatTag}"
@@ -37,7 +34,6 @@
     </tr>
   {/each}
 </table>
-</div>
 
 <style>
   .deleteIcon {

--- a/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
@@ -92,7 +92,7 @@
 </script>
 
   {#if customFormattingSettings.customFormats && customFormattingSettings.customFormats.length > 0}
-  <CollapsibleTableSection headerText={"Saved Custom Formats"} expanded={true}>
+  <CollapsibleTableSection headerText={"Saved Custom Formats"} expanded={false}>
     <CustomFormatGrid
       formats={customFormattingSettings.customFormats}
       deleteHandler={deleteCustomFormat}

--- a/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
@@ -1,5 +1,6 @@
 <script>
   import CustomFormatGrid from "./CustomFormatGrid.svelte";
+  import CollapsibleTableSection from "./CollapsibleTableSection.svelte";
   import ssf from "ssf";
   export let builtInFormats = {};
   export let customFormattingSettings = {};
@@ -9,7 +10,6 @@
   let formatTag;
   let formatCode;
   let valueType;
-  let editingCustomFormat = false;
   let newFormatValidationErrors = "";
 
   async function deleteCustomFormat(format) {
@@ -49,21 +49,15 @@
   function resetNewCustomFormat() {
     formatTag = undefined;
     formatCode = undefined;
-    valueType = undefined;
+    valueType = 'number';
     newFormatValidationErrors = "";
-    editingCustomFormat = false;
-  }
-
-  function showAddCustomFormat() {
-    resetNewCustomFormat();
-    editingCustomFormat = true;
   }
 
   function getValidationErrors() {
     let errors = [];
     if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(formatTag)) {
       errors.push(
-        `"${formatTag}" is invalid. The format tag should always start with a letter and only contain letters and numbers.`
+        `"${formatTag}" is not a valid format tag. The format tag should always start with a letter and only contain letters and numbers.`
       );
     }
     let testValue = 10;
@@ -97,73 +91,57 @@
   }
 </script>
 
-{#if customFormattingSettings.customFormats && customFormattingSettings.customFormats.length > 0}
-  <CustomFormatGrid
-    formats={customFormattingSettings.customFormats}
-    deleteHandler={deleteCustomFormat}
-  />
-{/if}
+  {#if customFormattingSettings.customFormats && customFormattingSettings.customFormats.length > 0}
+  <CollapsibleTableSection headerText={"Saved Custom Formats"} expanded={true}>
+    <CustomFormatGrid
+      formats={customFormattingSettings.customFormats}
+      deleteHandler={deleteCustomFormat}
+    />
+  </CollapsibleTableSection>
+  {/if}
 
-{#if editingCustomFormat}
-  <addNewFormatArea>
-    <div class="separator">Add a new custom format</div>
-
-    <form
-      on:submit|preventDefault={submitNewCustomFormat}
-      autocomplete="off"
-      class="addFormatForm"
-    >
-      <div class="input-item">
-        <label for="valueType">Value Type</label>
-        <select id="valueType" bind:value={valueType}>
-          {#each valueTypeOptions as option}
-            <option value={option}>
-              {option}
-            </option>
-          {/each}
-        </select>
-      </div>
-      <div class="input-item">
-        <label for="formatTag">Format Tag</label>
-        <input
-          id="formatTag"
-          type="text"
-          placeholder="myformat"
-          bind:value={formatTag}
-        />
-      </div>
-      <div class="input-item">
-        <label for="formatCode">Format Code</label>
-        <input
-          id="formatCode"
-          type="text"
-          placeholder={valueType === "date" ? "mm/dd/yyyy" : "$#,##0.0"}
-          bind:value={formatCode}
-        />
-      </div>
-      <div class="new-format-buttons">
-        <button
-          id="submitCustomFormatButton"
-          type="submit"
-          disabled={!(formatTag && formatCode)}>Add</button
-        >
-        <button id="resetNewCustomFormatButton" on:click={resetNewCustomFormat}
-          >Cancel</button
-        >
-      </div>
-      <div class="error">{@html newFormatValidationErrors}</div>
-    </form>
-  </addNewFormatArea>
-{:else}
-<div>
-  <button
-    id="showAddCustomFormatButton"
-    on:click={showAddCustomFormat}
-    disabled={editingCustomFormat}
-    >New Custom Format
-  </button>
-</div>
-{/if}
+  <form
+    on:submit|preventDefault={submitNewCustomFormat}
+    autocomplete="off"
+    class="addFormatForm"
+  >
+    <div class="input-item">
+      <label for="valueType">Value Type</label>
+      <select id="valueType" bind:value={valueType}>
+        {#each valueTypeOptions as option}
+          <option value={option}>
+            {option}
+          </option>
+        {/each}
+      </select>
+    </div>
+    <div class="input-item">
+      <label for="formatTag">Format Tag</label>
+      <input
+        id="formatTag"
+        type="text"
+        placeholder="myformat"
+        bind:value={formatTag}
+      />
+    </div>
+    <div class="input-item">
+      <label for="formatCode">Format Code</label>
+      <input
+        id="formatCode"
+        type="text"
+        placeholder={valueType === "date" ? "mm/dd/yyyy" : "$#,##0.0"}
+        bind:value={formatCode}
+      />
+    </div>
+    <div class="new-format-buttons">
+      <button
+        id="submitCustomFormatButton"
+        type="submit"
+        disabled={!(formatTag && formatCode)}>Add Custom Format</button
+      >
+    </div>
+    <div class="error">{@html newFormatValidationErrors}</div>
+  </form>
 
 <style>
   input {
@@ -190,7 +168,6 @@
     width: 35%;
     text-transform: uppercase;
     font-weight: normal;
-    font-size: 12px;
     color: var(--grey-800);
   }
   button {
@@ -252,7 +229,6 @@
     margin-block-start: 0.5em;
     color: var(--grey-600);
     font-weight: bold;
-    padding-left: 1em;
   }
   .separator::after {
     content: "";
@@ -266,33 +242,6 @@
   }
   .error {
     color: var(--red-600);
-  }
-
-  .addFormatForm {
-    padding: 0em 2em 0em 2em;
-  }
-
-  #showAddCustomFormatButton {
-    margin: 5px 0px 0px 0px;
-    background-color: var(--blue-600);
-    color:white;
-    font-weight: bold;
-    border-radius: 4px;
-    border: 1px solid var(--blue-700);
-    padding:0.4em 0.8em;
-    transition-property: background, color;
-    transition-duration: 350ms;
-  }
-
-  #showAddCustomFormatButton:active {
-    background-color: var(--blue-800);
-    color:white;
-    font-weight: bold;
-    border-radius: 4px;
-    border: 1px solid var(--blue-900);
-    padding:0.4em 0.8em;
-    transition-property: background, color;
-    transition-duration: 350ms;
   }
 
   #submitCustomFormatButton {
@@ -318,7 +267,7 @@
   }
 
   #submitCustomFormatButton:disabled,
-button[disabled]{
+  button[disabled]{
   border: 1px solid var(--grey-400);
   background-color: var(--grey-100);
   color: var(--grey-600);
@@ -326,29 +275,5 @@ button[disabled]{
   transition-property: background, color;
   transition-duration: 350ms;
 }
-
-
-  #resetNewCustomFormatButton {
-    background-color: var(--grey-500);
-    margin-right: 0;
-    color:white;
-    font-weight: bold;
-    border-radius: 4px;
-    border: 1px solid var(--grey-600);
-    padding:0.4em 1.10em;
-    transition-property: background, color;
-    transition-duration: 350ms;
-  }
-
-  #resetNewCustomFormatButton:active {
-    background-color: var(--grey-600);
-    color:white;
-    font-weight: bold;
-    border-radius: 4px;
-    border: 1px solid var(--grey-700);
-    padding:0.4em 1.10em;
-    transition-property: background, color;
-    transition-duration: 350ms;
-  }
 
 </style>

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -12,15 +12,13 @@
     <div class="panel">
       <h1>Value Formatting</h1>
       <p>Value formatting in Evidence is achieved using format tags appended to SQL column names.</p>
-
       <h2>Example</h2>
       <code class=sql-example>select date as month<span class=format-tag>_mmm</span>, sales as sales<span class=format-tag>_usd</span> from table  </code>  
       <p></p>
       <p>Choose from the built in format tags below, or create a custom format tag.</p>
-
     </div>
     <div class="panel">
-      <h2>Built in Formats</h2>
+      <h1>Built in Format Tags</h1>
       <CollapsibleTableSection headerText={"Dates"} expanded={true}>
         <BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "date")}/>
       </CollapsibleTableSection>
@@ -35,16 +33,16 @@
       </CollapsibleTableSection>
     </div>
     <div class="panel">
-      <CollapsibleTableSection headerText={"Custom Formats"} expanded={true}>
-        Custom formats can be used in the same way as built-in formats, using  <a class=docs-link target=none href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68">excel-style format codes.</a> Format tags do not appear in column titles when used in charts or other components.  
-        <svelte:component
-          this={CustomFormatsSection}
+      <h1>Custom Format Tags</h1>
+      <p>
+        Add new format tags to your project. Custom format tags use <a class=docs-link target=none href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68">excel-style format codes.</a>
+      </p>
+        <CustomFormatsSection
           builtInFormats={BUILT_IN_FORMATS}
           {customFormattingSettings}
         />
-      </CollapsibleTableSection>
       </div>
-  </div>
+      </div>
   <footer>
     <span
       >Learn more about <a
@@ -110,10 +108,5 @@
         color: var(--blue-800);
     }
 
-  h2 {
-    text-transform: uppercase;
-    font-weight: normal;
-    font-size: 14px;
-  }
 
 </style>

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -11,7 +11,7 @@
   <div class="container">
     <div class="panel">
       <h1>Value Formatting</h1>
-      <p>Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted in Evidence.</p><p>Format tags are appended to the end of column names, per the example below.</p> 
+      <p>Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted in Evidence.</p><p>Apply format tags by including them at the end of column names. For example:</p> 
       <pre>
 select 
   growth as growth<span class=format-tag>_pct</span>, -- formatted as a percentage
@@ -19,11 +19,11 @@ select
 from table 
       </pre>
       <p></p>
-      <p>All of the built in format tags are listed below for reference, and you can create your own custom format tags for your project.</p>
     </div>
     <div class="panel">
       <h1>Built in Format Tags</h1>
-      <CollapsibleTableSection headerText={"Dates"} expanded={true}>
+      <p>All of the built in format tags are listed below for reference.</p>
+      <CollapsibleTableSection headerText={"Dates"} expanded={false}>
         <BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "date")}/>
       </CollapsibleTableSection>
       <CollapsibleTableSection headerText={"Currencies"} expanded={false}>

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -16,15 +16,15 @@
       <h2>Example</h2>
       <code class=sql-example>select date as month<span class=format-tag>_mmm</span>, sales as sales<span class=format-tag>_usd</span> from table  </code>  
       <p></p>
-      <p>Choose from the list of available format tags below, or create a custom format tag using Excel-style format codes. <a class=docs-link target=none href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68">Learn about Excel format codes here &rarr;</a></p>
+      <p>Choose from the built in format tags below, or create a custom format tag.</p>
 
     </div>
-    <div class="subpanels">
+    <div class="panel">
+      <h2>Built in Formats</h2>
       <CollapsibleTableSection headerText={"Dates"} expanded={true}>
         <BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "date")}/>
       </CollapsibleTableSection>
       <CollapsibleTableSection headerText={"Currencies"} expanded={false}>
-        Evidence supports several international currencies. Select a currency from the drop-down below to see the available format tags.
         <CurrencyFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "currency")} />
       </CollapsibleTableSection>
       <CollapsibleTableSection headerText={"Numbers"} expanded={false}>
@@ -33,11 +33,10 @@
       <CollapsibleTableSection headerText={"Percentages"} expanded={false}>
         <BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "percent")} />
       </CollapsibleTableSection>
-      
     </div>
     <div class="panel">
       <CollapsibleTableSection headerText={"Custom Formats"} expanded={true}>
-        Custom formats can be used in the same way as built-in formats. Note that your format tag will not appear in the column title when used in a component.  
+        Custom formats can be used in the same way as built-in formats, using  <a class=docs-link target=none href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68">excel-style format codes.</a> Format tags do not appear in column titles when used in charts or other components.  
         <svelte:component
           this={CustomFormatsSection}
           builtInFormats={BUILT_IN_FORMATS}
@@ -71,11 +70,6 @@
   .panel {
     border-top: 1px solid var(--grey-200);
     padding: 1em;
-  }
-
-  .subpanels {
-    border-top: 1px solid var(--grey-200);
-    padding: 1em 1em 1em 1em;
   }
 
   .panel:first-of-type {
@@ -115,5 +109,11 @@
     .docs-link:hover {
         color: var(--blue-800);
     }
+
+  h2 {
+    text-transform: uppercase;
+    font-weight: normal;
+    font-size: 14px;
+  }
 
 </style>

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -11,11 +11,15 @@
   <div class="container">
     <div class="panel">
       <h1>Value Formatting</h1>
-      <p>Value formatting in Evidence is achieved using format tags appended to SQL column names.</p>
-      <h2>Example</h2>
-      <code class=sql-example>select date as month<span class=format-tag>_mmm</span>, sales as sales<span class=format-tag>_usd</span> from table  </code>  
+      <p>Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted in Evidence.</p><p>Format tags are appended to the end of column names, per the example below.</p> 
+      <pre>
+select 
+  growth as growth<span class=format-tag>_pct</span>, -- formatted as a percentage
+  sales as sales<span class=format-tag>_usd</span>    -- formatted as US dollars
+from table 
+      </pre>
       <p></p>
-      <p>Choose from the built in format tags below, or create a custom format tag.</p>
+      <p>All of the built in format tags are listed below for reference, and you can create your own custom format tags for your project.</p>
     </div>
     <div class="panel">
       <h1>Built in Format Tags</h1>
@@ -74,8 +78,12 @@
     border-top: none;
   }
 
-  .sql-example {
-    font-size: 11pt;
+  pre {
+    background-color: var(--blue-999);
+    color: var(--grey-100);
+    font-size: 10pt;
+    border-radius: 4px;
+    padding: 0.5em;
   }
 
   /* .format-tag {
@@ -85,8 +93,7 @@
   } */
 
   .format-tag {
-    color: var(--blue-600);
-    font-weight: 800;
+    color: var(--blue-300);
   }
   footer {
     border: 1px solid var(--grey-200);

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -5,6 +5,14 @@
   import CustomFormatsSection from "./CustomFormatsSection.svelte";
   import CollapsibleTableSection from "./CollapsibleTableSection.svelte";
   import CurrencyFormatGrid from "./CurrencyFormatGrid.svelte";
+  import Prism from "../QueryViewerSupport/Prismjs.svelte";
+
+  let exampleQuery = `
+select 
+  growth as growth_pct, -- formatted as a percentage
+  sales as sales_usd    -- formatted as US dollars
+from table` 
+
 </script>
 
 <form>
@@ -12,12 +20,9 @@
     <div class="panel">
       <h1>Value Formatting</h1>
       <p>Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted in Evidence.</p><p>Apply format tags by including them at the end of column names. For example:</p> 
-      <pre>
-select 
-  growth as growth<span class=format-tag>_pct</span>, -- formatted as a percentage
-  sales as sales<span class=format-tag>_usd</span>    -- formatted as US dollars
-from table 
-      </pre>
+      <div class=code-container>
+        <Prism language="sql" code={exampleQuery}/>
+      </div>
       <p></p>
     </div>
     <div class="panel">
@@ -78,12 +83,11 @@ from table
     border-top: none;
   }
 
-  pre {
-    background-color: var(--blue-999);
-    color: var(--grey-100);
-    font-size: 10pt;
+  div.code-container {
+    background-color: var(--grey-100);
+    border: 1px solid var(--grey-200);
+    overflow: auto;
     border-radius: 4px;
-    padding: 0.5em;
   }
 
   /* .format-tag {
@@ -92,9 +96,6 @@ from table
     padding: 2px 4px 2px 4px;
   } */
 
-  .format-tag {
-    color: var(--blue-300);
-  }
   footer {
     border: 1px solid var(--grey-200);
     border-radius: 0 0 5px 5px;

--- a/sites/example-project/src/components/ui/Formatting/format-grid.css
+++ b/sites/example-project/src/components/ui/Formatting/format-grid.css
@@ -1,8 +1,10 @@
 table {
-  width: 100%;
-  font-size: calc(0.75em - 0px);
+  font-size: 14px;
   border-collapse: collapse;
   font-family: sans-serif;
+  /* Offset the cell padding to get the outside edges aligned w/ the parent */
+  margin-left: -8px;
+  width: calc(100% + 16px);
 }
 th {
   max-width: 1px;
@@ -16,9 +18,9 @@ td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-tr:hover {
+/* tr:hover {
   background-color: rgb(247, 249, 250);
-}
+} */
 .align_left {
   text-align: left;
 }

--- a/sites/example-project/src/components/ui/QueryViewerSupport/prismtheme.css
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/prismtheme.css
@@ -96,7 +96,7 @@ pre[class*="language-"] {
 }
 
 .token.comment {
-	color: #aabfc9;
+	color: var(--blue-700);
 }
 
 .token.constant {

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -31,7 +31,7 @@
   import DatabaseSettingsPanel from "@evidence-dev/components/ui/Databases/DatabaseSettingsPanel.svelte";
   import VersionControlPanel from "@evidence-dev/components/ui/VersionControl/VersionControlPanel.svelte";
   import DeploySettingsPanel from "@evidence-dev/components/ui/Deployment/DeploySettingsPanel.svelte";
-  import FormattingSettingsPanel from "@evidence-dev/components/ui/Formatting/FormattingSettingsPanel.svelte";
+  import FormattingSettingsPanel from "$lib/ui/Formatting/FormattingSettingsPanel.svelte";
   import TelemetrySettingsPanel from "@evidence-dev/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte";
 </script>
 

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -39,8 +39,8 @@
   <DatabaseSettingsPanel {settings} {gitIgnore} />
   <VersionControlPanel {settings} />
   <DeploySettingsPanel {settings} />
-  <TelemetrySettingsPanel {settings} />
   <FormattingSettingsPanel {settings} {customFormattingSettings} />
+  <TelemetrySettingsPanel {settings} />
   <br />
 {:else}
   <p>Settings are only available in development mode.</p>

--- a/sites/example-project/src/pages/settings/index.svelte
+++ b/sites/example-project/src/pages/settings/index.svelte
@@ -31,7 +31,7 @@
   import DatabaseSettingsPanel from "@evidence-dev/components/ui/Databases/DatabaseSettingsPanel.svelte";
   import VersionControlPanel from "@evidence-dev/components/ui/VersionControl/VersionControlPanel.svelte";
   import DeploySettingsPanel from "@evidence-dev/components/ui/Deployment/DeploySettingsPanel.svelte";
-  import FormattingSettingsPanel from "$lib/ui/Formatting/FormattingSettingsPanel.svelte";
+  import FormattingSettingsPanel from "@evidence-dev/components/ui/Formatting/FormattingSettingsPanel.svelte";
   import TelemetrySettingsPanel from "@evidence-dev/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte";
 </script>
 


### PR DESCRIPTION
Some further refinements on the styling and copy in the formats section of the settings. 

- Data tables aligned to header, increased size, removed border box 
- More obvious interaction and working transitions in the currencies section 
- Cleaned up description + example 
- Remove layers on the custom formats section. Form is visible from the beginning, only one action. 
- Collapsible section in the custom formats area serves the same purpose as collapsible sections above it. 
- Collapse all sections to ensure that the custom formats input is visible from the docs section at the top.

**After** 
![CleanShot 2022-08-04 at 11 19 44](https://user-images.githubusercontent.com/6857673/182885091-4d9e8c8a-b31e-45d9-a1d0-486a0880bcba.gif)
