### PR TITLE
Support Custom Components Library

### DIFF
--- a/.changeset/angry-bats-live.md
+++ b/.changeset/angry-bats-live.md
@@ -1,0 +1,6 @@
+---
+"@evidence-dev/evidence": patch
+"evidence-test-environment": patch
+---
+
+Support adding local components from a /components/ directory

--- a/.changeset/gorgeous-cars-doubt.md
+++ b/.changeset/gorgeous-cars-doubt.md
@@ -1,0 +1,7 @@
+---
+"@evidence-dev/evidence": patch
+"evidence-docs": patch
+"evidence-test-environment": patch
+---
+
+Update docs and test-env

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -8,7 +8,7 @@ import {fileURLToPath} from 'url';
 import sade from 'sade';
 
 const populateTemplate = function() {
-    // Create the template project in .evidence/dev 
+    // Create the template project in .evidence/template
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
 
@@ -81,6 +81,7 @@ prog
     populateTemplate()
     const watcher = runFileWatcher('./pages/','./.evidence/template/src/pages/')
     const staticWatcher = runFileWatcher('./static/','./.evidence/template/static/')
+    const componentWatcher = runFileWatcher('./components/','./.evidence/template/src/components/')
     const flatArgs = flattenArguments(args);
 
     // Run svelte kit dev in the hidden directory 
@@ -95,6 +96,7 @@ prog
       child.kill()
       watcher.close()
       staticWatcher.close()
+      componentWatcher.close()
     })
 
   }); 
@@ -106,6 +108,7 @@ prog
     populateTemplate()
     const watcher = runFileWatcher('./pages/','./.evidence/template/src/pages/')
     const staticWatcher = runFileWatcher('./static/','./.evidence/template/static/')
+    const componentWatcher = runFileWatcher('./components/','./.evidence/template/src/components/')
     const flatArgs = flattenArguments(args);
 
     // Run svelte kit build in the hidden directory 
@@ -131,6 +134,7 @@ prog
       child.kill();
       watcher.close();
       staticWatcher.close();
+      componentWatcher.close();
       if (code !== 0) {
         throw `Build process exited with code ${code}`;
       }

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -11,7 +11,8 @@ const templatePaths = [
     'src/pages/index.md',
     'src/pages/__layout.svelte',
     'src/pages/settings/',
-    'src/pages/api/'
+    'src/pages/api/',
+    'src/components/'
 ]
 
 fs.emptyDirSync("./template/")

