### PR TITLE
Turn off format tags for string columns

### DIFF
--- a/.changeset/cold-ears-fetch.md
+++ b/.changeset/cold-ears-fetch.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Turns off format tags for string columns

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -29,6 +29,10 @@ export const lookupColumnFormat = (
 ) => {
   let potentialFormatTag = maybeExtractFormatTag(columnName);
 
+  if(columnEvidenceType.evidenceType === 'string'){
+    return undefined;
+  }
+
   if (potentialFormatTag) {
     let customFormats = getCustomFormats();
     let matchingFormat = [...BUILT_IN_FORMATS, ...customFormats].find(


### PR DESCRIPTION
This PR turns off format tag usage for columns where type is `string`.

Currently, if you apply a format tag to a string, it will work with whatever information is contained in the column. This is normally fine, but occasionally it can mask an underlying type issue. For example, if you have dates stored as strings, applying a date format tag may work in 90% of cases, but the remainder of the cases will give the wrong date (due to timezone conversions) and it will be difficult to debug.

Turning off format tags for strings is an effort to bring type issues to light earlier through this workflow:
- Run query as normal
- Check that data is formatted correctly in query viewer
- If something looks off or unformatted, check the data type in the query viewer for that column
- Edit SQL query as needed to get the correct type

One thing to note here is that Evidence attempts to detect the correct type from the data contained in the database column. For example, SQLite date types all come into Evidence as strings, but are identified as dates through our type system.