### PR TITLE
Consistent article width across breakpoint

### DIFF
--- a/.changeset/fluffy-plants-shake.md
+++ b/.changeset/fluffy-plants-shake.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Make article widths consistent across breakpoint

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -200,7 +200,7 @@ aside.toc {
 	}
 
 	article {
-		max-width: 80ch;
+		max-width: 70ch;
 	}
 
 	.settings-article {


### PR DESCRIPTION
@mcrascal this is the thing I was mentioning yesterday

## Situtation today:
- Weird "getting larger as you make width smaller" effect. Toggles between 70ch and 80ch width
- Especially odd when there is no Table of Contents

![CleanShot 2022-10-14 at 18 08 02](https://user-images.githubusercontent.com/58074498/195951223-2e970a38-b979-40af-ae55-af5f7b9525ee.gif)

## Proposed Change
- Always 70ch width

![CleanShot 2022-10-14 at 18 07 11](https://user-images.githubusercontent.com/58074498/195951436-a3b33088-2bea-40de-94fe-95d6b58944f7.gif)

Thoughts?