### PR TITLE
Some minor fixes for docs

### DIFF
--- a/sites/docs/docs/features/advanced/templating.md
+++ b/sites/docs/docs/features/advanced/templating.md
@@ -5,35 +5,35 @@ sidebar_position: 1
 
 ## Text Expressions
 
-In Evidence, curly braces like these `{...}` evaluate javascript. In most cases, you will want to pass data into a componet such as `<Value/>` or `<LineChart/>`, but text expressions can be very handy. You don't need to be an expert in javascript to use text expressions, and the possibilities are nearly endless. 
+In Evidence, curly braces like these `{...}` evaluate javascript. In most cases, you will want to pass data into a component such as `<Value/>` or `<LineChart/>`, but text expressions can be very handy. You don't need to be an expert in javascript to use text expressions, and the possibilities are nearly endless.
 
 #### Examples
 
-* Doing math: `{5+5}` will show up as "10" in your report. 
+* Doing math: `{5+5}` will show up as "10" in your report.
 * Dynamically getting the number of records from a query result: `{example_query.length}` will display the number of rows returned by `example_query`.
-* Using a [conditional](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) to create a colloquial explanation of what's going on: 
+* Using a [conditional](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) to create a colloquial explanation of what's going on:
 
 ```
 We are {revenue_growth[0].projected_vs_target >= 0 ? "on track for " : "behind"} our revenue growth target.
 ```
 
-Will resolve to "We are on track for our revenue growth target." or "We are behind our revenue growth target." depending on the results of the `revenue_growth` query. 
+Will resolve to "We are on track for our revenue growth target." or "We are behind our revenue growth target." depending on the results of the `revenue_growth` query.
 
 
 ## Conditionals
 
-Conditionals are critical tool for managing information overload, and ensuring that your reporting is consistently showing actionable information. 
+Conditionals are critical tool for managing information overload, and ensuring that your reporting is consistently showing actionable information.
 
 Conditionals allow you to show a section of your document if a condition is met. You can optionally include `{:else}` and `{:else if}` blocks inside of your `{#if}...{/if}` blocks.
 
