### PR TITLE
Scatter and bubble chart tooltip enhancement

### DIFF
--- a/.changeset/thick-items-turn.md
+++ b/.changeset/thick-items-turn.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Enhances scatter and bubble tooltips by letting you add a title for each point

--- a/sites/docs/docs/features/charts/bubble-chart.md
+++ b/sites/docs/docs/features/charts/bubble-chart.md
@@ -79,8 +79,8 @@ hide_table_of_contents: false
 <tr>	<td>title</td>	<td>Chart title. Appears at top left of chart.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>string</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>subtitle</td>	<td>Chart subtitle. Appears just under title.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>string</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>legend</td>	<td>Turns legend on or off. Legend appears at top center of chart.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true for multiple series</td>	</tr>
-<tr>	<td>xAxisTitle</td>	<td>Name to show under x-axis. If 'true', formatted column name is used. Only works with swapXY=false</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>false</td>	</tr>
-<tr>	<td>yAxisTitle</td>	<td>Name to show beside y-axis. If 'true', formatted column name is used.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>false</td>	</tr>
+<tr>	<td>xAxisTitle</td>	<td>Name to show under x-axis. If 'true', formatted column name is used. Only works with swapXY=false</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>yAxisTitle</td>	<td>Name to show beside y-axis. If 'true', formatted column name is used.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>xGridlines</td>	<td>Turns on/off gridlines extending from x-axis tick marks (vertical lines when swapXY=false)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>yGridlines</td>	<td>Turns on/off gridlines extending from y-axis tick marks (horizontal lines when swapXY=false)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>xAxisLabels</td>	<td>Turns on/off value labels on the x-axis</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/docs/docs/features/charts/scatter-plot.md
+++ b/sites/docs/docs/features/charts/scatter-plot.md
@@ -75,8 +75,8 @@ hide_table_of_contents: false
 <tr>	<td>title</td>	<td>Chart title. Appears at top left of chart.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>string</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>subtitle</td>	<td>Chart subtitle. Appears just under title.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>string</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>legend</td>	<td>Turns legend on or off. Legend appears at top center of chart.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true for multiple series</td>	</tr>
-<tr>	<td>xAxisTitle</td>	<td>Name to show under x-axis. If 'true', formatted column name is used. Only works with swapXY=false</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>false</td>	</tr>
-<tr>	<td>yAxisTitle</td>	<td>Name to show beside y-axis. If 'true', formatted column name is used.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>false</td>	</tr>
+<tr>	<td>xAxisTitle</td>	<td>Name to show under x-axis. If 'true', formatted column name is used. Only works with swapXY=false</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>yAxisTitle</td>	<td>Name to show beside y-axis. If 'true', formatted column name is used.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | string | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>xGridlines</td>	<td>Turns on/off gridlines extending from x-axis tick marks (vertical lines when swapXY=false)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>yGridlines</td>	<td>Turns on/off gridlines extending from y-axis tick marks (horizontal lines when swapXY=false)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>xAxisLabels</td>	<td>Turns on/off value labels on the x-axis</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -84,7 +84,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
                     let tooltipData = filteredData.map((d) => d[tooltipTitle])
                     seriesData.forEach((item, index) => item.push(tooltipData[index]));
                 }
-            console.log(seriesData)
+
                 // Set series name:
                 seriesName = seriesDistinct[i] + " - " + columnSummary[y[j]].title;
                 tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
@@ -105,13 +105,11 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
                 seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[i]]]);
             }
         
-            console.log(seriesData)
             // Append size column if supplied (for bubble chart):
             if(size){
                 let sizeData = data.map((d) => d[size])
                 seriesData.forEach((item, index) => item.push(sizeData[index]));
             }
-            console.log(seriesData)
 
             // Append tooltip label if supplied:
             if(tooltipTitle){
@@ -140,7 +138,6 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
             let sizeData = data.map((d) => d[size])
             seriesData.forEach((item, index) => item.push(sizeData[index]));
         }
-        console.log(seriesData)
 
         // Append tooltip label if supplied:
         if(tooltipTitle){

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -1,6 +1,6 @@
 import getDistinctValues from './getDistinctValues.js'
 
-export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, name=null, xMismatch, columnSummary, size=null) {
+export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, name=null, xMismatch, columnSummary, size=null, tooltipTitle=null) {
 
     function generateTempConfig(seriesData, seriesName, baseConfig) {
         let tempConfig = {
@@ -23,6 +23,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
 
     // 1) Series column with single y column
     if (series != null && typeof y !== "object") {
+        
         legend = true;
         seriesDistinct = getDistinctValues(data, series);
 
@@ -40,7 +41,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
                 if(swapXY){
                     seriesData = filteredData.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
                 } else {
-                    seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y]]);
+                    seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[tooltipTitle]]);
                 }
             }
 
