### PR TITLE
Add reactivity to charts

### DIFF
--- a/sites/example-project/src/components/modules/echarts.js
+++ b/sites/example-project/src/components/modules/echarts.js
@@ -3,7 +3,6 @@ import {colours} from './colours'
 
 
 export default(node, option, renderer) => {
-
 	echarts.registerTheme('evidence-light', {
         "grid": {
             "left": "0%",
@@ -443,9 +442,9 @@ export default(node, option, renderer) => {
     window.addEventListener("resize", () => { chart.resize();});
 
 	return {
-		// update(option){
-		// 	chart.update(option, true, true);
-		// },
+		update(option){
+			chart.setOption(option, true, true);
+		},
 		destroy() {
 			chart.dispose();
 		}

--- a/sites/example-project/src/components/viz/Area.svelte
+++ b/sites/example-project/src/components/viz/Area.svelte
@@ -17,22 +17,22 @@
     export let fillColor = undefined;
     export let fillOpacity = undefined;
     export let line = true;
-    line = (line === "true" || line === true);
+    $: line = (line === "true" || line === true);
 
     export let handleMissing = "gap";
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    let x = $props.x;
-    let swapXY = $props.swapXY;
-    let xType = $props.xType;
-    let xMismatch = $props.xMismatch;
-    let columnSummary = $props.columnSummary;
-    y = y ?? $props.y;
-    series = series ?? $props.series;
+    $: data = $props.data;
+    $: x = $props.x;
+    $: swapXY = $props.swapXY;
+    $: xType = $props.xType;
+    $: xMismatch = $props.xMismatch;
+    $: columnSummary = $props.columnSummary;
+    $: y = y ?? $props.y;
+    $: series = series ?? $props.series;
 
     let stackName;
-    if(!series && typeof y !== 'object'){
+    $: if(!series && typeof y !== 'object'){
         // Single Series
         name = name ?? formatTitle(y, columnSummary[y].title);
     } else {
@@ -43,11 +43,11 @@
         xType = xType === "value" ? "category" : xType;
     }
 
-    if(handleMissing === "zero"){
+    $: if(handleMissing === "zero"){
         data = replaceNulls(data, y)
     }
 
-    let baseConfig = {
+    $: baseConfig = {
             type: "line",
             stack: stackName,
             areaStyle: {
@@ -67,16 +67,16 @@
             }
     }
 
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
+    $: seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
     
-    config.update(d => {d.series.push(...seriesConfig); return d})
+    $: config.update(d => {d.series.push(...seriesConfig); return d})
 
-    if(options){
+    $: if(options){
         config.update(d => {return {...d, ...options}})
     }
 
 
-    let chartOverrides = {
+    $: chartOverrides = {
          yAxis: { 
              boundaryGap: ['0%', '1%'],
          },
@@ -86,7 +86,7 @@
          },
      }
 
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
             d.tooltip = {...d.tooltip, order: 'seriesDesc'} // Areas always stacked 
             if(swapXY){

--- a/sites/example-project/src/components/viz/AreaChart.svelte
+++ b/sites/example-project/src/components/viz/AreaChart.svelte
@@ -28,9 +28,6 @@
     export let handleMissing = undefined;
 
     export let sort = undefined;
-
-    let chartType = "Area Chart";
-
 </script>
 
 <Chart
@@ -51,7 +48,7 @@
     {yMin}
     {title}
     {subtitle}
-    {chartType}
+    chartType="Area Chart"
     {sort}
     >
     <Area

--- a/sites/example-project/src/components/viz/Bar.svelte
+++ b/sites/example-project/src/components/viz/Bar.svelte
@@ -1,8 +1,8 @@
 <script>
     import {getContext} from 'svelte'
     import { propKey, configKey } from './context'
-    let props = getContext(propKey)
-    let config = getContext(configKey)
+    $: props = getContext(propKey)
+    $: config = getContext(configKey)
     
     import getSeriesConfig from '$lib/modules/getSeriesConfig.js';
     import getStackedData from '$lib/modules/getStackedData.js';
@@ -25,20 +25,20 @@
     let barMaxWidth;
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    let x = $props.x;
-    let swapXY = $props.swapXY;
-    let xType = $props.xType;
-    let xMismatch = $props.xMismatch;
-    let columnSummary = $props.columnSummary;
-    let sort = $props.sort;
-    y = y ?? $props.y;
-    series = series ?? $props.series;
+    $: data = $props.data;
+    $: x = $props.x;
+    $: swapXY = $props.swapXY;
+    $: xType = $props.xType;
+    $: xMismatch = $props.xMismatch;
+    $: columnSummary = $props.columnSummary;
+    $: sort = $props.sort;
+    $: { y = y ?? $props.y;}
+    $: { series = series ?? $props.series;}
 
     let stackedData;
     let sortOrder;
 
-    if(!series && typeof y !== 'object'){
+    $: if(!series && typeof y !== 'object'){
         // Single Series
         name = name ?? formatTitle(y, columnSummary[y].title);
 
@@ -78,9 +78,9 @@
         }
     }
 
-    barMaxWidth = 60;
+    $: {barMaxWidth = 60;}
 
-    let baseConfig = {
+    $: baseConfig = {
             type: "bar",
             stack: stackName,
             label: {
@@ -99,15 +99,15 @@
             }
     }
  
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
+    $: seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
     
-    config.update(d => {d.series.push(...seriesConfig); return d})
+    $: config.update(d => {d.series.push(...seriesConfig); return d})
 
-    if(options){
+    $: if(options){
         config.update(d => {return {...d, ...options}})
     }
 
-    let chartOverrides = {
+    $: chartOverrides = {
          // Evidence definition of axes (yAxis = dependent, xAxis = independent)
          xAxis: {
              boundaryGap: ['1%', '2%'],
@@ -115,7 +115,7 @@
          }
     }
 
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
             if(type === "stacked"){
                 d.tooltip = {...d.tooltip, order: 'seriesDesc'} 

--- a/sites/example-project/src/components/viz/BarChart.svelte
+++ b/sites/example-project/src/components/viz/BarChart.svelte
@@ -21,10 +21,12 @@
     export let yTickMarks = undefined;
     export let yMin = undefined;
     export let swapXY = false;
-    if(swapXY === "true" || swapXY === true){
-        swapXY = true;
-    } else {
-        swapXY = false;
+    $: {
+        if(swapXY === "true" || swapXY === true) {
+            swapXY = true;
+        } else {
+            swapXY = false;
+        }
     }
 
     export let type = undefined; // stacked or grouped
@@ -35,9 +37,6 @@
     export let outlineWidth = undefined;
 
     export let sort = undefined;
-
-    let chartType = "Bar Chart";
-
 </script>
 
 <Chart
@@ -59,7 +58,7 @@
     {swapXY}
     {title}
     {subtitle}
-    {chartType}
+    chartType="Bar Chart"
     {sort}
     >
     <Bar

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -24,28 +24,28 @@
 
     let maxSize = 35;
     export let scaleTo = 1;
-    maxSize = maxSize * (scaleTo / 1);
+    $: maxSize = maxSize * (scaleTo / 1);
 
     export let useTooltip = false;
     let multiSeries;
     let tooltipOutput;
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    let x = $props.x;
-    let swapXY = $props.swapXY;
-    let xType = $props.xType;
-    let xFormat = $props.xFormat;
-    let yFormat = $props.yFormat;
-    let sizeFormat = $props.sizeFormat;
-    let xMismatch = $props.xMismatch;
-    let columnSummary = $props.columnSummary;
-    y = y ?? $props.y;
-    series = series ?? $props.series;
-    size = size ?? $props.size;
-    let yMin = $props.yMin;
+    $: data = $props.data;
+    $: x = $props.x;
+    $: swapXY = $props.swapXY;
+    $: xType = $props.xType;
+    $: xFormat = $props.xFormat;
+    $: yFormat = $props.yFormat;
+    $: sizeFormat = $props.sizeFormat;
+    $: xMismatch = $props.xMismatch;
+    $: columnSummary = $props.columnSummary;
+    $: y = y ?? $props.y;
+    $: series = series ?? $props.series;
+    $: size = size ?? $props.size;
+    $: yMin = $props.yMin;
 
-    if(!series && typeof y !== 'object'){
+    $: if(!series && typeof y !== 'object'){
         // Single Series
         name = name ?? formatTitle(y, columnSummary[y].title);
         multiSeries = false;
@@ -56,9 +56,9 @@
     }
 
     // Determine bubble sizes:
-    let sizeExtents = getColumnExtentsLegacy(data, size);
-    let maxData = sizeExtents[1];
-    let maxSizeSq = Math.pow(maxSize, 2);
+    $: sizeExtents = getColumnExtentsLegacy(data, size);
+    $: maxData = sizeExtents[1];
+    $: maxSizeSq = Math.pow(maxSize, 2);
 
     // Maximum point in dataset is assigned the maximum point area on the graph. Other
     // points are assigned based on their proportion to the maximum point. 
@@ -70,7 +70,7 @@
         return Math.sqrt((newPointSize / maxData) * maxSizeSq)
     }
 
-    let baseConfig = {
+    $: baseConfig = {
             type: "scatter",
             label: {
                 show: false,
@@ -95,7 +95,7 @@
 
     let tooltipOpts;
     let tooltipOverride;
-    if(useTooltip){
+    $: if(useTooltip){
         tooltipOpts = {
             tooltip: {
                 formatter: function(params) {
@@ -124,16 +124,16 @@
     }
 
     // If user has passed in custom echarts config options, append to the baseConfig:
-    if(options){
+    $: if(options){
         baseConfig = {...baseConfig, ...options}
     }
 
     // Generate config for each series:
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary, size);
-    config.update(d => {d.series.push(...seriesConfig); return d})
+    $: seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary, size);
+    $: config.update(d => {d.series.push(...seriesConfig); return d})
 
     // Overriding global chart config:
-    let chartOverrides = {
+    $: chartOverrides = {
         yAxis: {
             scale: true,
             boundaryGap: ['1%', '1%']
@@ -143,7 +143,7 @@
         }
     }
 
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
             if(swapXY){
                 d.yAxis = {...d.yAxis, ...chartOverrides.xAxis};

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -30,12 +30,6 @@
     export let scaleTo = undefined;
 
     export let sort = undefined;
-
-    let chartType = "Bubble Chart";
-    let bubble = true;
-
-    let useTooltip = true;
-
 </script>
 
 <Chart
@@ -57,8 +51,8 @@
     {yMin}
     {title}
     {subtitle}
-    {chartType}
-    {bubble}
+    chartType="Bubble Chart"
+    bubble=true
     {sort}
     >
     <Bubble
@@ -68,6 +62,6 @@
         {outlineColor}
         {outlineWidth}
         {scaleTo}
-        {useTooltip}
+        useTooltip=true
     />
 </Chart>

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -36,47 +36,49 @@
       dataPage = updatedSlice;
     }
 
-    try{
+    $: {
+      try{
+        error = undefined;
       // 2 - Check Inputs
-      try {
-        if (queryID && data) {
-          throw Error('Only one of "queryID" or "data" attributes should be provided');
-        } else if (queryID) {
-          data = getContext(PAGE_QUERY_RESULTS).getData(queryID);
+        try {
+          if (queryID && data) {
+            throw Error('Only one of "queryID" or "data" attributes should be provided');
+          } else if (queryID) {
+            data = getContext(PAGE_QUERY_RESULTS).getData(queryID);
+          }
+          checkInputs(data);
+        } catch (err) {
+            throw err;
         }
-        checkInputs(data);
-      } catch (err) {
-          throw err;
-      }
 
-      // 3 - Get Column Summary
-      columnSummary = getColumnSummary(data, 'array');
+        // 3 - Get Column Summary
+        columnSummary = getColumnSummary(data, 'array');
 
-      // 4 - Process Data
-      // Filter for columns with type of "date"
-      let dateCols = columnSummary.filter(d => d.type === "date")
-      dateCols = dateCols.map(d => d.id);
+        // 4 - Process Data
+        // Filter for columns with type of "date"
+        let dateCols = columnSummary.filter(d => d.type === "date")
+        dateCols = dateCols.map(d => d.id);
 
-      if(dateCols.length > 0){
-        for(let i = 0; i < dateCols.length; i++){
-          data = getParsedDate(data, dateCols[i]);
+        if(dateCols.length > 0){
+          for(let i = 0; i < dateCols.length; i++){
+            data = getParsedDate(data, dateCols[i]);
+          }
         }
+
+        // Table input:
+        columnWidths = 98/(columnSummary.length+1)
+
+        // Slicer:
+        index = 0;
+        size = Number.parseInt(rows);
+        max = Math.max(data.length - size,0);
+        dataPage = data.slice(index, index+size);
+        updatedSlice = '';
+
+      } catch(e) {
+          error = e.message;
       }
-
-      // Table input:
-      columnWidths = 98/(columnSummary.length+1)
-
-      // Slicer:
-      index = 0;
-      size = Number.parseInt(rows);
-      max = Math.max(data.length - size,0);
-      dataPage = data.slice(index, index+size);
-      updatedSlice = '';
-
-    } catch(e) {
-        error = e.message;
     }
-
 </script>
 
 {#if !error}

--- a/sites/example-project/src/components/viz/Hist.svelte
+++ b/sites/example-project/src/components/viz/Hist.svelte
@@ -14,19 +14,19 @@
     export let fillOpacity = 1;
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    x = x ?? $props.x;
-    let xFormat = $props.xFormat;
-    let yFormat = $props.yFormat;
+    $: data = $props.data;
+    $: x = x ?? $props.x;
+    $: xFormat = $props.xFormat;
+    $: yFormat = $props.yFormat;
 
     // Determine right method to use based on distinct x values (echarts-stat limitation causes some errors otherwise)
     let method;
-    let xDistinct = getDistinctValues(data, x).filter(function(x){
+    $: xDistinct = getDistinctValues(data, x).filter(function(x){
         return x != null;
     });
-    let xMax = Math.max(...xDistinct);
+    $: xMax = Math.max(...xDistinct);
 
-    if(xDistinct.length <= 1){
+    $: if(xDistinct.length <= 1){
         method = 'squareRoot'
     } else if(xMax < 10){
         method = 'freedmanDiaconis'
@@ -37,19 +37,19 @@
     }
 
     // Filter dataset to only x column and create bins
-    data = data.map((d) => d[x])
+    $: data = data.map((d) => d[x])
 
     // Run ECharts histogram function
-    let histData = ecStat.histogram(data, method);
+    $: histData = ecStat.histogram(data, method);
 
     // Remove empty first bin if it would cause negative values on x-axis:
-    let firstBinMin = histData.data[0][2]
-    let firstBinCount = histData.data[0][1]
-    if(firstBinMin < 0 && firstBinCount === 0){
+    $: firstBinMin = histData.data[0][2]
+    $: firstBinCount = histData.data[0][1]
+    $: if(firstBinMin < 0 && firstBinCount === 0){
         histData.data.shift()
     }
 
-    let seriesConfig = {
+    $: seriesConfig = {
         type: 'custom',
         label: {show: true},
         renderItem: function (params, api) {
@@ -89,9 +89,9 @@
         }
     }
 
-    config.update(d => {d.series.push(seriesConfig); return d})
+    $: config.update(d => {d.series.push(seriesConfig); return d})
 
-    let chartOverrides = {
+    $: chartOverrides = {
          yAxis: { // vertical axis
              boundaryGap: ['0%','1%'],
              axisLabel: {
@@ -108,7 +108,7 @@
          }
      }
 
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
                 d.yAxis = {...d.yAxis, ...chartOverrides.yAxis};
                 d.xAxis = {...d.xAxis, ...chartOverrides.xAxis}; 

--- a/sites/example-project/src/components/viz/Histogram.svelte
+++ b/sites/example-project/src/components/viz/Histogram.svelte
@@ -21,9 +21,6 @@
     export let fillColor = undefined;
     export let fillOpacity = undefined;
 
-    let chartType = "Histogram";
-    let hist = true;
-
 </script>
 
 <Chart 
@@ -41,8 +38,8 @@
     {yMin}
     {title}
     {subtitle}
-    {chartType}
-    {hist}
+    chartType="Histogram"
+    hist=true
     >
         <Hist
             {fillColor}

--- a/sites/example-project/src/components/viz/Line.svelte
+++ b/sites/example-project/src/components/viz/Line.svelte
@@ -20,23 +20,23 @@
     export let lineOpacity = undefined;
 
     export let markers = false;
-    markers = (markers === "true" || markers === true);
+    $: markers = (markers === "true" || markers === true);
     export let markerShape = 'circle';
     export let markerSize = 8;
 
     export let handleMissing = "gap";
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    let x = $props.x;
-    let swapXY = $props.swapXY;
-    let xType = $props.xType;
-    let xMismatch = $props.xMismatch;
-    let columnSummary = $props.columnSummary;
-    y = y ?? $props.y;
-    series = series ?? $props.series;
+    $: data = $props.data;
+    $: x = $props.x;
+    $: swapXY = $props.swapXY;
+    $: xType = $props.xType;
+    $: xMismatch = $props.xMismatch;
+    $: columnSummary = $props.columnSummary;
+    $: y = y ?? $props.y;
+    $: series = series ?? $props.series;
  
-    if(!series && typeof y !== 'object'){
+    $: if(!series && typeof y !== 'object'){
         // Single Series
         name = name ?? formatTitle(y, columnSummary[y].title);
     } else {
@@ -44,11 +44,11 @@
         data = getCompletedData(data, x, y, series);
     }
 
-    if(handleMissing === "zero"){
+    $: if(handleMissing === "zero"){
         data = replaceNulls(data, y)
     }
 
-    let baseConfig = {
+    $: baseConfig = {
             type: "line",
             label: {
                 show: false,
@@ -79,14 +79,14 @@
             symbolSize: markerSize
     }
 
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
-    config.update(d => {d.series.push(...seriesConfig); return d})
+    $: seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
+    $: config.update(d => {d.series.push(...seriesConfig); return d})
 
-    if(options){
+    $: if(options){
         config.update(d => {return {...d, ...options}})
     }
 
-    let chartOverrides = {
+    $: chartOverrides = {
          yAxis: {
              boundaryGap: ['0%', '1%']
          },
@@ -95,7 +95,7 @@
          }
      }
 
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
             if(swapXY){
                 d.yAxis = {...d.yAxis, ...chartOverrides.xAxis};

--- a/sites/example-project/src/components/viz/LineChart.svelte
+++ b/sites/example-project/src/components/viz/LineChart.svelte
@@ -33,9 +33,6 @@
     export let handleMissing = undefined;
 
     export let sort = undefined;
-
-    let chartType = "Line Chart";
-
 </script>
 
 <Chart
@@ -56,7 +53,7 @@
     {yMin}
     {title}
     {subtitle}
-    {chartType}
+    chartType="Line Chart"
     {sort}
     >
     <Line

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -26,19 +26,19 @@
     let tooltipOutput;
 
     // Prop check. If local props supplied, use those. Otherwise fall back to global props.
-    let data = $props.data;
-    let x = $props.x;
-    let swapXY = $props.swapXY;
-    let xType = $props.xType;
-    let xFormat = $props.xFormat;
-    let yFormat = $props.yFormat;
-    let xMismatch = $props.xMismatch;
-    let columnSummary = $props.columnSummary;
-    y = y ?? $props.y;
-    series = series ?? $props.series;
-    let yMin = $props.yMin;
+    $: data = $props.data;
+    $: x = $props.x;
+    $: swapXY = $props.swapXY;
+    $: xType = $props.xType;
+    $: xFormat = $props.xFormat;
+    $: yFormat = $props.yFormat;
+    $: xMismatch = $props.xMismatch;
+    $: columnSummary = $props.columnSummary;
+    $: y = y ?? $props.y;
+    $: series = series ?? $props.series;
+    $: yMin = $props.yMin;
 
-    if(!series && typeof y !== 'object'){
+    $: if(!series && typeof y !== 'object'){
         // Single Series
         name = name ?? formatTitle(y, columnSummary[y].title);
         multiSeries = false;
@@ -49,7 +49,7 @@
     }
 
     // Set up base config for this type of chart series:
-    let baseConfig = {
+    $: baseConfig = {
             type: "scatter",
             label: {
                 show: false,
@@ -72,7 +72,7 @@
     // Tooltip settings (scatter and bubble charts require different tooltip than default)
     let tooltipOpts;
     let tooltipOverride;
-    if(useTooltip){
+    $: if(useTooltip){
         tooltipOpts = {
             tooltip: {
                 formatter: function(params) {
@@ -99,18 +99,18 @@
     }
 
     // If user has passed in custom echarts config options, append to the baseConfig:
-    if(options){
+    $: if(options){
         baseConfig = {...baseConfig, ...options}
     }
 
 
     // Generate config for each series:
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
-    config.update(d => {d.series.push(...seriesConfig); return d})
+    $: seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
+    $: config.update(d => {d.series.push(...seriesConfig); return d})
 
     
     // Chart-level config settings:
-    let chartOverrides = {
+    $: chartOverrides = {
          yAxis: {
              scale: true,
              boundaryGap: ['1%', '1%']
@@ -121,7 +121,7 @@
     }
 
     // Apply the chart-level overrides to the main config used by Chart.svelte:
-    if(chartOverrides){
+    $: if(chartOverrides){
         config.update(d => {
             if(swapXY){
                 d.yAxis = {...d.yAxis, ...chartOverrides.xAxis};

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -29,11 +29,6 @@
     export let pointSize = undefined;
 
     export let sort = undefined;
-
-    let chartType = "Scatter Plot";
-
-    let useTooltip = true;
-
 </script>
 
 <Chart
@@ -54,7 +49,7 @@
     {yMin}
     {title}
     {subtitle}
-    {chartType}
+    chartType="Scatter Plot"
     {sort}
     >
     <Scatter
@@ -64,6 +59,6 @@
         {outlineColor}
         {outlineWidth}
         {pointSize}
-        {useTooltip}
+        useTooltip=true
     />
 </Chart>

--- a/sites/example-project/src/components/viz/Value.svelte
+++ b/sites/example-project/src/components/viz/Value.svelte
@@ -19,55 +19,56 @@
     let error;
 
     let columnSummary
-    try {
+    $: {
+        try {
+            error = undefined;
+            if(!placeholder){
+                if(data) {
 
-        if(!placeholder){
-            if(data) {
-
-                if(typeof data == 'string') {
-                    throw Error(`Received: data=${data}, expected: data={${data}}`)
-                }
-
-                if (!Array.isArray(data)){
-                    // Accept bare objects 
-                    data = [data]
-                }
-
-                if(isNaN(row)){
-                    throw Error("row must be a number (row="+row+")")
-                }
-
-                try{
-                    Object.keys(data[row])[0]
-                } catch(e) {
-                    throw Error("Row "+row+" does not exist in the dataset")
-                }
-
-                column = column ?? Object.keys(data[row])[0]
-
-                checkInputs(data, [column]);
-
-                columnSummary = getColumnSummary(data, 'array');
-                let dateCols = columnSummary.filter(d => d.type === "date")
-                dateCols = dateCols.map(d => d.id);
-                if(dateCols.length > 0){
-                    for(let i = 0; i < dateCols.length; i++){
-                    data = getParsedDate(data, dateCols[i]);
+                    if(typeof data == 'string') {
+                        throw Error(`Received: data=${data}, expected: data={${data}}`)
                     }
+
+                    if (!Array.isArray(data)){
+                        // Accept bare objects 
+                        data = [data]
+                    }
+
+                    if(isNaN(row)){
+                        throw Error("row must be a number (row="+row+")")
+                    }
+
+                    try{
+                        Object.keys(data[row])[0]
+                    } catch(e) {
+                        throw Error("Row "+row+" does not exist in the dataset")
+                    }
+
+                    column = column ?? Object.keys(data[row])[0]
+
+                    checkInputs(data, [column]);
+
+                    columnSummary = getColumnSummary(data, 'array');
+                    let dateCols = columnSummary.filter(d => d.type === "date")
+                    dateCols = dateCols.map(d => d.id);
+                    if(dateCols.length > 0){
+                        for(let i = 0; i < dateCols.length; i++){
+                        data = getParsedDate(data, dateCols[i]);
+                        }
+                    }
+
+                    value = data[row][column]
+                    columnSummary = columnSummary.filter(d => d.id === column);
+                    fmt = columnSummary[0].format;
+
+                } else {
+                    throw Error("No data provided. If you referenced a query result, check that the name is correct.")
                 }
-
-                value = data[row][column]
-                columnSummary = columnSummary.filter(d => d.id === column);
-                fmt = columnSummary[0].format;
-
-            } else {
-                throw Error("No data provided. If you referenced a query result, check that the name is correct.")
             }
+        } catch(e) {  
+            error = e.message;
         }
-} catch(e) {  
-    error = e.message;
-}
-
+    }
 </script>
 
 {#if placeholder}

--- a/sites/example-project/src/pages/test-analysis.md
+++ b/sites/example-project/src/pages/test-analysis.md
@@ -164,7 +164,7 @@ order by banks desc
 <!-- <DataTable data={data.banks}/> -->
 
 ```dates
-select date_trunc(established_date, year) as established_date, count(*) as banks 
+select date_trunc(established_date, year) as established_date, count(*)  as banks 
 from `bigquery-public-data.fdic_banks.institutions`
 group by established_date
 order by established_date asc


### PR DESCRIPTION
Adds reactivity to charts using `$`:
https://svelte.dev/tutorial/reactive-declarations
https://svelte.dev/tutorial/reactive-statements
https://svelte.dev/tutorial/reactive-assignments

Tested manually by going through example project pages and changing queries. 