### PR TITLE
revert smart quotes

### DIFF
--- a/.changeset/clean-seals-dance.md
+++ b/.changeset/clean-seals-dance.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/preprocess": patch
+---
+
+Resolves a bug introduced by smart quotes

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -257,7 +257,7 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false){
         mdsvex.mdsvex(
             {extensions: [".md"],
             smartypants: {
-                quotes: true,
+                quotes: false,
                 ellipses: true,
                 backticks: true,
                 dashes: 'oldschool',


### PR DESCRIPTION
reverts the change in #346, to prevent MDSVEX from introducing errors when users include a string in svelte template syntax. e.g. `{"this should render"}`