@@ -126,7 +127,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
             if(swapXY){
                 seriesData = data.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
             } else {
-                seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y]]);
+                seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[tooltipTitle]]);
             }
         }
 

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -20,10 +20,9 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
     let filteredData;
     let seriesName;
     let seriesDistinct;
-
+    
     // 1) Series column with single y column
     if (series != null && typeof y !== "object") {
-        
         legend = true;
         seriesDistinct = getDistinctValues(data, series);
 
@@ -31,20 +30,24 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
             // Filter for specific series:
             filteredData = data.filter((d) => d[series] === seriesDistinct[i]);
 
-            if(size != null){
-                if(swapXY){
-                    seriesData = filteredData.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x]), d[size]]);
-                } else {
-                    seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[size]]);
-                }
+            if(swapXY){
+                seriesData = filteredData.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
             } else {
-                if(swapXY){
-                    seriesData = filteredData.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
-                } else {
-                    seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[tooltipTitle]]);
-                }
+                seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y]]);
+            }
+        
+            // Append size column if supplied (for bubble chart):
+            if(size){
+                let sizeData = filteredData.map((d) => d[size])
+                seriesData.forEach((item, index) => item.push(sizeData[index]));
             }
 
+            // Append tooltip label if supplied:
+            if(tooltipTitle){
+                let tooltipData = filteredData.map((d) => d[tooltipTitle])
+                seriesData.forEach((item, index) => item.push(tooltipData[index]));
+            }
+        
             // Set series name:
             seriesName = seriesDistinct[i];
 
@@ -64,21 +67,24 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
      
             for (j = 0; j < y.length; j++) {
 
-
-                if(size != null){
-                    if(swapXY){
-                        seriesData = filteredData.map((d) => [d[y[j]], (xMismatch ? d[x].toString() : d[x]), d[size]]);
-                    } else {
-                        seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[j]], d[size]]);
-                    }
+                if(swapXY){
+                    seriesData = filteredData.map((d) => [d[y[j]], (xMismatch ? d[x].toString() : d[x])]);
                 } else {
-                    if(swapXY){
-                        seriesData = filteredData.map((d) => [d[y[j]], (xMismatch ? d[x].toString() : d[x])]);
-                    } else {
-                        seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[j]]]);
-                    }
+                    seriesData = filteredData.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[j]]]);
                 }
    
+                // Append size column if supplied (for bubble chart):
+                if(size){
+                    let sizeData = filteredData.map((d) => d[size])
+                    seriesData.forEach((item, index) => item.push(sizeData[index]));
+                }
+
+                // Append tooltip label if supplied:
+                if(tooltipTitle){
+                    let tooltipData = filteredData.map((d) => d[tooltipTitle])
+                    seriesData.forEach((item, index) => item.push(tooltipData[index]));
+                }
+            console.log(seriesData)
                 // Set series name:
                 seriesName = seriesDistinct[i] + " - " + columnSummary[y[j]].title;
                 tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
@@ -93,20 +99,26 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
 
         for (i = 0; i < y.length; i++) {
 
-            if(size != null){
-                if(swapXY){
-                    seriesData = data.map((d) => [d[y[i]], (xMismatch ? d[x].toString() : d[x]), d[size]]);
-                } else {
-                    seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[i]], d[size]]);
-                }
+            if(swapXY){
+                seriesData = data.map((d) => [d[y[i]], (xMismatch ? d[x].toString() : d[x])]);
             } else {
-                if(swapXY){
-                    seriesData = data.map((d) => [d[y[i]], (xMismatch ? d[x].toString() : d[x])]);
-                } else {
-                    seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[i]]]);
-                }
+                seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y[i]]]);
             }
+        
+            console.log(seriesData)
+            // Append size column if supplied (for bubble chart):
+            if(size){
+                let sizeData = data.map((d) => d[size])
+                seriesData.forEach((item, index) => item.push(sizeData[index]));
+            }
+            console.log(seriesData)
 
+            // Append tooltip label if supplied:
+            if(tooltipTitle){
+                let tooltipData = data.map((d) => d[tooltipTitle])
+                seriesData.forEach((item, index) => item.push(tooltipData[index]));
+            }
+        
             seriesName = columnSummary[y[i]].title;
             tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
             seriesConfig.push(tempConfig);
