### PR TITLE
Add pull_request_target and approval workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: Tests
 
 on:
   pull_request:
-    branches: 
-      - master
   
   Tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches: 
       - main
 
@@ -27,7 +27,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.23.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ jobs:
 
   Tests:
     runs-on: ${{ matrix.os }}
+    needs: [ approve ]
+    environment:
+      name: Integrate Pull Request
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   approve:
     runs-on: ubuntu-latest
     steps:
-      - name: approve
+      - name: Approve
         run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."
 
   Tests:
@@ -26,6 +26,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.23.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.23.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,11 @@
 name: Tests
 
 on:
-  pull_request_target:
-    branches: [ main ]
+  pull_request:
 
 jobs:
-  approve: 
-    runs-on: ubuntu-latest
-    steps:
-    - name: Approve
-      run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
-
   Tests:
     runs-on: ${{ matrix.os }}
-    needs: [ approve ]
-    environment:
-      name: Integrate Pull Request
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -25,9 +15,6 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.23.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches: 
       - main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: Tests
 
 on:
   pull_request_target:
-    branches: 
-      - main
 
 jobs:
   approve:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Approve
-        run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."
+        run: echo "For security reasons, all pull requests from forks need to be approved first before running any automated CI."
 
-  Tests:
+  Tests-sources:
     runs-on: ${{ matrix.os }}
+    if: ${{ github.actor == 'archiewood' || github.actor == 'mcrascal' || github.actor == 'ud3sh' || github.actor == 'hughess'}}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [14, 16]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: pnpm/action-setup@v2.2.1
+        with:
+          version: 6.23.2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_SSL: ${{ secrets.POSTGRES_SSL }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          BIGQUERY_PROJECT_ID: ${{ secrets.BIGQUERY_PROJECT_ID }}
+          BIGQUERY_CLIENT_EMAIL: ${{ secrets.BIGQUERY_CLIENT_EMAIL }}
+          BIGQUERY_PRIVATE_KEY:  ${{ secrets.BIGQUERY_PRIVATE_KEY }}
+          SEND_ANONYMOUS_USAGE_STATS:  ${{ secrets.SEND_ANONYMOUS_USAGE_STATS }}
+          SQLITE_FILENAME: ":memory:"
+
+
+
+
+  Tests-forks:
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'archiewood' && github.actor != 'mcrascal' && github.actor != 'ud3sh' && github.actor != 'hughess'}}
     needs: [ approve ]
     environment:
       name: Integrate Pull Request
@@ -52,3 +95,6 @@ jobs:
           BIGQUERY_PRIVATE_KEY:  ${{ secrets.BIGQUERY_PRIVATE_KEY }}
           SEND_ANONYMOUS_USAGE_STATS:  ${{ secrets.SEND_ANONYMOUS_USAGE_STATS }}
           SQLITE_FILENAME: ":memory:"
+
+
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,7 @@ on:
 
 jobs:
   approve:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [14, 16]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Approve
         run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,22 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
+    branches: [ main ]
 
 jobs:
+  approve: 
+    runs-on: ubuntu-latest
+      
+    steps:
+      - name: Approve
+        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
+  
   Tests:
     runs-on: ${{ matrix.os }}
+    needs: [ approve ]
+    environment:
+      name: Integrate Pull Request
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -15,6 +26,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.23.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,8 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: 
+      - master
   
   Tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,6 @@ jobs:
 
   Tests:
     runs-on: ${{ matrix.os }}
-    needs: [approve]
-    environment:
-      name: Integrate Pull Request
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches: 
       - main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2.2.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,10 @@ name: Tests
 
 on:
   pull_request:
-  
+    branches: 
+      - main
+
+jobs:
   Tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 on:
   pull_request:
-
-jobs:
+    branches: [ main ]
+  
   Tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   approve: 
     runs-on: ubuntu-latest
-      
+
     steps:
-      - name: Approve
-        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
+    - name: Approve
+      run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   
   Tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,10 @@ on:
 jobs:
   approve: 
     runs-on: ubuntu-latest
-
     steps:
     - name: Approve
       run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
-  
+
   Tests:
     runs-on: ${{ matrix.os }}
     needs: [ approve ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   approve:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [14, 16]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Approve
         run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   approve:
     runs-on: ubuntu-latest
     steps:
-      - name: Approve
+      - name: approve
         run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."
 
   Tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,22 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches: 
       - main
 
 jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."
+
   Tests:
     runs-on: ${{ matrix.os }}
+    needs: [approve]
+    environment:
+      name: Integrate Pull Request
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/sites/docs/docs/features/advanced/parameterized-pages.md
+++ b/sites/docs/docs/features/advanced/parameterized-pages.md
@@ -4,7 +4,7 @@ hide_table_of_contents: false
 title: Parameterized Pages
 ---
 
-A parameter is included in a URL for a page to reference a specific item in a dataset (e.g., a department, region, product, etc.). This parameter can then be used to filter queries and present data specific to the item in the parameter.
+A parameter is included in a URL for a page to reference a specific item in a dataset (e.g., a department, region, product, etc.). This parameter can then be used to filter queries and present data specific to the item in the parameter
 
 A page's parameter can be accessed through this variable:
 ```markdown

--- a/sites/docs/docs/features/advanced/parameterized-pages.md
+++ b/sites/docs/docs/features/advanced/parameterized-pages.md
@@ -4,7 +4,7 @@ hide_table_of_contents: false
 title: Parameterized Pages
 ---
 
-A parameter is included in a URL for a page to reference a specific item in a dataset (e.g., a department, region, product, etc.). This parameter can then be used to filter queries and present data specific to the item in the parameter
+A parameter is included in a URL for a page to reference a specific item in a dataset (e.g., a department, region, product, etc.). This parameter can then be used to filter queries and present data specific to the item in the parameter.
 
 A page's parameter can be accessed through this variable:
 ```markdown


### PR DESCRIPTION
## Problem:
- Tests fail from PRs from non maintainers. 
- This is because forks by default do not have access to the secrets that are needed for the tests to run.

## Implementation:
- Set up `pull_request_target` to trigger the action. This can access secrets.
- However, this requires an authentication workflow to ensure there are not malicious attempts to use said secrets.
- This is set up, such that maintainers will have to "approve" PRs, allowing the tests to run
   - For existing maintainers / contributors, approval is automatic

This is well explained (and mainly copied from) [here](https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci)