### PR TITLE
Change date type inference check to ignore dates in formats other than YYYY-MM-DD

### DIFF
--- a/.changeset/weak-geckos-wait.md
+++ b/.changeset/weak-geckos-wait.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/db-commons": patch
+---
+
+changes date inference logic to cover sqlite use cases

--- a/packages/db-commons/index.cjs
+++ b/packages/db-commons/index.cjs
@@ -20,7 +20,7 @@ const inferValueType = function (columnValue) {
         return EvidenceType.BOOLEAN;
     } else if (typeof columnValue === 'string') {
         let result = EvidenceType.STRING;
-        if(columnValue && columnValue.match(/-/g).length === 2){
+        if(columnValue && (columnValue.match(/-/g) || []).length === 2){
             let testDateStr = columnValue;
             if(!columnValue.includes(":")){
                 testDateStr = columnValue + "T00:00";

--- a/packages/db-commons/index.cjs
+++ b/packages/db-commons/index.cjs
@@ -20,7 +20,7 @@ const inferValueType = function (columnValue) {
         return EvidenceType.BOOLEAN;
     } else if (typeof columnValue === 'string') {
         let result = EvidenceType.STRING;
-        if(columnValue && columnValue.includes("-")){
+        if(columnValue && columnValue.match(/-/g).length === 2){
             let testDateStr = columnValue;
             if(!columnValue.includes(":")){
                 testDateStr = columnValue + "T00:00";

--- a/sites/example-project/src/pages/database-specific/sqlite-dates.md
+++ b/sites/example-project/src/pages/database-specific/sqlite-dates.md
@@ -10,6 +10,24 @@ select * from orders
 limit 100
 ```
 
+```orders_by_month
+select
+  substr(order_datetime,1,7) as date,
+  count(*) as number_of_orders,
+  sum(sales) as sales_usd0k,
+  sum(sales)/count(*) as average_order_value_usd2
+from orders
+
+group by date order by 1 desc
+```
+
+```order_summary
+select order_month, count(*) as orders 
+from ${orders}
+group by 1
+order by 1 asc
+```
+
 ```reviews
 select * from reviews
 limit 100
@@ -19,3 +37,19 @@ limit 100
 select * from marketing_spend
 limit 100
 ```
+
+<LineChart
+    data={orders_by_month}
+    x=date
+    y=number_of_orders
+    sort=false
+/>
+
+<LineChart
+    data={order_summary}
+    x=order_month
+    y=orders
+/>
+
+
+


### PR DESCRIPTION
Currently, our date type inference logic determines dates as follows:
1. For any string columns, check if the data contains one `-`. If so, assume it is a date
2. If the value does not contain a timestamp, append a timestamp of `T00:00`
3. Run the new value through a check to see if it should be considered a date (attempt to run `new Date` then parse the result)

This works in most cases because databases have consistent formatting of date and datetime types. The only database that can cause issues here is SQLite, since there is no date type.

We found an example that causes this logic to break down:
 - Column containing months in the format `YYYY-MM` is included in a query
 - It passes the first check based on having one `-`
 - It passes through the date check and is returned as `type=date`

This PR updates the date type inference logic to only check strings that contain 2 hyphens. This means that the only dates that will be typed as dates by Evidence are in the format `YYYY-MM-DD` (and several variations of timestamps appended to that format).