@@ -117,18 +129,23 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
     if(series == null && typeof y !== "object") {
         legend = false;
 
-        if(size != null){
-            if(swapXY){
-                seriesData = data.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x]), d[size]]);
-            } else {
-                seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[size]]);
-            }
+        if(swapXY){
+            seriesData = data.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
         } else {
-            if(swapXY){
-                seriesData = data.map((d) => [d[y], (xMismatch ? d[x].toString() : d[x])]);
-            } else {
-                seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y], d[tooltipTitle]]);
-            }
+            seriesData = data.map((d) => [(xMismatch ? d[x].toString() : d[x]), d[y]]);
+        }
+
+        // Append size column if supplied (for bubble chart):
+        if(size){
+            let sizeData = data.map((d) => d[size])
+            seriesData.forEach((item, index) => item.push(sizeData[index]));
+        }
+        console.log(seriesData)
+
+        // Append tooltip label if supplied:
+        if(tooltipTitle){
+            let tooltipData = data.map((d) => d[tooltipTitle])
+            seriesData.forEach((item, index) => item.push(tooltipData[index]));
         }
 
         seriesName = columnSummary[y].title;

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -27,6 +27,8 @@
     maxSize = maxSize * (scaleTo / 1);
 
     export let useTooltip = false;
+    export let tooltipTitle;
+
     let multiSeries;
     let tooltipOutput;
 
@@ -43,6 +45,7 @@
     y = y ?? $props.y;
     series = series ?? $props.series;
     size = size ?? $props.size;
+    tooltipTitle = tooltipTitle ?? $props.tooltipTitle;
     let yMin = $props.yMin;
 
     if(!series && typeof y !== 'object'){
@@ -100,15 +103,29 @@
             tooltip: {
                 formatter: function(params) {
                     if(multiSeries){
-                        tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
-                        ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                        ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                        ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                        if(tooltipTitle){
+                            tooltipOutput = `<span style='font-weight:600'>${formatValue(params.value[3], "0")}</span><br/>
+                            ${formatTitle(series)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.seriesName)}</span><br/>
+                            ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                            ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                        } else {
+                            tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
+                            ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                            ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                        }                    
                     } else {
-                        tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                        <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                        <span style='font-weight: 600;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
-                    }
+                        if(tooltipTitle){
+                            tooltipOutput = `<span style='font-weight:600;'>${formatValue(params.value[3],"0")}</span><br/>
+                            <span style='font-weight: 400;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            <span style='font-weight: 400;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                            <span style='font-weight: 400;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                        } else {
+                            tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
+                            <span style='font-weight: 600;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                        }                    }
                     return tooltipOutput
                 }
             }
@@ -129,7 +146,7 @@
     }
 
     // Generate config for each series:
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary, size);
+    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary, size, tooltipTitle);
     config.update(d => {d.series.push(...seriesConfig); return d})
 
     // Overriding global chart config:

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -108,23 +108,23 @@
                             ${formatTitle(series)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.seriesName)}</span><br/>
                             ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
                             ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                            ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                            ${formatTitle(size, sizeFormat)} <span style='font-weight: 400; color:var(--grey-400);'> (size)</span>: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
                         } else {
                             tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
                             ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
                             ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                            ${formatTitle(size, sizeFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                            ${formatTitle(size, sizeFormat)} <span style='font-weight: 400; color:var(--grey-400);'> (size)</span>: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
                         }                    
                     } else {
                         if(tooltipTitle){
                             tooltipOutput = `<span style='font-weight:600;'>${formatValue(params.value[3],"0")}</span><br/>
                             <span style='font-weight: 400;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
                             <span style='font-weight: 400;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                            <span style='font-weight: 400;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                            <span style='font-weight: 400;'>${formatTitle(size, sizeFormat)} <span style='font-weight: 400; color:var(--grey-400);'> (size)</span>:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
                         } else {
                             tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
                             <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span><br/>
-                            <span style='font-weight: 600;'>${formatTitle(size, sizeFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
+                            <span style='font-weight: 600;'>${formatTitle(size, sizeFormat)} <span style='font-weight: 400; color:var(--grey-400);'> (size)</span>:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[2], sizeFormat)}</span>`
                         }                    }
                     return tooltipOutput
                 }

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -12,8 +12,8 @@
     export let title = undefined;
     export let subtitle = undefined;
     export let legend = undefined;
-    export let xAxisTitle = undefined;
-    export let yAxisTitle = undefined;
+    export let xAxisTitle = 'true';
+    export let yAxisTitle = 'true';
     export let xGridlines = undefined;
     export let yGridlines = undefined;
     export let xAxisLabels = undefined;

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -34,6 +34,8 @@
 
     export let sort = undefined;
 
