### PR TITLE
Apply consistent date handling across components

### DIFF
--- a/.changeset/tame-pens-beam.md
+++ b/.changeset/tame-pens-beam.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Applies date and time handling consistently across components

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -176,7 +176,7 @@ function applyFormatting(
       let typedValue;
       try {
         if (columnFormat.valueType === "date" && typeof value === "string") {
-          typedValue = new Date(value);
+          typedValue = new Date(value+"T00:00");
         } else if (
           columnFormat.valueType === "number" &&
           typeof value !== "number" &&

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -3,6 +3,7 @@
     import DownloadData from '../DownloadData.svelte'
     import { getContext} from 'svelte';
     import getColumnSummary from '$lib/modules/getColumnSummary.js';
+    import getParsedDate from '$lib/modules/getParsedDate.js';
     import { formatValue } from '$lib/modules/formatting.js';
     import { PAGE_QUERY_RESULTS } from '$lib/modules/globalContexts.js';
 
@@ -44,6 +45,15 @@
                   type: column.evidenceType
                 });
             });
+          }
+
+          let dateCols = columnSummary.filter(d => d.type === "date")
+          dateCols = dateCols.map(d => d.id);
+
+          if(dateCols.length > 0){
+            for(let i = 0; i < dateCols.length; i++){
+              data = getParsedDate(data, dateCols[i]);
+            }
           }
         }
     }

--- a/sites/example-project/src/pages/dates-and-times/index.md
+++ b/sites/example-project/src/pages/dates-and-times/index.md
@@ -1,0 +1,33 @@
+# Dates and Times
+
+## Query Viewer
+```date_query
+select date('2020-04-25') as date, 100 as value
+union all
+select date('2020-04-26') as date, 103 as value
+union all
+select date('2020-04-27') as date, 106 as value
+union all
+select date('2020-04-28') as date, 109 as value
+union all
+select date('2020-04-29') as date, 115 as value
+union all
+select date('2020-04-30') as date, 125 as value
+limit 100
+```
+
+## Value Component
+<Value data={date_query}/>  
+
+## DataTable Component
+<DataTable data={date_query}/>
+
+## Chart
+<LineChart
+    data={date_query}
+    x=date
+    y=value
+/>
+
+
+


### PR DESCRIPTION
# Summary
This PR applies consistent date and time treatment across components.

Prior to these changes, the following components used the `getParsedDate` function logic to handle dates:
 - `Value`
 - `DataTable`
 - `Chart` (axes)

The following components and functions were using default javascript logic, which in some cases led to different date results:
- `QueryDataTable`
- `formatValue`

These changes update `QueryDataTable` and `formatValue` to treat dates consistently to the other components mentioned above.

# Before & After
## Before:
- QueryDataTable showing dates inconsistent with query input
  <img width="588" alt="CleanShot 2022-10-03 at 11 10 01@2x" src="https://user-images.githubusercontent.com/12602440/193628790-96c7dffc-067a-4f33-a4e2-b885d6855ae7.png">
- Chart tooltips not matching axis label values
  <img width="154" alt="CleanShot 2022-10-03 at 11 10 13@2x" src="https://user-images.githubusercontent.com/12602440/193628789-4f309ca7-6a6b-4f9d-823d-45abdfb2caa5.png">

## After:
<img width="593" alt="CleanShot 2022-10-03 at 11 13 10@2x" src="https://user-images.githubusercontent.com/12602440/193628730-9a0f06e2-13ff-4378-9311-b8e47aaf5fac.png">
<img width="138" alt="CleanShot 2022-10-03 at 11 21 46@2x" src="https://user-images.githubusercontent.com/12602440/193628713-ce939a0e-cc26-4780-9b1d-0f7cb7c1107a.png">

# Next Steps
Consistency is the first issue to solve for date handling in Evidence, but there are still two remaining issues related to dates:
1. Fix `getParsedDate` logic to be applicable across all browsers (currently causing issues in Safari and Firefox when used with Snowflake)
2. Centralize date logic alongside Evidence's data type inference (to avoid having to account for dates specifically in each new component we build)