--- a/sites/docs/docs/features/advanced/custom-components.md
+++ b/sites/docs/docs/features/advanced/custom-components.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 3
+hide_table_of_contents: false
+title: Custom Components
+---
+
+In Evidence, you can build your own components and use them anywhere in your project. This is made possible through Svelte, the JavaScript framework Evidence is built on. 
+
+Below is a **short guide** on building a simple component in Evidence. 
+
+For a fuller guide, Svelte offers a really great interactive tutorial that you can complete in your browser in about an hour: [Svelte Tutorial](https://svelte.dev/tutorial/basics)
+
+## Why build custom components?
+### For yourself:
+- **Less repetitive code** for you to write by "abstracting" it into a separate component.
+- **Easier maintenance** of your project, as you only need to edit code in one place if you want to make changes.
+
+### To share:
+- **Share functionality with others** inside or outside your organization, by sharing your component with them.
+
+:::tip Built a great component?
+Let us know in our [Slack community](https://join.slack.com/t/evidencedev/shared_invite/zt-uda6wp6a-hP6Qyz0LUOddwpXW5qG03Q)! 
+
+We'd love to see what you've built, and may add generally applicable components to the Evidence library!
+:::
+
+
+
+## Example custom component
+
+If you were creating a component called `<Hello />`, which included some text and a BarChart, to use in `index.md`, you could do so like this:
+
+Add a folder called `components/` in the root of your project. This is where Evidence looks for your Svelte components:
+
+
+
+### Folder structure
+```
+.
+|-- pages/
+|   `-- index.md
+`-- components/
+    `-- Hello.svelte
+```
+
+`Hello.svelte` is your component. Add the following code to these two files:
+
+
+### File contents
+
+````html title="index.md"
+<!-- You need to import the component. You can reference your components folder as '$lib' -->
+<script>
+    import Hello from '$lib/Hello.svelte';
+</script>
+
+
+```sales_by_country
+select 'Canada' as country, 100 as sales_usd
+    union all
+select 'USA' as country, 200 as sales_usd
+    union all
+select 'UK' as country, 300 as sales_usd
+```
+
+<!-- To use data in the component, pass it to the component as a prop
+     You can use multiple queries, and name the props anything you like -->
+<Hello query={sales_by_country} />
+````
+
+
+```html title="Hello.svelte"
+<!-- To allow the component to accept data, you need to use the 'export let' syntax
+     If you need any Evidence components inside your custom component, you must import them explicitly -->
+<script>
+    export let query
+    import BarChart from '@evidence-dev/components/viz/BarChart.svelte'
+</script>
+
+<p>Here is a BarChart in a Component, with some accompanying text. 
+Components stored in the /components/ folder will be included in your project.</p>
+
+<BarChart data={query} />
+```
+
+
+## Building your own component: Checklist
+
+If you're building a component, here are some things to keep in mind:
+
+In your markdown file:
+1. **`import` the custom component** into any .md files where you want to use it.
+1. **Pass any data as props** if you need to access query results in the component
+
+In the custom component:
+1. **Use the `/components/` folder** for your .svelte files
+1. **`export` any props you want to use** in the component
+1. **Import any [Evidence components](https://github.com/evidence-dev/evidence/tree/main/sites/example-project/src/components)** you want to use in the components
+1. **Use Svelte (HTML + extra features) syntax** in this component - it will not support Markdown

--- a/sites/test-env/components/Hello.svelte
+++ b/sites/test-env/components/Hello.svelte
@@ -1,6 +1,6 @@
 <script>
     export let query
-    import BarChart from '$lib/viz/BarChart.svelte'
+    import BarChart from '@evidence-dev/components/viz/BarChart.svelte'
 </script>
 
 <p>Here is a BarChart in a Component, with some accompanying text. Components stored in the /components/ folder will be included in your project.</p>

--- a/sites/test-env/components/Hello.svelte
+++ b/sites/test-env/components/Hello.svelte
@@ -1,0 +1,14 @@
+<script>
+    export let query
+    import BarChart from '$lib/viz/BarChart.svelte'
+</script>
+
+<p>Here is a BarChart in a Component, with some accompanying text. Components stored in the /components/ folder will be included in your project.</p>
+
+<p>You import them using this in the script tag in your .md file: </p>
+
+<code>
+    import Hello from '$lib/Hello.svelte';
+</code>
+
+<BarChart data={query}/>

--- a/sites/test-env/pages/firstquery.md
+++ b/sites/test-env/pages/firstquery.md
@@ -39,3 +39,19 @@ Visit <a href="https://docs.evidence.dev/getting-started/connect-data-warehouse"
 This is a picture of a cat, stored in /static/
 
 ![Cute cat](kitty-cat.jpeg)
+
+## Custom Components
+
+<script>
+    import Hello from '$lib/Hello.svelte';
+</script>
+
+```test_query
+select 'Canada' as country, 100 as sales_usd
+union all
+select 'USA' as country, 200 as sales_usd
+union all
+select 'UK' as country, 300 as sales_usd
+```
+
+<Hello query={test_query}/>


### PR DESCRIPTION
## What does this do
This adds the the first part of this [feature](https://github.com/evidence-dev/evidence/issues/430).

It allows users to build their own components, stored in `./components/` to use in markdown files in their Evidence project.


## To consider:
- Should these components automatically be added to the imports?
   - so that users don't have to import their custom components at the top of markdown files
- Should all custom components also import all the Evidence components?
   - so using Evidence components inside custom components is easy

I think these may both come with trade-offs