+    export let tooltipTitle = undefined;
+
     let chartType = "Bubble Chart";
     let bubble = true;
 
@@ -46,6 +48,7 @@
     {x}
     {y}
     {size}
+    {tooltipTitle}
     {series}
     {xType}
     {legend}

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -301,7 +301,6 @@ try{
                 : getSortedData(data, x, true) 
             : data;
          
-
     // ---------------------------------------------------------------------------------------
     // Get format codes for axes
     // ---------------------------------------------------------------------------------------
@@ -329,7 +328,7 @@ try{
         }
 
         xAxisTitle = xAxisTitle === 'true' ? formatTitle(x, xFormat) : xAxisTitle === 'false' ? '' : xAxisTitle;
-        yAxisTitle = yAxisTitle === 'true' ? formatTitle(y, yFormat) : yAxisTitle === 'false' ? '' : yAxisTitle;
+        yAxisTitle = yAxisTitle === 'true' ? typeof y === 'object' ? '' : formatTitle(y, yFormat) : yAxisTitle === 'false' ? '' : yAxisTitle;
 
     // ---------------------------------------------------------------------------------------
     // Set legend flag

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -30,6 +30,7 @@
         export let y = undefined;
         export let series = undefined;
         export let size = undefined;
+        export let tooltipTitle = undefined;
 
         export let swapXY = false; // Flipped axis chart
         if(swapXY === "true" || swapXY === true){
@@ -233,6 +234,7 @@ try{
         };
         if(size){inputCols.push(size)};
         if(series){optCols.push(series)};
+        if(tooltipTitle){optCols.push(tooltipTitle)}
 
         checkInputs(data, inputCols, optCols)
 
@@ -341,7 +343,7 @@ try{
     // ---------------------------------------------------------------------------------------
     // Add props to store to let child components access them
     // ---------------------------------------------------------------------------------------
-        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xFormat, yFormat, sizeFormat, xMismatch, size, yMin, columnSummary, xAxisTitle, yAxisTitle}});
+        props.update(d => {return {...d, data, x, y, series, swapXY, sort, xType, xFormat, yFormat, sizeFormat, xMismatch, size, yMin, columnSummary, xAxisTitle, yAxisTitle, tooltipTitle}});
 
     // ---------------------------------------------------------------------------------------
     // Axis Configuration

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -22,6 +22,7 @@
     export let pointSize = 10;
 
     export let useTooltip = false; // if true, will override the default 'axis'-based echarts tooltip. true only for scatter-only charts
+    export let tooltipTitle;
     let multiSeries;
     let tooltipOutput;
 
@@ -68,7 +69,6 @@
             }
     }
 
-
     // Tooltip settings (scatter and bubble charts require different tooltip than default)
     let tooltipOpts;
     let tooltipOverride;
