### PR TITLE
Fix tooltip column title formatting issue

### DIFF
--- a/.changeset/purple-cougars-sip.md
+++ b/.changeset/purple-cougars-sip.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix for tooltip column name formatting

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -130,7 +130,9 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
             }
         }
 
-        tempConfig = generateTempConfig(seriesData, seriesName=name, baseConfig);
+        seriesName = columnSummary[y].title;
+
+        tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
         seriesConfig.push(tempConfig);
     }
 


### PR DESCRIPTION
In `getSeriesConfig`, there was a scenario where we were passing echarts an unformatted column title - it only showed up in single series charts. This PR passes a formatted title instead, solving the tooltip formatting issue.

Closes #385 