-```json 
+```json
 {#if condition}
 
-Display this content. 
+Display this content.
 
 {:else if another condition}
 
-A different piece of content. 
+A different piece of content.
 
 {:else }
 
@@ -42,22 +42,22 @@ Finally, this last piece of content.
 {/if}
 ```
 
-#### Example 
+#### Example
 
-Imagine you wanted to encourage your sales leaders "up-sell" low margin customers, but only when there were enough low-margin customers to do that work in-bulk. You could use a conditional to do something like this: 
+Imagine you wanted to encourage your sales leaders "up-sell" low margin customers, but only when there were enough low-margin customers to do that work in-bulk. You could use a conditional to do something like this:
 
 ```markdown
 {#if low_margin_customers.length > 15}
 
-The following customers are generating low margins. 
+The following customers are generating low margins.
 
-Consider re-allocating an account management call block to up-sell these customers. 
+Consider re-allocating an account management call block to up-sell these customers.
 
 <Table data={low_margin_customers}/>
 
 {:else }
 
-There are fewer than fifteen low margin customers, which is not enough to fill a call block. 
+There are fewer than fifteen low margin customers, which is not enough to fill a call block.
 
 {/if}
 ```
@@ -65,7 +65,7 @@ There are fewer than fifteen low margin customers, which is not enough to fill a
 
 ## Loops
 
-Loops enable you to iterate over the rows in a query result, and reference the row using an alias of your choosing. 
+Loops enable you to iterate over the rows in a query result, and reference the row using an alias of your choosing.
 
 ```markdown
 {#each query_name as alias}
@@ -75,46 +75,46 @@ Loops enable you to iterate over the rows in a query result, and reference the r
 {/each}
 ```
 
-If you have more content than you would like to loop over on a single page, consider using a [paramaterized page](/features/advanced/parameterized-pages). 
+If you have more content than you would like to loop over on a single page, consider using a [paramaterized page](/features/advanced/parameterized-pages).
 
-#### Example 
+#### Example
 
 Imagine you were creating a report on the performance of your organization's locations. You could use a loop to generate a section of your report for each location. When a new location appears in your query results, a new section will appear in your report.
 
-The following table is being returned by the query `location_summary` 
+The following table is being returned by the query `location_summary`
 
-|id   |name   |sales_usd  |gross_margin_pct   
+|id   |name   |sales_usd  |gross_margin_pct
 |---|---|---|---|
-|1   |New York   |9000   |0.60   |   
-|2  |Los Angeles   |5000   |0.45   |   
-|3   |Toronto   |4000   |0.70   |   
+|1   |New York   |9000   |0.60   |
+|2  |Los Angeles   |5000   |0.45   |
+|3   |Toronto   |4000   |0.70   |
 
 
 By using an `{#each}` block, we can iterate over each of the rows in `location_summary`, and reference the current row with the alias `location`. Here we'll create a header, and a paragraph for each of the three locations.
 
-```markdown 
-Daily sales: 
+```markdown
+Daily sales:
 
 {#each location_summary as location}
 
-## {location.name} 
+## {location.name}
 
-<Value data={location.sales_usd}/> in sales at a <Value data={location.gross_margin_pct}/> gross margin. 
+<Value data={location.sales_usd}/> in sales at a <Value data={location.gross_margin_pct}/> gross margin.
 
 {/each}
 ```
 
-Which would result in the following output 
+Which would result in the following output
 > Daily sales:
 >
 >** New York **
 >
->$9,000 in sales at a 60% gross margin. 
+>$9,000 in sales at a 60% gross margin.
 >
 >** Los Angeles **
 >
->$5,000 in sales at a 45% gross margin. 
+>$5,000 in sales at a 45% gross margin.
 >
->** Toronto ** 
+>** Toronto **
 >
->$4,000 in sales at a 70% gross margin. 
+>$4,000 in sales at a 70% gross margin.

--- a/sites/docs/docs/features/queries/query-chaining.md
+++ b/sites/docs/docs/features/queries/query-chaining.md
@@ -43,7 +43,7 @@ from (
         sum(sales) as sales
     from production.daily_sales
     group by 1
-) as t
+)
 ```
 
 ## Presentation
@@ -53,6 +53,8 @@ You can choose whether you want to see the compiled or written SQL inside the qu
 ## Other
 
 The order that queries appear on the page doesn't matter to the SQL compiler. You can reference queries that appear before or after the query that you are authoring.
+
+Some SQL dialects require sub-queries to be aliased, including Postgres and MySQL. E.g. `from ${sales_by_region} as sales_by_region`.
 
 The SQL compiler detects circular and missing references. If a query includes either a circular reference or a missing reference, Evidence will display an error that looks like a syntax error in a normal SQL query. Queries with compiler errors are not sent to your database.
 

--- a/sites/docs/docs/features/queries/query-chaining.md
+++ b/sites/docs/docs/features/queries/query-chaining.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 hide_title: false
 hide_table_of_contents: false
-title: Query Chaining 
+title: Query Chaining
 ---
 
 Query chaining enables analysts to reference the results of a query from other queries.
@@ -17,17 +17,17 @@ For example, if you want to reference a query named `daily_sales`, you would wri
 Here we have a normal SQL query, called *sales_by_region:*
 
 ```sql
-select 
+select
     region,
     sum(sales) as sales
-from production.daily_sales 
+from production.daily_sales
 group by 1
 ```
 
 Next, we have a query calculating average sales across regions, which references *sales_by_region* using the `${ }` syntax.
 
 ```sql
-select 
+select
     avg(sales) as average_sales
 from ${sales_by_region}
 ```
@@ -35,15 +35,15 @@ from ${sales_by_region}
 Below is the compiled SQL that's sent to the database:
 
 ```sql
-select 
+select
     avg(sales) as average_sales
 from (
-    select 
+    select
         region,
         sum(sales) as sales
-    from production.daily_sales 
-    group by 1 
-)
+    from production.daily_sales
+    group by 1
+) as t
 ```
 
 ## Presentation
@@ -52,8 +52,8 @@ You can choose whether you want to see the compiled or written SQL inside the qu
 
 ## Other
 
-The order that queries appear on the page doesn't matter to the SQL compiler. You can reference queries that appear before or after the query that you are authoring. 
+The order that queries appear on the page doesn't matter to the SQL compiler. You can reference queries that appear before or after the query that you are authoring.
 
-The SQL compiler detects circular and missing references. If a query includes either a circular reference or a missing reference, Evidence will display an error that looks like a syntax error in a normal SQL query. Queries with compiler errors are not sent to your database. 
+The SQL compiler detects circular and missing references. If a query includes either a circular reference or a missing reference, Evidence will display an error that looks like a syntax error in a normal SQL query. Queries with compiler errors are not sent to your database.
 
 ![circular-error-single](/img/circular-error-single.png)

--- a/sites/docs/docs/features/queries/sql-queries.md
+++ b/sites/docs/docs/features/queries/sql-queries.md
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 title: Writing Queries
 ---
 
-When you open a page in dev mode, Evidence runs all of the queries on the page. You can see the progress of these queries printed in the console. In dev mode, Evidence monitors the contents of your SQL blocks, and reloads the page as necessary to reflect any changes you've made to your queries. 
+When you open a page in dev mode, Evidence runs all of the queries on the page. You can see the progress of these queries printed in the console. In dev mode, Evidence monitors the contents of your SQL blocks, and reloads the page as necessary to reflect any changes you've made to your queries.
 
 ## Query Blocks
 You can include SQL queries in your page using a markdown code block (starting and ending with 3 backticks). Evidence requires a query name to be supplied directly after the first 3 backticks.
@@ -13,7 +13,8 @@ You can include SQL queries in your page using a markdown code block (starting a
 ````markdown
 ```sales_by_country
 select country, sum(sales) as sales
-from international_transactions 
+from international_transactions
+group by 1
 ```
 ````
 


### PR DESCRIPTION
While reading through docs, I noticed some minor problems with SQL queries and a typo, this PR fixes them.

- [Missing groupby](https://docs.evidence.dev/features/queries/sql-queries#query-blocks)
- [The last query is not valid for most DB engines, you need an alias for the subquery](https://docs.evidence.dev/features/queries/query-chaining#example)
- typo [componet](https://docs.evidence.dev/features/advanced/templating#text-expressions)