### PR TITLE
359 charts not copying properly

### DIFF
--- a/.changeset/cuddly-carrots-type.md
+++ b/.changeset/cuddly-carrots-type.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix chart copy paste bug and better support command-a keyboard shortcut for copying full pages

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -8,6 +8,10 @@ html {
 
 body, html {
 	height: 100%;
+	user-select: none;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
 }
 
 img {

--- a/sites/example-project/src/components/modules/echartsCopy.js
+++ b/sites/example-project/src/components/modules/echartsCopy.js
@@ -437,6 +437,7 @@ export default(node, option, renderer) => {
     });
 
     const chart = echarts.init(node, 'evidence-light', {renderer: 'canvas'});   
+    option.animation = false // disable animation
 
 	chart.setOption(option);
 

--- a/sites/example-project/src/components/modules/echartsCopy.js
+++ b/sites/example-project/src/components/modules/echartsCopy.js
@@ -442,8 +442,8 @@ export default(node, option, renderer) => {
 	chart.setOption(option);
 
     let src = chart.getConnectedDataURL({
-        type: 'png',
-        pixelRatio: 1.5,
+        type: 'jpeg',
+        pixelRatio: 2,
         backgroundColor: '#fff',
         excludeComponents: ['toolbox']
     });

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -34,6 +34,7 @@
 	  <div class=content class:settings-content={$page.path === '/settings'}>
 		<article class:settings-article={$page.path === '/settings'}>
 			<slot/>
+			<p>&nbsp;</p>
 		</article>
 		<aside class='toc'>
 			<TableOfContents/>

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -79,6 +79,10 @@ article {
 	grid-area: article;
 	padding: 0 1.5em 0 1.5em;
 	box-sizing: border-box;
+	user-select: text;
+	-moz-user-select: text;
+	-webkit-user-select: text;
+	-ms-user-select: text;
 }
 
 .settings-content {


### PR DESCRIPTION
Resolves: 

- Axis only copying (caused by leaving animation on in the copy target) 
- Separate issue with inconsistent treatment of PNGs landing in MS word (switched to jpeg) 

Adds `⌘A` keyboard shortcut support 

- Styling to restrict text selection to the main article section of the page
- Addition of a non breaking space at the end of each article to ensure text selection reaches the end of all content 

Demo 
![CleanShot 2022-09-13 at 14 08 17](https://user-images.githubusercontent.com/6857673/189979053-cfe5b9ae-8645-40ee-92d0-1984e29bae0c.gif)