@@ -77,12 +77,25 @@
             tooltip: {
                 formatter: function(params) {
                     if(multiSeries){
-                        tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
-                        ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                        ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        if(tooltipTitle){
+                            tooltipOutput = `<span style='font-weight:600'>${formatValue(params.value[2], "0")}</span><br/>
+                            ${formatTitle(series)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.seriesName)}</span><br/>
+                            ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        } else {
+                            tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
+                            ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        }
                     } else {
-                        tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                        <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        if(tooltipTitle){
+                            tooltipOutput = `<span style='font-weight:600;'>${formatValue(params.value[2],"0")}</span><br/>
+                            <span style='font-weight: 400;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            <span style='font-weight: 400;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        } else {
+                            tooltipOutput = `<span style='font-weight: 600;'>${formatTitle(x, xFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
+                            <span style='font-weight: 600;'>${formatTitle(y, yFormat)}:</span> <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                        }
                     }
                     return tooltipOutput
                 }
@@ -103,9 +116,8 @@
         baseConfig = {...baseConfig, ...options}
     }
 
-
     // Generate config for each series:
-    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary);
+    let seriesConfig = getSeriesConfig(data, x, y, series, swapXY, baseConfig, name, xMismatch, columnSummary, undefined, tooltipTitle);
     config.update(d => {d.series.push(...seriesConfig); return d})
 
     

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -37,6 +37,7 @@
     let columnSummary = $props.columnSummary;
     y = y ?? $props.y;
     series = series ?? $props.series;
+    tooltipTitle = tooltipTitle ?? $props.tooltipTitle;
     let yMin = $props.yMin;
 
     if(!series && typeof y !== 'object'){
@@ -81,11 +82,11 @@
                             tooltipOutput = `<span style='font-weight:600'>${formatValue(params.value[2], "0")}</span><br/>
                             ${formatTitle(series)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.seriesName)}</span><br/>
                             ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                            ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                            ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
                         } else {
                             tooltipOutput = `<span style='font-weight:600'>${formatValue(params.seriesName)}</span><br/>
                             ${formatTitle(x, xFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[0], xFormat)}</span><br/>
-                            ${formatTitle(y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
+                            ${formatTitle(typeof y === 'object' ? params.seriesName : y, yFormat)}: <span style='float:right; margin-left: 15px;'>${formatValue(params.value[1], yFormat)}</span>`
                         }
                     } else {
                         if(tooltipTitle){

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -33,6 +33,8 @@
 
     export let sort = undefined;
 
+    export let tooltipTitle = undefined;
+
     let chartType = "Scatter Plot";
 
     let useTooltip = true;
@@ -71,5 +73,6 @@
         {outlineWidth}
         {pointSize}
         {useTooltip}
+        {tooltipTitle}
     />
 </Chart>

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -46,6 +46,7 @@
     {x}
     {y}
     {series}
+    {tooltipTitle}
     {xType}
     {legend}
     {xAxisTitle}
@@ -73,6 +74,5 @@
         {outlineWidth}
         {pointSize}
         {useTooltip}
-        {tooltipTitle}
     />
 </Chart>

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -11,8 +11,8 @@
     export let title = undefined;
     export let subtitle = undefined;
     export let legend = undefined;
-    export let xAxisTitle = undefined;
-    export let yAxisTitle = undefined;
+    export let xAxisTitle = 'true';
+    export let yAxisTitle = 'true';
     export let xGridlines = undefined;
     export let yGridlines = undefined;
     export let xAxisLabels = undefined;

--- a/sites/example-project/src/pages/charts/bubble-chart.md
+++ b/sites/example-project/src/pages/charts/bubble-chart.md
@@ -60,4 +60,10 @@ let region_bubble = [
 <BubbleChart data={smallb} x=x y=y size=size xAxisTitle=true yAxisTitle=true/>
 
 ## Multi-Series Bubble Chart
-<BubbleChart data={region_bubble} x=score_a y=score_b size=size series=region xAxisTitle=true yAxisTitle=true/>
+<BubbleChart data={region_bubble} x=score_a y=score_b size=size series=region xAxisTitle=true yAxisTitle=true />
+
+## Bubble Chart with Tooltip Title
+<BubbleChart data={smallb} x=x y=y size=size xAxisTitle=true yAxisTitle=true tooltipTitle=y/>
+
+## Multi-Series Bubble Chart with Tooltip Title
+<BubbleChart data={region_bubble} x=score_a y=score_b size=size series=region xAxisTitle=true yAxisTitle=true tooltipTitle=region/>

--- a/sites/example-project/src/pages/charts/bubble-chart.md
+++ b/sites/example-project/src/pages/charts/bubble-chart.md
@@ -54,16 +54,42 @@ let region_bubble = [
     {region: 'South', score_a: 102, score_b: 88, size: 62},
     {region: 'South', score_a: 82, score_b: 68, size: 3}
 ]
+
+let countries = [
+    {country: 'United States', continent: 'North America', gdp_usd: 22996, gdp_growth_pct1: 0.017, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.085, jobless_rate_pct1: 0.037, gov_budget: -16.7, debt_to_gdp: 137.2, current_account: -3.6, population: 332.4},
+    {country: 'China', continent: 'Asia', gdp_usd: 17734, gdp_growth_pct1: 0.004, interest_rate_pct1: 0.0365, inflation_rate_pct1: 0.027, jobless_rate_pct1: 0.054, gov_budget: -3.7, debt_to_gdp: 66.8, current_account: 1.8, population: 1412.6},
+    {country: 'Japan', continent: 'Asia', gdp_usd: 4937, gdp_growth_pct1: 0.002, interest_rate_pct1: -0.001, inflation_rate_pct1: 0.026, jobless_rate_pct1: 0.026, gov_budget: -12.6, debt_to_gdp: 266.2, current_account: 3.2, population: 125.31},
+    {country: 'Germany', continent: 'Europe', gdp_usd: 4223, gdp_growth_pct1: 0.017, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.079, jobless_rate_pct1: 0.055, gov_budget: -3.7, debt_to_gdp: 69.3, current_account: 7.4, population: 83.16},
+    {country: 'United Kingdom', continent: 'Europe', gdp_usd: 3187, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.0175, inflation_rate_pct1: 0.101, jobless_rate_pct1: 0.038, gov_budget: -6, debt_to_gdp: 95.9, current_account: -2.6, population: 67.53},
+    {country: 'India', continent: 'Asia', gdp_usd: 3173, gdp_growth_pct1: 0.135, interest_rate_pct1: 0.054, inflation_rate_pct1: 0.0671, jobless_rate_pct1: 0.078, gov_budget: -9.4, debt_to_gdp: 73.95, current_account: -1.7, population: 1380},
+    {country: 'France', continent: 'Europe', gdp_usd: 2937, gdp_growth_pct1: 0.042, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.058, jobless_rate_pct1: 0.074, gov_budget: -6.5, debt_to_gdp: 112.9, current_account: 0.4, population: 67.63},
+    {country: 'Italy', continent: 'Europe', gdp_usd: 2100, gdp_growth_pct1: 0.047, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.084, jobless_rate_pct1: 0.079, gov_budget: -7.2, debt_to_gdp: 150.8, current_account: 2.5, population: 59.24},
+    {country: 'Canada', continent: 'North America', gdp_usd: 1991, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.076, jobless_rate_pct1: 0.049, gov_budget: -4.7, debt_to_gdp: 117.8, current_account: 0.1, population: 38.44},
+    {country: 'South Korea', continent: 'Asia', gdp_usd: 1799, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.057, jobless_rate_pct1: 0.029, gov_budget: -6.1, debt_to_gdp: 42.6, current_account: 3.5, population: 51.74},
+    {country: 'Russia', continent: 'Europe', gdp_usd: 1776, gdp_growth_pct1: -0.04, interest_rate_pct1: 0.08, inflation_rate_pct1: 0.151, jobless_rate_pct1: 0.039, gov_budget: 0.8, debt_to_gdp: 18.2, current_account: 6.8, population: 145.55},
+    {country: 'Brazil', continent: 'South America', gdp_usd: 1609, gdp_growth_pct1: 0.032, interest_rate_pct1: 0.1375, inflation_rate_pct1: 0.1007, jobless_rate_pct1: 0.091, gov_budget: -4.5, debt_to_gdp: 80.27, current_account: -1.8, population: 213.32}
+]
 </script>
 
-## Bubble Chart
+## Basic Bubble Chart
 <BubbleChart data={smallb} x=x y=y size=size xAxisTitle=true yAxisTitle=true/>
 
-## Multi-Series Bubble Chart
-<BubbleChart data={region_bubble} x=score_a y=score_b size=size series=region xAxisTitle=true yAxisTitle=true />
+## Bubble Chart
+<BubbleChart
+    data={countries}
+    x=debt_to_gdp
+    y=gdp_growth_pct1
+    size=gdp_usd
+    tooltipTitle=country
+/>
 
-## Bubble Chart with Tooltip Title
-<BubbleChart data={smallb} x=x y=y size=size xAxisTitle=true yAxisTitle=true tooltipTitle=y/>
+## Multi-Series Bubble Chart 
 
-## Multi-Series Bubble Chart with Tooltip Title
-<BubbleChart data={region_bubble} x=score_a y=score_b size=size series=region xAxisTitle=true yAxisTitle=true tooltipTitle=region/>
+<BubbleChart
+    data={countries}
+    x=inflation_rate_pct1
+    y=jobless_rate_pct1
+    size=gdp_usd
+    series=continent
+    tooltipTitle=country
+/>

--- a/sites/example-project/src/pages/charts/scatter-plot.md
+++ b/sites/example-project/src/pages/charts/scatter-plot.md
@@ -46,6 +46,54 @@ let regions = [
     {region: 'South', score_a: 99, score_b: 74},
     {region: 'South', score_a: 83, score_b: 73}
 ]
+
+let regions_states = [
+    {region: 'West', state: 'WA', score_a: 59, score_b: 51},
+    {region: 'West', state: 'CA', score_a: 70, score_b: 43},
+    {region: 'West', state: 'OR', score_a: 72, score_b: 38},
+    {region: 'West', state: 'NV', score_a: 66, score_b: 34},
+    {region: 'West', state: 'UT', score_a: 59, score_b: 48},
+    {region: 'West', state: 'TX', score_a: 66, score_b: 34},
+    {region: 'West', state: 'NE', score_a: 62, score_b: 30},
+    {region: 'West', state: 'AK', score_a: 58, score_b: 32},
+    {region: 'West', state: 'WY', score_a: 51, score_b: 35},
+    {region: 'East', state: 'NY', score_a: 47, score_b: 37},
+    {region: 'East', state: 'NJ', score_a: 67, score_b: 48},
+    {region: 'East', state: 'DE', score_a: 81, score_b: 71},
+    {region: 'East', state: 'MD', score_a: 86, score_b: 54},
+    {region: 'East', state: 'CT', score_a: 76, score_b: 68},
+    {region: 'East', state: 'VA', score_a: 65, score_b: 67},
+    {region: 'East', state: 'WV', score_a: 81, score_b: 50},
+    {region: 'East', state: 'KS', score_a: 59, score_b: 77},
+    {region: 'East', state: 'IN', score_a: 64, score_b: 57},
+    {region: 'East', state: 'IL', score_a: 55, score_b: 62},
+    {region: 'South', state: 'NC', score_a: 112, score_b: 82},
+    {region: 'South', state: 'SC', score_a: 80, score_b: 83},
+    {region: 'South', state: 'GA', score_a: 75, score_b: 85},
+    {region: 'South', state: 'FL', score_a: 93, score_b: 55},
+    {region: 'South', state: 'TN', score_a: 99, score_b: 81},
+    {region: 'South', state: 'LA', score_a: 81, score_b: 53},
+    {region: 'South', state: 'AL', score_a: 113, score_b: 86},
+    {region: 'South', state: 'MO', score_a: 98, score_b: 103},
+    {region: 'South', state: 'MI', score_a: 84, score_b: 83},
+]
+
+let single_region = [
+    {region: 'TX', score_a: 59, score_b: 51},
+    {region: 'OK', score_a: 70, score_b: 43},
+    {region: 'LA', score_a: 72, score_b: 38},
+    {region: 'AL', score_a: 66, score_b: 34},
+    {region: 'FL', score_a: 59, score_b: 48},
+    {region: 'NY', score_a: 66, score_b: 34},
+    {region: 'NJ', score_a: 62, score_b: 30},
+    {region: 'WA', score_a: 58, score_b: 32},
+    {region: 'NV', score_a: 51, score_b: 35},
+    {region: 'IL', score_a: 51, score_b: 52},
+    {region: 'IN', score_a: 59, score_b: 35},
+    {region: 'DE', score_a: 47, score_b: 37},
+    {region: 'KS', score_a: 54, score_b: 44},
+    {region: 'MA', score_a: 46, score_b: 48}
+]
 </script>
 
 ```census
@@ -65,3 +113,15 @@ from `bigquery-public-data.census_bureau_acs.state_2017_1yr`
 
 ## Multi-Series Scatter Plot
 <ScatterPlot data={regions} x=score_a y=score_b series=region xAxisTitle=true yAxisTitle=true/>
+
+## Scatter Plot with Tooltip Title
+<ScatterPlot
+    data={single_region}
+    x=score_a
+    y=score_b
+    tooltipTitle=region
+/>
+
+## Multi-Series Scatter Plot with Tooltip Title
+<ScatterPlot data={regions_states} x=score_a y=score_b tooltipTitle=state series=region xAxisTitle=true yAxisTitle=true/>
+

--- a/sites/example-project/src/pages/charts/scatter-plot.md
+++ b/sites/example-project/src/pages/charts/scatter-plot.md
@@ -94,6 +94,22 @@ let single_region = [
     {region: 'KS', score_a: 54, score_b: 44},
     {region: 'MA', score_a: 46, score_b: 48}
 ]
+
+
+let countries = [
+    {country: 'United States', continent: 'North America', gdp_usd: 22996, gdp_growth_pct1: 0.017, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.085, jobless_rate_pct1: 0.037, gov_budget: -16.7, debt_to_gdp: 137.2, current_account: -3.6, population: 332.4},
+    {country: 'China', continent: 'Asia', gdp_usd: 17734, gdp_growth_pct1: 0.004, interest_rate_pct1: 0.0365, inflation_rate_pct1: 0.027, jobless_rate_pct1: 0.054, gov_budget: -3.7, debt_to_gdp: 66.8, current_account: 1.8, population: 1412.6},
+    {country: 'Japan', continent: 'Asia', gdp_usd: 4937, gdp_growth_pct1: 0.002, interest_rate_pct1: -0.001, inflation_rate_pct1: 0.026, jobless_rate_pct1: 0.026, gov_budget: -12.6, debt_to_gdp: 266.2, current_account: 3.2, population: 125.31},
+    {country: 'Germany', continent: 'Europe', gdp_usd: 4223, gdp_growth_pct1: 0.017, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.079, jobless_rate_pct1: 0.055, gov_budget: -3.7, debt_to_gdp: 69.3, current_account: 7.4, population: 83.16},
+    {country: 'United Kingdom', continent: 'Europe', gdp_usd: 3187, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.0175, inflation_rate_pct1: 0.101, jobless_rate_pct1: 0.038, gov_budget: -6, debt_to_gdp: 95.9, current_account: -2.6, population: 67.53},
+    {country: 'India', continent: 'Asia', gdp_usd: 3173, gdp_growth_pct1: 0.135, interest_rate_pct1: 0.054, inflation_rate_pct1: 0.0671, jobless_rate_pct1: 0.078, gov_budget: -9.4, debt_to_gdp: 73.95, current_account: -1.7, population: 1380},
+    {country: 'France', continent: 'Europe', gdp_usd: 2937, gdp_growth_pct1: 0.042, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.058, jobless_rate_pct1: 0.074, gov_budget: -6.5, debt_to_gdp: 112.9, current_account: 0.4, population: 67.63},
+    {country: 'Italy', continent: 'Europe', gdp_usd: 2100, gdp_growth_pct1: 0.047, interest_rate_pct1: 0.005, inflation_rate_pct1: 0.084, jobless_rate_pct1: 0.079, gov_budget: -7.2, debt_to_gdp: 150.8, current_account: 2.5, population: 59.24},
+    {country: 'Canada', continent: 'North America', gdp_usd: 1991, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.076, jobless_rate_pct1: 0.049, gov_budget: -4.7, debt_to_gdp: 117.8, current_account: 0.1, population: 38.44},
+    {country: 'South Korea', continent: 'Asia', gdp_usd: 1799, gdp_growth_pct1: 0.029, interest_rate_pct1: 0.025, inflation_rate_pct1: 0.057, jobless_rate_pct1: 0.029, gov_budget: -6.1, debt_to_gdp: 42.6, current_account: 3.5, population: 51.74},
+    {country: 'Russia', continent: 'Europe', gdp_usd: 1776, gdp_growth_pct1: -0.04, interest_rate_pct1: 0.08, inflation_rate_pct1: 0.151, jobless_rate_pct1: 0.039, gov_budget: 0.8, debt_to_gdp: 18.2, current_account: 6.8, population: 145.55},
+    {country: 'Brazil', continent: 'South America', gdp_usd: 1609, gdp_growth_pct1: 0.032, interest_rate_pct1: 0.1375, inflation_rate_pct1: 0.1007, jobless_rate_pct1: 0.091, gov_budget: -4.5, debt_to_gdp: 80.27, current_account: -1.8, population: 213.32}
+]
 </script>
 
 ```census
@@ -112,16 +128,10 @@ from `bigquery-public-data.census_bureau_acs.state_2017_1yr`
 />
 
 ## Multi-Series Scatter Plot
-<ScatterPlot data={regions} x=score_a y=score_b series=region xAxisTitle=true yAxisTitle=true/>
-
-## Scatter Plot with Tooltip Title
 <ScatterPlot
-    data={single_region}
-    x=score_a
-    y=score_b
-    tooltipTitle=region
+    data={countries}
+    x=gdp_usd
+    y=gdp_growth_pct1
+    tooltipTitle=country
+    series=continent
 />
-
-## Multi-Series Scatter Plot with Tooltip Title
-<ScatterPlot data={regions_states} x=score_a y=score_b tooltipTitle=state series=region xAxisTitle=true yAxisTitle=true/>
-


### PR DESCRIPTION
This PR improves tooltips in scatter and bubble charts by letting you pass in a column to use as the title for the tooltip.

For example, if you are charting a list of products and their characteristics, you may want to show the product name as the title of the tooltip, rather than only showing the metrics associated with that product.

## Summary of changes:
- `tooltipTitle` prop - pass in a column which will be used as the title for the tooltip (best for identifying individual items in your data - e.g., products, countries)
- Axis titles are now turned on by default for scatter and bubble charts
- The `size` column used in a bubble chart is now appended with a `(size)` indicator so you know which column is driving size differences across points

## Scatter
### Before
<img width="583" alt="CleanShot 2022-09-07 at 13 53 40@2x" src="https://user-images.githubusercontent.com/12602440/188946149-a38237b8-0136-470f-ad0c-9369651621e5.png">

### After
<img width="582" alt="CleanShot 2022-09-07 at 13 45 27@2x" src="https://user-images.githubusercontent.com/12602440/188945577-7968a8b6-d403-40cf-a60f-e6efe52571e5.png">

## Bubble
### Before
<img width="590" alt="CleanShot 2022-09-07 at 13 54 12@2x" src="https://user-images.githubusercontent.com/12602440/188946147-715d8d97-05d9-4cee-8c8a-95c58090dc5c.png">

### After
<img width="586" alt="CleanShot 2022-09-07 at 13 45 08@2x" src="https://user-images.githubusercontent.com/12602440/188945580-543f9933-abf6-4d22-9815-5fb2cae4f289.png">
