### PR TITLE
Postgres Connector Case Normalization Fix

### DIFF
--- a/.changeset/popular-bats-tell.md
+++ b/.changeset/popular-bats-tell.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/postgres": patch
+---
+
+Fix postgres connector to handle cases consistently between query object and types object

--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -61,7 +61,7 @@ const mapResultsToEvidenceColumnTypes = function (results) {
         }
         return (
           {
-            'name': field.name,
+            'name': field.name.toLowerCase(),
             'evidenceType': evidenceType,
             'typeFidelity': typeFidelity,
           });

--- a/sites/example-project/src/components/modules/getColumnEvidenceType.js
+++ b/sites/example-project/src/components/modules/getColumnEvidenceType.js
@@ -10,11 +10,11 @@ export default function getColumnEvidenceType(data, column) {
     }
     if (item && item['_evidenceColumnTypes']) {
       let columnTypes = item['_evidenceColumnTypes'];
-      return columnTypes.find(item => item.name === column);
+      return columnTypes.find(item => item.name?.toLowerCase() === column?.toLowerCase());
     } else {
       // infer types as a fall-back (when someone is passing arbitrary data objects)
       let columnTypes = inferColumnTypes(data);
-      return columnTypes.find(item => item.name === column);
+      return columnTypes.find(item => item.name?.toLowerCase() === column?.toLowerCase());
     }
   }
 


### PR DESCRIPTION
## Context:
- User reported difficult connecting to Cube.js via their [Postgres SQL API](https://cube.dev/docs/backend/sql)
- Cube.js compiles queries, and then passes the results back to the query engine.
- Cube.js by default uses camel case for the names of the fields that are passed back

## Problem
- The postgres connector lowercases all of the field names: `myColumn` -> `mycolumn`
- But the `evidenceType` column name is not lowercased
- This means that if when Evidence looks for the type of `mycolumn` it cannot find it.

Result:
![image](https://user-images.githubusercontent.com/58074498/183506174-060eb991-7ffb-4a0c-94b7-46079f74501c.png)

## Proposed fix
- Lowercase the field name for the column types object also