### PR TITLE
Breadcrumb fix

### DIFF
--- a/.changeset/pink-panthers-tell.md
+++ b/.changeset/pink-panthers-tell.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fixes breadcrumb link issue for parameterized pages

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -49,7 +49,7 @@
         <span>
             {#each crumbs as crumb, i}
                 {#if i > 0 }
-                <a href={crumb.href}>&emsp13;/&emsp13;{crumb.title}</a>  
+                &emsp13;/&emsp13;<a href={crumb.href}>{crumb.title}</a>  
                 {:else}
                 <a href={crumb.href}>{crumb.title}</a>  
                 {/if}

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -3,7 +3,7 @@
     import { showQueries } from './stores.js'
     import { pageHasQueries } from '@evidence-dev/components/ui/stores';
 
-    export let menu;
+    export let folderList;
 
     $: pathArray = $page.path.split('/').slice(1)
 
@@ -28,13 +28,13 @@
             crumbs.splice(1, crumbs.length-3, {href: upOne, title:'...'})
         }
 
-        // Check if path is in file system - if not, avoid creating a link to that page
+        // Check if folder contains no index files - if so, disable breadcrumb link:
         crumbs.forEach((path, i) => {
-            if(!menu.map(d => d.href).includes(path.href)){
-                path.href = '';
+            if(folderList.filter(d => d.folderHref === path.href && d.indexFileCount === 0).length > 0){
+                path.href = 'javascript:void(0)';
             }
         })
-        return crumbs   
+        return crumbs
     }
 
     $: crumbs = buildCrumbs(pathArray)

--- a/sites/example-project/src/components/ui/Header.svelte
+++ b/sites/example-project/src/components/ui/Header.svelte
@@ -2,11 +2,12 @@
     import BreadCrumbs from './BreadCrumbs.svelte';
     import PrintButton from './PrintButton.svelte';
     export let menu;
+    export let folderList;
 </script>
 
 <header>
     <div class="breadcrumb-container">
-        <BreadCrumbs {menu}/>
+        <BreadCrumbs {menu} {folderList}/>
         <PrintButton/>
     </div>
 </header>

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -6,34 +6,7 @@
 	import MdErrorOutline from 'svelte-icons/md/MdErrorOutline.svelte'
 
 	export let menu;
-
-	let folders = [...new Set(menu.map(item => item.folder))];
-	folders = folders.filter(d => d !== undefined);
-
-	let fileCount;
-	let folderList = [];
-	let folderObj;
-	let folderLink;
-	let contents;
-
-	let folderLab;
-	let folderHref;
-	let folderHrefUri;
-	let folderNameError;
-	
-	for(let i = 0; i < folders.length; i++){
-		contents = menu.filter(d => d.folder === folders[i]);
-
-		folderLab = contents[0].folderLabel;
-		folderHref = contents[0].folderHref;
-		folderHrefUri = contents[0].folderHrefUri;
-		folderNameError = contents[0].folderNameError;
-
-		fileCount = contents.filter(d => d.href !== folderHref).length;
-		folderLink = contents.filter(d => d.href === folderHref).length > 0;
-		folderObj = {folder: folders[i], folderLabel: folderLab, folderHref: folderHref, folderHrefUri: folderHrefUri, fileCount: fileCount, folderLink: folderLink, folderNameError: folderNameError}
-		folderList.push(folderObj)
-	}
+	export let folderList;
 
 	// Keep only folders with at least 1 page that is not index.md or a parameterized page (path contains '[')
 	folderList = folderList.filter(d => d.fileCount > 0)
@@ -56,7 +29,7 @@
             <a href='/' on:click={() => open = !open}><h1 class=project-title>Evidence</h1></a>
         </div>
         <nav>
-			{#if folders}
+			{#if folderList}
             {#each folderCheck as folder}
 				<CollapsibleSection {folder} {menu} {folderList} bind:open={open}/>
             {/each}

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -80,6 +80,36 @@
 		})
 	}
 
+	let folders = [...new Set(menu.map(item => item.folder))];
+	folders = folders.filter(d => d !== undefined);
+
+	let fileCount;
+	let folderList = [];
+	let folderObj;
+	let folderLink;
+	let contents;
+
+	let folderLab;
+	let folderHref;
+	let folderHrefUri;
+	let indexFileCount;
+	let folderNameError;
+	
+	for(let i = 0; i < folders.length; i++){
+		contents = menu.filter(d => d.folder === folders[i]);
+
+		folderLab = contents[0].folderLabel;
+		folderHref = contents[0].folderHref;
+		folderHrefUri = contents[0].folderHrefUri;
+		folderNameError = contents[0].folderNameError;
+
+		fileCount = contents.filter(d => d.href !== folderHref).length;
+		indexFileCount = contents.filter(d => d.href === folderHref).length;
+		folderLink = contents.filter(d => d.href === folderHref).length > 0;
+		folderObj = {folder: folders[i], folderLabel: folderLab, folderHref: folderHref, folderHrefUri: folderHrefUri, fileCount: fileCount, indexFileCount: indexFileCount, folderLink: folderLink, folderNameError: folderNameError}
+		folderList.push(folderObj)
+	}
+
 </script>
 
 <script>
@@ -107,11 +137,11 @@
 <div class="grid">
 	{#if $page.path !== '/settings'}
 		<div class="header-bar">
-			<Header {menu}/>
+			<Header {menu} {folderList}/>
 			<Hamburger bind:open/>
 		</div>
 	{/if}
-	<Sidebar bind:open {menu}/> 
+	<Sidebar bind:open {menu} {folderList}/> 
 	<main in:blur|local>
 	  <div class=content class:settings-content={$page.path === '/settings'}>
 		<article class:settings-article={$page.path === '/settings'}>


### PR DESCRIPTION
Fixes a few issues with breadcrumbs:
1. Removes slashes from the click target for breadcrumb links
2. Allows breadcrumb links to be created for nested parameterized pages (was blocked by a previous fix #417)
3. Disables breadcrumb link if a folder does not contain an index file (rather than previous version which checked if the specific path existed in the menu)