### PR TITLE
Auto load database variables from `.env`

### DIFF
--- a/packages/db-orchestrator/index.cjs
+++ b/packages/db-orchestrator/index.cjs
@@ -48,7 +48,7 @@ const validateQuery = function (query) {
 
 const importDBAdapter = async function(settings) {
     try {
-        databaseType = settings ? settings.database : process.env["DATABASE"] || process.env["database"]
+        databaseType = (settings && settings.database) || process.env["DATABASE"] || process.env["database"]
         const { default: runQuery } = await import('@evidence-dev/'+ databaseType);
         return runQuery
     }catch {

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -6,6 +6,9 @@ import * as chokidar from 'chokidar'
 import path from 'path';
 import {fileURLToPath} from 'url';
 import sade from 'sade';
+import * as dotenv from 'dotenv';
+
+dotenv.config()
 
 const populateTemplate = function() {
     // Create the template project in .evidence/template

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -38,6 +38,7 @@
     "@sveltejs/adapter-static": "1.0.0-next.22",
     "vite-plugin-full-reload": "0.2.2",
     "chokidar": "3.5.3",
+    "dotenv": "^16.0.3",
     "fs-extra": "10.0.1",
     "sade": "^1.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
       '@evidence-dev/telemetry': workspace:^
       '@sveltejs/adapter-static': 1.0.0-next.22
       chokidar: 3.5.3
+      dotenv: ^16.0.3
       fs-extra: 10.0.1
       sade: ^1.8.1
       vite-plugin-full-reload: 0.2.2
@@ -119,6 +120,7 @@ importers:
       '@evidence-dev/telemetry': link:../telemetry
       '@sveltejs/adapter-static': 1.0.0-next.22
       chokidar: 3.5.3
+      dotenv: 16.0.3
       fs-extra: 10.0.1
       sade: 1.8.1
       vite-plugin-full-reload: 0.2.2
@@ -6199,7 +6201,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6207,7 +6209,7 @@ packages:
   /axios/0.27.2_debug@3.2.7:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -8013,6 +8015,11 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /dotenv/16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /downloadjs/1.4.7:
     resolution: {integrity: sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=}
 
@@ -9057,7 +9064,7 @@ packages:
         optional: true
     dev: false
 
-  /follow-redirects/1.15.2_debug@3.2.7:
+  /follow-redirects/1.15.2:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -9065,8 +9072,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 3.2.7
     dev: false
 
   /fork-ts-checker-webpack-plugin/6.5.2_webpack@5.74.0:
@@ -9890,7 +9895,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -13543,6 +13548,12 @@ packages:
   /react-dev-utils/12.0.1_webpack@5.74.0:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.1.2
@@ -13568,12 +13579,11 @@ packages:
       shell-quote: 1.7.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.74.0
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dom/17.0.2_react@17.0.2:
@@ -15577,6 +15587,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -15588,6 +15599,7 @@ packages:
   /unified/9.2.1:
     resolution: {integrity: sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -15599,6 +15611,7 @@ packages:
   /unified/9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5


### PR DESCRIPTION
This allows configuring database variables from `.env` at the root of an `evidence` project as follows:

```
SQLITE_FILENAME=needful_things.db
DATABASE=sqlite
SEND_ANONYMOUS_USAGE_STATS=no
```