### PR TITLE
resolve changeset issue

### DIFF
--- a/.changeset/cool-chicken-cheat.md
+++ b/.changeset/cool-chicken-cheat.md
@@ -1,5 +1,0 @@
----
-"@evidence-dev/components": patch
----
-
-Add blockquote styling

--- a/.changeset/new-spoons-crash.md
+++ b/.changeset/new-spoons-crash.md
@@ -1,8 +1,0 @@
----
-"@evidence-dev/db-orchestrator": patch
-"@evidence-dev/telemetry": patch
-"evidence-docs": patch
-"@evidence-dev/components": patch
----
-
-Updated telemetry to include operating system

--- a/.changeset/pink-panthers-tell.md
+++ b/.changeset/pink-panthers-tell.md
@@ -1,5 +1,0 @@
----
-"@evidence-dev/components": patch
----
-
-Fixes breadcrumb link issue for parameterized pages

--- a/.changeset/quiet-books-rescue.md
+++ b/.changeset/quiet-books-rescue.md
@@ -1,5 +1,0 @@
----
-"@evidence-dev/components": patch
----
-
-Fixes a minor code presentation issue

--- a/.changeset/selfish-needles-warn.md
+++ b/.changeset/selfish-needles-warn.md
@@ -1,7 +1,0 @@
----
-"@evidence-dev/db-orchestrator": patch
-"@evidence-dev/telemetry": patch
-"@evidence-dev/components": patch
----
-
-Updates telemetry to include database type

--- a/.changeset/strong-mugs-prove.md
+++ b/.changeset/strong-mugs-prove.md
@@ -1,5 +1,0 @@
----
-"@evidence-dev/components": patch
----
-
-Fix for chart size in flex layout

--- a/packages/db-orchestrator/CHANGELOG.md
+++ b/packages/db-orchestrator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @evidence-dev/db-orchestrator
 
+## 1.1.7
+
+### Patch Changes
+
+- f16158e: Updated telemetry to include operating system
+- 90b1846: Updates telemetry to include database type
+- Updated dependencies [f16158e]
+- Updated dependencies [90b1846]
+  - @evidence-dev/telemetry@1.0.4
+
 ## 1.1.6
 
 ### Patch Changes

--- a/packages/db-orchestrator/package.json
+++ b/packages/db-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidence-dev/db-orchestrator",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "DB orchestration for Evidence projects",
   "main": "index.cjs",
   "author": "evidence.dev",

--- a/packages/evidence/CHANGELOG.md
+++ b/packages/evidence/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @evidence-dev/evidence
 
+## 5.0.13
+
+### Patch Changes
+
+- Updated dependencies [77cee78]
+- Updated dependencies [f16158e]
+- Updated dependencies [7ea5780]
+- Updated dependencies [03bf05f]
+- Updated dependencies [90b1846]
+- Updated dependencies [7aaa078]
+  - @evidence-dev/components@1.3.10
+  - @evidence-dev/db-orchestrator@1.1.7
+  - @evidence-dev/telemetry@1.0.4
+
 ## 5.0.12
 
 ### Patch Changes

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidence-dev/evidence",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "dependencies for evidence projects",
   "type": "module",
   "keywords": [

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @evidence-dev/telemetry
 
+## 1.0.4
+
+### Patch Changes
+
+- f16158e: Updated telemetry to include operating system
+- 90b1846: Updates telemetry to include database type
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@evidence-dev/telemetry",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Annonymous usage telemetry for Evidence projects",
     "main": "index.cjs",
     "author": "evidence.dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
 
   sites/example-project:
     specifiers:
-      '@evidence-dev/telemetry': 1.0.3
+      '@evidence-dev/telemetry': 1.0.4
       '@tidyjs/tidy': 2.4.4
       cross-env: ^7.0.3
       downloadjs: 1.4.7

--- a/sites/docs/CHANGELOG.md
+++ b/sites/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # evidence-docs
 
+## 1.0.4
+
+### Patch Changes
+
+- f16158e: Updated telemetry to include operating system
+
 ## 1.0.3
 
 ### Patch Changes

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evidence-docs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/sites/example-project/CHANGELOG.md
+++ b/sites/example-project/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @evidence-dev/components
 
+## 1.3.10
+
+### Patch Changes
+
+- 77cee78: Add blockquote styling
+- f16158e: Updated telemetry to include operating system
+- 7ea5780: Fixes breadcrumb link issue for parameterized pages
+- 03bf05f: Fixes a minor code presentation issue
+- 90b1846: Updates telemetry to include database type
+- 7aaa078: Fix for chart size in flex layout
+- Updated dependencies [f16158e]
+- Updated dependencies [90b1846]
+  - @evidence-dev/telemetry@1.0.4
+
 ## 1.3.9
 
 ### Patch Changes

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidence-dev/components",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "scripts": {
     "dev": "svelte-kit package && svelte-kit dev",
     "build": "svelte-kit build",
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@evidence-dev/telemetry": "1.0.3",
+    "@evidence-dev/telemetry": "1.0.4",
     "@tidyjs/tidy": "2.4.4",
     "downloadjs": "1.4.7",
     "echarts": "5.3.2",

--- a/sites/test-env/CHANGELOG.md
+++ b/sites/test-env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # evidence-test-environment
 
+## 1.0.28
+
+### Patch Changes
+
+- @evidence-dev/evidence@5.0.13
+
 ## 1.0.27
 
 ### Patch Changes

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evidence-test-environment",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "private": true,
   "scripts": {
     "build": "evidence build",


### PR DESCRIPTION
The release workflow for components package dependency on telemetry is a bit broken. I'll open an issue to track this separately. 

I've manually worked through the version and release process -- this PR should catch up main. 

- update components telemetry dep to `workspace:` 
- install
- manually changeset version and release
- bump components telementry dep to published version `1.0.4`
- re-run release