### PR TITLE
fix: hide root level parameterized pages in sidebar

### DIFF
--- a/.changeset/wild-rings-unite.md
+++ b/.changeset/wild-rings-unite.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Prevent parameterized pages from showing in sidebar at root level, addresses #410

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -13,6 +13,7 @@
 
 	for(let path in rootMDFiles) {
 		pathEnd = path.replace('/src/pages/', '').replace(/^\.\//, '')
+		if (path.includes('[')) continue;
 		menu.push({
 			filename: pathEnd,
 			label: pathEnd.replace(/\.md$/, '').replace(/_/g, ' ').replace(/-/g, ' '),
@@ -61,7 +62,7 @@
 				folderNameError: pathSplit[0].includes(" ")
 			})
 		}
-	} 
+	}
 
 	for(let path in levelTwoIndexFiles) {
 		pathEnd = path.replace('/src/pages/', '').replace(/^\.\//, '')
@@ -94,7 +95,7 @@
 	let folderHrefUri;
 	let indexFileCount;
 	let folderNameError;
-	
+
 	for(let i = 0; i < folders.length; i++){
 		contents = menu.filter(d => d.folder === folders[i]);
 
@@ -123,7 +124,7 @@
 	import Sidebar from '@evidence-dev/components/ui/Sidebar.svelte'
 	import LoadingIndicator from "@evidence-dev/components/ui/LoadingIndicator.svelte";
 
-	export let open = false  
+	export let open = false
 </script>
 
 <svelte:head>
@@ -141,7 +142,7 @@
 			<Hamburger bind:open/>
 		</div>
 	{/if}
-	<Sidebar bind:open {menu} {folderList}/> 
+	<Sidebar bind:open {menu} {folderList}/>
 	<main in:blur|local>
 	  <div class=content class:settings-content={$page.path === '/settings'}>
 		<article class:settings-article={$page.path === '/settings'}>
@@ -173,7 +174,7 @@ main {
   grid-area: main;
 }
 
-div.content { 
+div.content {
 	margin: auto;
 	max-width:100ch;
 	box-sizing: border-box;
@@ -181,7 +182,7 @@ div.content {
 	grid-template-columns: 4fr minmax(0,1fr);
 	gap: 0 5ch;
   	grid-template-areas:
-    	'article toc'; 
+    	'article toc';
     justify-items: left;
 }
 
@@ -202,7 +203,7 @@ article {
 	max-width: 100ch !important;
 	grid-template-columns: 1fr !important;
 	grid-template-areas:
-    	'article' !important; 
+    	'article' !important;
 }
 
 .settings-article {
@@ -223,10 +224,10 @@ aside.toc {
 	justify-content: space-between;
 }
 @media (max-width: 1440px) {
-	div.content { 
+	div.content {
 		grid-template-columns: 1fr;
 		grid-template-areas:
-			'article'; 
+			'article';
 	}
 
 	article {
@@ -241,7 +242,7 @@ aside.toc {
 	max-width: 100ch !important;
 	grid-template-columns: 1fr !important;
 	grid-template-areas:
-    	'article' !important; 
+    	'article' !important;
 }
 
 	aside.toc {


### PR DESCRIPTION
This addresses the bug described in #410. 

It specifically addresses:

> **Expected Behaviour**
> - Not show is sidebar

For manual testing I added `[something].md` at root, along with `anotherthing.md` and verified that `[something]` does *not* show in the sidebar, but `anotherthing.md` does.

This does **not** address:

> - possibly crawl links in pages to determine which parameterized pages should be show in sidebar.

If anyone could elaborate on what the "crawl" functionality looks like maybe the PR can be expanded.
