### PR TITLE
Date parsing improvements

### DIFF
--- a/.changeset/popular-maps-give.md
+++ b/.changeset/popular-maps-give.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Improves date parsing and consistency

--- a/sites/example-project/src/components/modules/dateParsing.js
+++ b/sites/example-project/src/components/modules/dateParsing.js
@@ -25,16 +25,28 @@ export function standardizeDateString(date){
     // Replace spaces with "T" to conform to ECMA standard:
     date = date.replace(" ", "T")
 
-    date = new Date(date)
     return date
 }
 
 export function convertColumnToDate(data, column) {
-    // Replaces a date column's string values with JS date objects, using the parseDate function
+    // Replaces a date column's string values with JS date objects, using the standardizeDateString function
 
     data = tidy(
         data,
         mutate({ [column]: (d) => new Date(standardizeDateString(d[column]))}),
+    );
+
+    return data;
+
+}
+
+export function standardizeDateColumn(data, column) {
+    // Replaces a date column's string values with standardized date strings, using the standardizeDateString function
+    // Used in Chart.svelte, where using Date objects leads to errors
+
+    data = tidy(
+        data,
+        mutate({ [column]: (d) => standardizeDateString(d[column])}),
     );
 
     return data;

--- a/sites/example-project/src/components/modules/dateParsing.js
+++ b/sites/example-project/src/components/modules/dateParsing.js
@@ -1,6 +1,6 @@
 import {tidy, mutate} from "@tidyjs/tidy";
 
-export function parseDate(date){
+export function standardizeDateString(date){
     // Parses an individual string into a JS date object
 
     let dateSplit = date.split(" ")
@@ -29,12 +29,12 @@ export function parseDate(date){
     return date
 }
 
-export default function getParsedDate(data, column) {
+export function convertColumnToDate(data, column) {
     // Replaces a date column's string values with JS date objects, using the parseDate function
 
     data = tidy(
         data,
-        mutate({ [column]: (d) => parseDate(d[column])}),
+        mutate({ [column]: (d) => new Date(standardizeDateString(d[column]))}),
     );
 
     return data;

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -8,7 +8,7 @@ import {
   isAutoFormat,
 } from "./autoFormatting";
 import { BUILT_IN_FORMATS } from "./builtInFormats";
-import { parseDate } from "./getParsedDate";
+import { standardizeDateString } from "./dateParsing";
 
 const AXIS_FORMATTING_CONTEXT = "axis";
 const VALUE_FORMATTING_CONTEXT = "value";
@@ -177,7 +177,7 @@ function applyFormatting(
       let typedValue;
       try {
         if (columnFormat.valueType === "date" && typeof value === "string") {
-          typedValue = parseDate(value);
+          typedValue = new Date(standardizeDateString(value));
         } else if (
           columnFormat.valueType === "number" &&
           typeof value !== "number" &&

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -8,6 +8,7 @@ import {
   isAutoFormat,
 } from "./autoFormatting";
 import { BUILT_IN_FORMATS } from "./builtInFormats";
+import { parseDate } from "./getParsedDate";
 
 const AXIS_FORMATTING_CONTEXT = "axis";
 const VALUE_FORMATTING_CONTEXT = "value";
@@ -176,7 +177,7 @@ function applyFormatting(
       let typedValue;
       try {
         if (columnFormat.valueType === "date" && typeof value === "string") {
-          typedValue = new Date(value+"T00:00");
+          typedValue = parseDate(value);
         } else if (
           columnFormat.valueType === "number" &&
           typeof value !== "number" &&

--- a/sites/example-project/src/components/modules/getParsedDate.js
+++ b/sites/example-project/src/components/modules/getParsedDate.js
@@ -1,18 +1,42 @@
 import {tidy, mutate} from "@tidyjs/tidy";
 
-export default function getParsedDate(data, column) {
+export function parseDate(date){
+    // Parses an individual string into a JS date object
+
+    let dateSplit = date.split(" ")
     
-    let append = '';
-    // if the date string does not include a timestamp,
-    // append midnight:
-    if(!data[0][column].includes(":")){
-        append = "T00:00"
+    // If date doesn't contain timestamp, add one at midnight (avoids timezone interpretation issue)
+    if(!date.includes(":")){
+        date = date + "T00:00:00"
     }
+    
+    // Remove any character groups beyond 2 (date and time):
+    if(dateSplit.length > 2){
+        date = dateSplit[0] + " " + dateSplit[1]
+    }
+
+    // Replace microseconds if needed:
+    const re = /\.([^\s]+)/;
+    date = date.replace(re, "")
+
+    // Remove "Z" to avoid timezone interpretation issue:
+    date = date.replace("Z", "")
+
+    // Replace spaces with "T" to conform to ECMA standard:
+    date = date.replace(" ", "T")
+
+    date = new Date(date)
+    return date
+}
+
+export default function getParsedDate(data, column) {
+    // Replaces a date column's string values with JS date objects, using the parseDate function
 
     data = tidy(
         data,
-        mutate({ [column]: (d) => new Date(d[column]+append)}),
+        mutate({ [column]: (d) => parseDate(d[column])}),
     );
 
     return data;
+
 }

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -3,7 +3,7 @@
     import DownloadData from '../DownloadData.svelte'
     import { getContext} from 'svelte';
     import getColumnSummary from '$lib/modules/getColumnSummary.js';
-    import getParsedDate from '$lib/modules/getParsedDate.js';
+    import { convertColumnToDate } from '$lib/modules/dateParsing.js';
     import { formatValue } from '$lib/modules/formatting.js';
     import { PAGE_QUERY_RESULTS } from '$lib/modules/globalContexts.js';
 
@@ -52,7 +52,7 @@
 
           if(dateCols.length > 0){
             for(let i = 0; i < dateCols.length; i++){
-              data = getParsedDate(data, dateCols[i]);
+              data = convertColumnToDate(data, dateCols[i]);
             }
           }
         }

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -14,6 +14,7 @@
         import getDistinctValues from '../modules/getDistinctValues';
         import getStackPercentages from '../modules/getStackPercentages.js';
         import getSortedData from '../modules/getSortedData.js';
+        import { standardizeDateColumn } from '../modules/dateParsing.js';
         import { formatAxisValue } from '../modules/formatting';
         import formatTitle from '../modules/formatTitle.js';
         import { formatValue } from '../modules/formatting.js';
@@ -151,6 +152,10 @@
         let inputCols = [];
         let optCols = [];
         let i;
+
+        // Date String Handling:
+        let dateCols;
+        let columnSummaryArray;
 
 let error;
 try{
@@ -301,6 +306,21 @@ try{
                 : getSortedData(data, x, true) 
             : data;
          
+    // ---------------------------------------------------------------------------------------
+    // Standardize date columns
+    // ---------------------------------------------------------------------------------------
+
+      columnSummaryArray = getColumnSummary(data, "array");
+      dateCols = columnSummaryArray.filter(d => d.type === "date")
+      dateCols = dateCols.map(d => d.id);
+
+      if(dateCols.length > 0){
+        for(let i = 0; i < dateCols.length; i++){
+          data = standardizeDateColumn(data, dateCols[i]);
+        }
+      }
+
+
     // ---------------------------------------------------------------------------------------
     // Get format codes for axes
     // ---------------------------------------------------------------------------------------

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -5,7 +5,7 @@
     import ErrorChart from './ErrorChart.svelte'
     import checkInputs from '$lib/modules/checkInputs.js'
     import getColumnSummary from '$lib/modules/getColumnSummary.js';
-    import getParsedDate from '$lib/modules/getParsedDate.js';
+    import { convertColumnToDate } from '$lib/modules/dateParsing.js';
     import { PAGE_QUERY_RESULTS } from '$lib/modules/globalContexts.js';
     import DownloadData from '$lib/ui/DownloadData.svelte'
 
@@ -59,7 +59,7 @@
 
       if(dateCols.length > 0){
         for(let i = 0; i < dateCols.length; i++){
-          data = getParsedDate(data, dateCols[i]);
+          data = convertColumnToDate(data, dateCols[i]);
         }
       }
 

--- a/sites/example-project/src/components/viz/Value.svelte
+++ b/sites/example-project/src/components/viz/Value.svelte
@@ -1,7 +1,7 @@
 <script>
     import getColumnSummary from "$lib/modules/getColumnSummary.js";
     import { formatValue } from "$lib/modules/formatting.js";
-    import getParsedDate from "$lib/modules/getParsedDate.js";
+    import { convertColumnToDate } from "$lib/modules/dateParsing.js";
     import checkInputs from "$lib/modules/checkInputs.js";
     import PulseNumber from "./PulseNumber.svelte";
     import IoIosHelpCircleOutline from 'svelte-icons/io/IoIosHelpCircleOutline.svelte'
@@ -52,7 +52,7 @@
                 dateCols = dateCols.map(d => d.id);
                 if(dateCols.length > 0){
                     for(let i = 0; i < dateCols.length; i++){
-                    data = getParsedDate(data, dateCols[i]);
+                    data = convertColumnToDate(data, dateCols[i]);
                     }
                 }
 

--- a/sites/example-project/src/pages/database-specific/bigquery-dates.md
+++ b/sites/example-project/src/pages/database-specific/bigquery-dates.md
@@ -1,0 +1,29 @@
+# BigQuery Dates
+
+```dates
+select 
+    CAST('2022-07-21' AS DATE) as date,
+    CAST('2022-07-21 11:21:24' AS DATETIME) as datetime,
+    CAST('2022-07-21 11:21:24Z' AS TIMESTAMP) as timestamp,
+    CAST('11:21:24' AS TIME) as time
+```
+
+{console.log(dates)}
+
+
+```fff
+select '11:10' as time, 100 as value
+union all
+select '11:11' as time, 105 as value
+union all
+select '11:12' as time, 110 as value
+union all
+select '11:13' as time, 113 as value
+union all
+select '11:14' as time, 122 as value
+```
+
+<LineChart
+    data={fff}
+/>
+

--- a/sites/example-project/src/pages/database-specific/postgres-dates.md
+++ b/sites/example-project/src/pages/database-specific/postgres-dates.md
@@ -1,0 +1,11 @@
+# Postgres Dates
+
+```dates
+select 
+    TO_DATE('2020-03-23', 'YYYY-MM-DD') as date,
+    TO_DATE('March 23, 2020', 'Month DD, YYYY') as datef,
+    TO_TIMESTAMP('2020-03-23', 'YYYY-MM-DD') as timestamp
+
+```
+
+{console.log(dates)}

--- a/sites/example-project/src/pages/database-specific/snowflake-dates.md
+++ b/sites/example-project/src/pages/database-specific/snowflake-dates.md
@@ -1,0 +1,164 @@
+# Snowflake Date & Time Fields
+
+<!-- {new Date('2020-03-03T00:00:00')} -->
+
+## Timestamp Types
+
+```timestamps
+select 
+    to_date('2020-04-22') as date,
+    to_timestamp('2020-04-22') as timestamp,
+    to_timestamp_tz('2020-04-22') as timestamp_tz,
+    to_timestamp_ntz('2020-04-22') as timestamp_ntz,
+    to_timestamp_ltz('2020-04-22') as timestamp_ltz
+```
+
+<Value data={timestamps} column=date/>
+<Value data={timestamps} column=timestamp/>
+<Value data={timestamps} column=timestamp_tz/>
+<Value data={timestamps} column=timestamp_ntz/>
+<Value data={timestamps} column=timestamp_ltz/>
+
+
+
+## Date
+
+```snowflake_date
+select 
+        to_date('2020-04-22') as date,
+        100 as sales_usd
+union all
+select 
+        to_date('2020-04-23') as date,
+        110 as sales_usd
+union all
+select 
+        to_date('2020-04-24') as date,
+        120 as sales_usd
+union all
+select 
+        to_date('2020-04-25') as date,
+        140 as sales_usd
+```
+
+<DataTable data={snowflake_date}/>
+
+<LineChart
+    data={snowflake_date}
+    x=date
+    y=sales_usd
+/>
+
+
+
+## Timestamp
+
+```snowflake_timestamp
+select 
+        to_timestamp('2020-04-22') as timestamp,
+        100 as sales_usd
+union all
+select 
+        to_timestamp('2020-04-23') as timestamp,
+        110 as sales_usd
+union all
+select 
+        to_timestamp('2020-04-24') as timestamp,
+        120 as sales_usd
+union all
+select 
+        to_timestamp('2020-04-25') as timestamp,
+        140 as sales_usd
+```
+
+<DataTable data={snowflake_timestamp}/>
+
+<LineChart
+    data={snowflake_timestamp}
+    x=timestamp
+    y=sales_usd
+/>
+
+## Timestamp_tz
+
+```snowflake_timestamp_tz
+select 
+        to_timestamp_tz('2020-04-22') as timestamp_tz,
+        100 as sales_usd
+union all
+select 
+        to_timestamp_tz('2020-04-23') as timestamp_tz,
+        110 as sales_usd
+union all
+select 
+        to_timestamp_tz('2020-04-24') as timestamp_tz,
+        120 as sales_usd
+union all
+select 
+        to_timestamp_tz('2020-04-25') as timestamp_tz,
+        140 as sales_usd
+```
+
+<DataTable data={snowflake_timestamp_tz}/>
+
+<LineChart
+    data={snowflake_timestamp_tz}
+    x=timestamp_tz
+    y=sales_usd
+/>
+
+## Timestamp_ntz
+
+```snowflake_timestamp_ntz
+select 
+        to_timestamp_ntz('2020-04-22') as timestamp_ntz,
+        100 as sales_usd
+union all
+select 
+        to_timestamp_ntz('2020-04-23') as timestamp_ntz,
+        110 as sales_usd
+union all
+select 
+        to_timestamp_ntz('2020-04-24') as timestamp_ntz,
+        120 as sales_usd
+union all
+select 
+        to_timestamp_ntz('2020-04-25') as timestamp_ntz,
+        140 as sales_usd
+```
+
+<DataTable data={snowflake_timestamp_ntz}/>
+
+<LineChart
+    data={snowflake_timestamp_ntz}
+    x=timestamp_ntz
+    y=sales_usd
+/>
+
+## Timestamp_ltz
+
+```snowflake_timestamp_ltz
+select 
+        to_timestamp_ltz('2020-04-22') as timestamp_ltz,
+        100 as sales_usd
+union all
+select 
+        to_timestamp_ltz('2020-04-23') as timestamp_ltz,
+        110 as sales_usd
+union all
+select 
+        to_timestamp_ltz('2020-04-24') as timestamp_ltz,
+        120 as sales_usd
+union all
+select 
+        to_timestamp_ltz('2020-04-25') as timestamp_ltz,
+        140 as sales_usd
+```
+
+<DataTable data={snowflake_timestamp_ltz}/>
+
+<LineChart
+    data={snowflake_timestamp_ltz}
+    x=timestamp_ltz
+    y=sales_usd
+/>

--- a/sites/example-project/src/pages/database-specific/sqlite-dates.md
+++ b/sites/example-project/src/pages/database-specific/sqlite-dates.md
@@ -1,0 +1,21 @@
+# SQLite Dates
+
+
+```table_list
+SELECT name FROM sqlite_schema WHERE type ='table'
+```
+
+```orders
+select * from orders
+limit 100
+```
+
+```reviews
+select * from reviews
+limit 100
+```
+
+```marketing_spend
+select * from marketing_spend
+limit 100
+```


### PR DESCRIPTION
## Summary
This PR implements improved date parsing.

### Original Problems
- Each database returns slightly different date strings
- Each browser interprets and parses dates differently depending on the format of the string
- Safari and Firefox return `Invalid Date` in several scenarios
- Chart not able to use dates from Snowflake if they include a timestamp

### Solution
- Splits `getParsedDate` into a few functions and saves them in a module called `dateParsing`
  - **`standardizeDateString`** - Parses any date string and attempts to get it into a standard format `YYYY-MM-DDTHH:MM:SS`
  - **`standardizeDateColumn`** - Applies `standardizeDateString` to a full column in a data object
  - **`convertColumnToDate`** - Applies `standardizeDateString` to a full column plus `new Date()`
- Adds date string standardization to `Chart.svelte`
  - ECharts is not able to read timestamps returned from Snowflake if they contain a timezone - standardizing the string fixes this 
  - Due to an issue in the `tidyJS` library, we're not able to use Date objects in multi-series charts, so using standardized strings is the preferred solution until that issue is resolved 
- Closes #388 

## Remaining Issues
This is likely not a good long-term solution - it relies on date strings being in a close enough format to be able to convert them to the standardized `YYYY-MM-DDTHH:MM:SS` format.

Potential future improvements:
- Centralize the date parsing logic alongside the type inference performed by Evidence in `dbcommons`
  - This would run the logic once rather than having to run it from within each component where data is used
- Return Date objects from each database connector rather than strings
  - This would eliminate the string parsing issues for most database connectors
  - Potential issue here would be how each connector converts to the Date object - there may be timezone conversion issues there as well, and it may be challenging to get all db connectors treating all dates in the same way
- We will need to build solid support for timezones eventually - this implementation effectively ignores timezones in order to standardize all outputs, but this is a naive approach and while it should cover the majority of use cases, we should only use it in the short-term 

