### PR TITLE
Fix null date bug

### DIFF
--- a/.changeset/red-rocks-love.md
+++ b/.changeset/red-rocks-love.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fixes bug related to nulls in date columns

--- a/sites/example-project/src/components/modules/dateParsing.js
+++ b/sites/example-project/src/components/modules/dateParsing.js
@@ -1,31 +1,35 @@
 import {tidy, mutate} from "@tidyjs/tidy";
 
 export function standardizeDateString(date){
-    // Parses an individual string into a JS date object
 
-    let dateSplit = date.split(" ")
-    
-    // If date doesn't contain timestamp, add one at midnight (avoids timezone interpretation issue)
-    if(!date.includes(":")){
-        date = date + "T00:00:00"
+    if(date){
+        // Parses an individual string into a JS date object
+
+        let dateSplit = date.split(" ")
+        
+        // If date doesn't contain timestamp, add one at midnight (avoids timezone interpretation issue)
+        if(!date.includes(":")){
+            date = date + "T00:00:00"
+        }
+        
+        // Remove any character groups beyond 2 (date and time):
+        if(dateSplit.length > 2){
+            date = dateSplit[0] + " " + dateSplit[1]
+        }
+
+        // Replace microseconds if needed:
+        const re = /\.([^\s]+)/;
+        date = date.replace(re, "")
+
+        // Remove "Z" to avoid timezone interpretation issue:
+        date = date.replace("Z", "")
+
+        // Replace spaces with "T" to conform to ECMA standard:
+        date = date.replace(" ", "T")
     }
-    
-    // Remove any character groups beyond 2 (date and time):
-    if(dateSplit.length > 2){
-        date = dateSplit[0] + " " + dateSplit[1]
-    }
-
-    // Replace microseconds if needed:
-    const re = /\.([^\s]+)/;
-    date = date.replace(re, "")
-
-    // Remove "Z" to avoid timezone interpretation issue:
-    date = date.replace("Z", "")
-
-    // Replace spaces with "T" to conform to ECMA standard:
-    date = date.replace(" ", "T")
 
     return date
+
 }
 
 export function convertColumnToDate(data, column) {
@@ -33,7 +37,7 @@ export function convertColumnToDate(data, column) {
 
     data = tidy(
         data,
-        mutate({ [column]: (d) => new Date(standardizeDateString(d[column]))}),
+        mutate({ [column]: (d) => d[column] ? new Date(standardizeDateString(d[column])) : null}),
     );
 
     return data;


### PR DESCRIPTION
Allows for null values in date columns, which were previously throwing errors.

There were two issues happening here:
1. `standardizeDateString` function was not able to handle nulls at all. Added a quick check so if a null is encountered, the function leaves it as is
2. `convertColumnToDate` function was running `new Date` on all values, including nulls. This was causing it to return Jan 1, 1970 when it encountered nulls. Added a check so it leaves nulls as is.