### PR TITLE
Improving Visual Hierarchy

### DIFF
--- a/.changeset/thin-files-add.md
+++ b/.changeset/thin-files-add.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Updates to visual hierarchy of H1-H6 and lists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -50,12 +50,12 @@ importers:
       export-to-csv: 0.2.1
       git-remote-origin-url: 4.0.0
       prettier: 2.6.2
-      prettier-plugin-svelte: 2.7.0_prettier@2.6.2+svelte@3.44.3
+      prettier-plugin-svelte: 2.7.0_ork634hvtrgwuerupv3oy3ufpm
       prismjs: 1.29.0
       ssf: 0.11.2
       svelte: 3.44.3
       svelte-icons: 2.1.0
-      svelte2tsx: 0.4.7_svelte@3.44.3+typescript@4.5.4
+      svelte2tsx: 0.4.7_4mfbg7enynchqcvqsuw2l6w43a
       typescript: 4.5.4
       uvu: 0.5.2
       vite: 2.9.5
@@ -150,13 +150,13 @@ importers:
       '@types/mocha': 9.0.0
       '@types/node': 14.17.9
       '@types/vscode': 1.63.0
-      '@typescript-eslint/eslint-plugin': 5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3
-      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 5.7.0_26qnnnmunc2nf2ry66bpj4is4m
+      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
       '@vscode/test-electron': 1.6.2
       eslint: 8.4.1
       glob: 7.1.7
       mocha: 9.1.3
-      ts-loader: 9.2.6_typescript@4.4.4+webpack@5.65.0
+      ts-loader: 9.2.6_ohqq63mdhocqvr4wpaakehweqe
       typescript: 4.4.4
       webpack: 5.65.0_webpack-cli@4.9.1
       webpack-cli: 4.9.1_webpack@5.65.0
@@ -191,7 +191,7 @@ importers:
     dependencies:
       blueimp-md5: 2.19.0
       fs-extra: 9.1.0
-      mdsvex: 0.10.6_svelte@3.44.3
+      mdsvex: 0.10.6
       remark-parse: 8.0.2
       unified: 9.2.1
       unist-util-visit: 2.0.3
@@ -257,10 +257,10 @@ importers:
       remark-math: '3'
       url-loader: ^4.1.1
     dependencies:
-      '@docusaurus/core': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/preset-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/core': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/preset-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@svgr/webpack': 5.5.0
       clsx: 1.1.1
@@ -306,6 +306,7 @@ importers:
       cross-env: 7.0.3
       fs-extra: 10.0.1
       jest: 28.1.2
+    publishDirectory: ../../packages/components
 
   sites/test-env:
     specifiers:
@@ -3258,7 +3259,7 @@ packages:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
     dev: false
 
-  /@docsearch/react/3.3.0_react-dom@17.0.2+react@17.0.2:
+  /@docsearch/react/3.3.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -3282,7 +3283,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/core/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3302,15 +3303,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0
-      '@docusaurus/utils-common': 2.1.0
-      '@docusaurus/utils-validation': 2.1.0
+      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
+      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3322,7 +3323,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
+      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3338,16 +3339,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
+      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
+      react-dev-utils: 12.0.1_webpack@5.74.0
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
+      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3356,7 +3357,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3382,7 +3383,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/core/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
+  /@docusaurus/core/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3402,15 +3403,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils': 2.1.0
+      '@docusaurus/utils-common': 2.1.0
+      '@docusaurus/utils-validation': 2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
+      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3422,7 +3423,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
+      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3438,16 +3439,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
+      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
+      react-dev-utils: 12.0.1_webpack@5.74.0
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
+      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3456,7 +3457,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3500,7 +3501,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_6e39cab45d9f22ba28fa56595d174ac9:
+  /@docusaurus/mdx-loader/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3524,7 +3525,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3535,7 +3536,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/mdx-loader/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3559,7 +3560,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3570,21 +3571,21 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/module-type-aliases/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/module-type-aliases/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@types/history': 4.7.11
       '@types/react': 18.0.24
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -3593,17 +3594,17 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-blog/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-blog/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3636,18 +3637,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-docs/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@types/react-router-config': 5.0.6
@@ -3679,16 +3680,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-pages/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
@@ -3714,20 +3715,20 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-debug/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-json-view: 1.21.3_react-dom@17.0.2+react@17.0.2
+      react-json-view: 1.21.3_sfoxds7t5ydpegc3knd667wn6m
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -3748,15 +3749,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-google-analytics/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3779,15 +3780,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-google-gtag/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3810,16 +3811,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-sitemap/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3846,25 +3847,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/preset-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-debug': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-google-analytics': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-google-gtag': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-sitemap': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/theme-search-algolia': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-debug': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-google-analytics': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-google-gtag': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-sitemap': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/theme-search-algolia': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3897,22 +3898,22 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@docusaurus/theme-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/theme-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/theme-translations': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3949,60 +3950,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/theme-common/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/utils': 2.1.0
-      '@types/history': 4.7.11
-      '@types/react': 18.0.24
-      '@types/react-router-config': 5.0.6
-      clsx: 1.2.1
-      parse-numeric-range: 1.3.0
-      prism-react-renderer: 1.3.5_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      tslib: 2.4.0
-      utility-types: 3.10.0
-    transitivePeerDependencies:
-      - '@docusaurus/types'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@swc/css'
-      - bufferutil
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - lightningcss
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-    dev: false
-
-  /@docusaurus/theme-common/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
-    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
-    engines: {node: '>=16.14'}
-    peerDependencies:
-      react: ^16.8.4 || ^17.0.0
-      react-dom: ^16.8.4 || ^17.0.0
-    dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@types/history': 4.7.11
       '@types/react': 18.0.24
@@ -4033,18 +3992,60 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
+  /@docusaurus/theme-common/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.1.0
+      '@types/history': 4.7.11
+      '@types/react': 18.0.24
+      '@types/react-router-config': 5.0.6
+      clsx: 1.2.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 1.3.5_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/theme-search-algolia/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.3.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docsearch/react': 3.3.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/theme-translations': 2.1.0
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -4087,7 +4088,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/types/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/types/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
@@ -4099,7 +4100,7 @@ packages:
       joi: 17.6.4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       utility-types: 3.10.0
       webpack: 5.74.0
       webpack-merge: 5.8.0
@@ -4131,7 +4132,7 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       tslib: 2.4.0
     dev: false
 
@@ -4193,7 +4194,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4213,7 +4214,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@svgr/webpack': 6.5.1
       file-loader: 6.2.0_webpack@5.74.0
       fs-extra: 10.1.0
@@ -4226,7 +4227,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -5512,7 +5513,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3:
+  /@typescript-eslint/eslint-plugin/5.7.0_26qnnnmunc2nf2ry66bpj4is4m:
     resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5523,8 +5524,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0_eslint@8.4.1+typescript@4.4.4
-      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
+      '@typescript-eslint/experimental-utils': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
+      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
       '@typescript-eslint/scope-manager': 5.7.0
       debug: 4.3.2
       eslint: 8.4.1
@@ -5538,7 +5539,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.7.0_eslint@8.4.1+typescript@4.4.4:
+  /@typescript-eslint/experimental-utils/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
     resolution: {integrity: sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5556,7 +5557,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.7.0_eslint@8.4.1+typescript@4.4.4:
+  /@typescript-eslint/parser/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
     resolution: {integrity: sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5725,7 +5726,7 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
 
-  /@webpack-cli/configtest/1.1.0_webpack-cli@4.9.1+webpack@5.65.0:
+  /@webpack-cli/configtest/1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm:
     resolution: {integrity: sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
@@ -6242,7 +6243,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_f645c55d63e77e0aacb83a76bcc9695b:
+  /babel-loader/8.2.5_6zc4kxld457avlfyhj3lzsljlm:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -6505,6 +6506,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /bonjour-service/1.0.14:
@@ -6681,6 +6684,8 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
     dev: false
     optional: true
 
@@ -7123,6 +7128,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -7341,7 +7348,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /css-minimizer-webpack-plugin/4.2.2_clean-css@5.3.1+webpack@5.74.0:
+  /css-minimizer-webpack-plugin/4.2.2_kwz7aenajwsweas6icw5ncsgdy:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7624,12 +7631,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -7851,6 +7868,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -7860,6 +7879,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /diff-sequences/28.1.1:
@@ -8769,6 +8790,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /extend-shallow/2.0.1:
@@ -8956,6 +8979,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-cache-dir/3.3.1:
@@ -9048,7 +9073,7 @@ packages:
       debug: 3.2.7
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.2_c312d410e43e390b1aefa8571ea033a1:
+  /fork-ts-checker-webpack-plugin/6.5.2_webpack@5.74.0:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9068,7 +9093,6 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      eslint: 8.18.0
       fs-extra: 9.1.0
       glob: 7.1.7
       memfs: 3.4.7
@@ -9076,7 +9100,6 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 4.5.4
       webpack: 5.74.0
     dev: false
 
@@ -11324,6 +11347,7 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 8.0.1
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -11404,7 +11428,7 @@ packages:
     resolution: {integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==}
     dev: false
 
-  /mdsvex/0.10.6_svelte@3.44.3:
+  /mdsvex/0.10.6:
     resolution: {integrity: sha512-aGRDY0r5jx9+OOgFdyB9Xm3EBr9OUmcrTDPWLB7a7g8VPRxzPy4MOBmcVYgz7ErhAJ7bZ/coUoj6aHio3x/2mA==}
     peerDependencies:
       svelte: 3.x
@@ -11412,7 +11436,6 @@ packages:
       '@types/unist': 2.0.6
       prism-svelte: 0.4.7
       prismjs: 1.24.1
-      svelte: 3.44.3
       vfile-message: 2.0.4
     dev: false
 
@@ -11870,6 +11893,7 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -12612,7 +12636,7 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: false
 
-  /postcss-loader/7.0.1_postcss@8.4.14+webpack@5.74.0:
+  /postcss-loader/7.0.1_m6qh27jiicejwnzfgs742cokpe:
     resolution: {integrity: sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -13234,7 +13258,7 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prettier-plugin-svelte/2.7.0_prettier@2.6.2+svelte@3.44.3:
+  /prettier-plugin-svelte/2.7.0_ork634hvtrgwuerupv3oy3ufpm:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -13313,6 +13337,11 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
     dev: false
     optional: true
 
@@ -13514,7 +13543,7 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-dev-utils/12.0.1_c312d410e43e390b1aefa8571ea033a1:
+  /react-dev-utils/12.0.1_webpack@5.74.0:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -13527,7 +13556,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_c312d410e43e390b1aefa8571ea033a1
+      fork-ts-checker-webpack-plugin: 6.5.2_webpack@5.74.0
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13544,6 +13573,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
+      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -13568,7 +13598,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-helmet-async/1.3.0_react-dom@17.0.2+react@17.0.2:
+  /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -13591,7 +13621,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-json-view/1.21.3_react-dom@17.0.2+react@17.0.2:
+  /react-json-view/1.21.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -13611,7 +13641,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-loadable-ssr-addon-v5-slorber/1.0.1_4e32ce23c6949bd47cf53d21bd84df08:
+  /react-loadable-ssr-addon-v5-slorber/1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -13623,7 +13653,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /react-router-config/5.1.1_react-router@5.3.4+react@17.0.2:
+  /react-router-config/5.1.1_2dl5roaqnyqqppnjni7uetnb3a:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
@@ -14302,6 +14332,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /seq-queue/0.0.5:
@@ -14337,6 +14369,8 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.31
       parseurl: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /serve-static/1.15.0:
@@ -14347,6 +14381,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -14710,6 +14746,7 @@ packages:
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -14989,7 +15026,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.7_svelte@3.44.3+typescript@4.5.4:
+  /svelte2tsx/0.4.7_4mfbg7enynchqcvqsuw2l6w43a:
     resolution: {integrity: sha512-1HqRb8+I8H0Gli0+w8nTmyZgbtO/jJE3g27cNKYFyN0GMdpOh0CRmiWuMH1k9N2JugkviI7wqETanqJTR0SI+A==}
     peerDependencies:
       svelte: ^3.24
@@ -15315,7 +15352,7 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: false
 
-  /ts-loader/9.2.6_typescript@4.4.4+webpack@5.65.0:
+  /ts-loader/9.2.6_ohqq63mdhocqvr4wpaakehweqe:
     resolution: {integrity: sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -15738,7 +15775,7 @@ packages:
       schema-utils: 3.1.1
     dev: false
 
-  /url-loader/4.1.1_file-loader@6.2.0+webpack@5.74.0:
+  /url-loader/4.1.1_u4acmn7fe6yqgbrqzialkgh5lu:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16104,7 +16141,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@webpack-cli/configtest': 1.1.0_webpack-cli@4.9.1+webpack@5.65.0
+      '@webpack-cli/configtest': 1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm
       '@webpack-cli/info': 1.4.0_webpack-cli@4.9.1
       '@webpack-cli/serve': 1.6.0_webpack-cli@4.9.1
       colorette: 2.0.16

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -93,24 +93,25 @@ h2 {
 h3 {
 	font-size: 1em;
 	font-weight: bold;
+	font-style: italic;
 	color: var(--grey-800);
 }
 
 h4 {
-	font-size: 1em;
+	font-size: 0.9em;
 	text-transform: lowercase;
 	font-family: 'Spectral SC', serif;
 	letter-spacing: 0.04em;
 }
 
 h5 {
-	font-size:0.83em;
+	font-size:0.8em;
 	font-family: 'Spectral', serif;
 	letter-spacing: 0.05em;
 }
 
 h6 {
-	font-size: 0.67em;
+	font-size: 0.65em;
 	font-family: 'Spectral', serif;
 	letter-spacing: 0.025em;
 }

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -57,26 +57,26 @@ h1, h2, h3, h4, h5, h6  {
 	font-weight: normal;
 	font-family: var(--ui-font-family);
 	line-height: 1.5;
-	margin: 1.0em 0 0.3em 0; 
+	margin: 0.8em 0 0.3em 0; 
 	scroll-margin-top: var(--header-height); /* ensure that table of contents links scroll with room for the header */
 }
 
 h1:first-of-type {
-	font-size: 2em;
+	font-size: 1.8em;
 	font-weight: bold;
 	color: var(--grey-800);
 	border-top: none;
 	padding-top: 0;
-	margin: 0em 0 0.3em 0; 
+	margin: 0em 0 0.2em 0; 
 }
 
 h1 {
-	font-size: 2em;
+	font-size: 1.8em;
 	font-weight: bold;
 	color: var(--grey-800);
 	display: block;
 	border-top: 1px solid var(--grey-200);
-	padding-top: 0.3em;
+	padding-top: 0.2em;
 }
 
 
@@ -85,15 +85,15 @@ h1:active {
 }
 
 h2 { 
-	font-size: 1.5em;
+	font-size: 1.3em;
 	font-weight: bold;
 	color: var(--grey-800);
 }
 
 h3 {
-	font-size: 1.17em;
-	font-style: italic;
-	font-family: 'Spectral', serif;
+	font-size: 1em;
+	font-weight: bold;
+	color: var(--grey-800);
 }
 
 h4 {

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -45,6 +45,14 @@ p, ul, ol {
 	font-feature-settings: "onum";
 }
 
+ul ul, ol ol  {
+	margin-block-end: 0em;
+}
+
+li + li {
+	margin-top: 0.25em;
+}
+
 h1, h2, h3, h4, h5, h6  {
 	font-weight: normal;
 	font-family: var(--ui-font-family);
@@ -54,22 +62,21 @@ h1, h2, h3, h4, h5, h6  {
 }
 
 h1:first-of-type {
-	font-size: 1.2em;
+	font-size: 2em;
 	font-weight: bold;
 	color: var(--grey-800);
 	border-top: none;
-	padding-top: none;
+	padding-top: 0;
 	margin: 0em 0 0.3em 0; 
 }
 
 h1 {
-	font-size: 1.2em;
+	font-size: 2em;
 	font-weight: bold;
 	color: var(--grey-800);
 	display: block;
 	border-top: 1px solid var(--grey-200);
 	padding-top: 0.3em;
-	margin: 1.1em 0 0.3em 0; 
 }
 
 
@@ -78,32 +85,32 @@ h1:active {
 }
 
 h2 { 
-	font-size: 1em;
+	font-size: 1.5em;
 	font-weight: bold;
 	color: var(--grey-800);
 }
 
 h3 {
-	font-size: 1em;
+	font-size: 1.17em;
 	font-style: italic;
 	font-family: 'Spectral', serif;
 }
 
 h4 {
-	font-size: 0.7em;
+	font-size: 1em;
 	text-transform: lowercase;
 	font-family: 'Spectral SC', serif;
 	letter-spacing: 0.04em;
 }
 
 h5 {
-	font-size:0.68em;
+	font-size:0.83em;
 	font-family: 'Spectral', serif;
 	letter-spacing: 0.05em;
 }
 
 h6 {
-	font-size: 0.65em;
+	font-size: 0.67em;
 	font-family: 'Spectral', serif;
 	letter-spacing: 0.025em;
 }

--- a/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
@@ -202,6 +202,7 @@ p.error {
 h3 {
     text-transform: uppercase;
     font-weight: normal;
+    font-style: normal;
     font-size: 14px;
 }
 

--- a/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
@@ -76,9 +76,9 @@
 <form on:submit|preventDefault={submitForm} autocomplete="off" in:blur|local>
     <div class=container>
         <div class=panel> 
-            <h1>Database Connection</h1>
+            <h2>Database Connection</h2>
             <p>Evidence supports one database connection per project.</p>
-            <h2>Connection Type</h2>
+            <h3>Connection Type</h3>
             <select data-test-id='dbConnectionType' bind:value={selectedDatabase} on:change={databaseChange}>
             {#each databaseOptions as option}
                 <option data-test-id={option.id} id={option.id} value={option} label={option.name}>
@@ -195,7 +195,7 @@ p.error {
     word-break: break-all;
 }
 
-h2 {
+h3 {
     text-transform: uppercase;
     font-weight: normal;
     font-size: 14px;
@@ -221,7 +221,7 @@ h2 {
 
 .panel {
     border-top: 1px solid var(--grey-200);
-    padding:1.0em;
+    padding: 0em 1em 1em 1em;
 }
 
 .panel:first-of-type {

--- a/sites/example-project/src/components/ui/Deployment/DeploySettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Deployment/DeploySettingsPanel.svelte
@@ -46,6 +46,7 @@
         text-transform: uppercase;
         font-weight: normal;
         font-size: 14px;
+        font-style: normal;
     }
     select {
         -webkit-appearance: none;

--- a/sites/example-project/src/components/ui/Deployment/DeploySettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Deployment/DeploySettingsPanel.svelte
@@ -19,9 +19,9 @@
 <form>
 <div class=container>
     <div class=panel> 
-    <h1>Deployment</h1>
+    <h2>Deployment</h2>
     <p>Evidence projects can be deployed to a variety of cloud environments. If you haven't done this type of thing before, we would suggest using Netlify.</p>
-    <h2>Deployment Environment</h2>
+    <h3>Deployment Environment</h3>
     <select bind:value={selectedDeployment}>
         {#each deploymentOptions as option}
         <option value={option}>
@@ -42,7 +42,7 @@
 </footer>
 </form>
 <style>
-    h2 {
+    h3 {
         text-transform: uppercase;
         font-weight: normal;
         font-size: 14px;
@@ -84,7 +84,7 @@
 
     .panel {
         border-top: 1px solid var(--grey-200);
-        padding:1.0em;
+        padding: 0em 1em 1em 1em;
     }
 
     .panel:first-of-type {

--- a/sites/example-project/src/components/ui/Deployment/NetlifyDeploy.svelte
+++ b/sites/example-project/src/components/ui/Deployment/NetlifyDeploy.svelte
@@ -10,7 +10,7 @@
 <p>You'll need to set up a git repo before deploying to netlify.</p>
 {:else }
 
-<h1>Deploying to Netlify</h1>
+<h2>Deploying to Netlify</h2>
 
 <ol>
     <li><a href='https://app.netlify.com/start' target=_blank>Start a new netlify project &rarr;</a></li>

--- a/sites/example-project/src/components/ui/Deployment/OtherDeploy.svelte
+++ b/sites/example-project/src/components/ui/Deployment/OtherDeploy.svelte
@@ -4,7 +4,7 @@
     export let settings
 </script>
 
-<h1>Deploying your Project</h1>
+<h2>Deploying your Project</h2>
 
 <p>
     In production, Evidence functions like a static site generator: 

--- a/sites/example-project/src/components/ui/Deployment/VercelDeploy.svelte
+++ b/sites/example-project/src/components/ui/Deployment/VercelDeploy.svelte
@@ -10,7 +10,7 @@
 <p>You'll need to set up a git repo before deploying to Vercel.</p>
 {:else }
 
-<h1>Deploying to Vercel</h1>
+<h2>Deploying to Vercel</h2>
 
 <ol>
     <li><a href='https://vercel.com/new' target=_blank>Start a new Vercel project &rarr;</a></li>

--- a/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
@@ -11,7 +11,7 @@
 <div class="collapsibleSection">
   <collapsibleHeader>
     <button area-expanded={expanded} on:click|preventDefault={toggleExpanded}>
-      <h2>{headerText}</h2>
+      <h3>{headerText}</h3>
       <ChevronToggle toggled={expanded} size=16/>
     </button>
   </collapsibleHeader>
@@ -29,7 +29,7 @@
     vertical-align: middle;
   }
 
-  h2 {
+  h3 {
     margin: 0;
   }
 

--- a/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CollapsibleTableSection.svelte
@@ -31,6 +31,7 @@
 
   h3 {
     margin: 0;
+    font-style: normal;
   }
 
   button {

--- a/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
+++ b/sites/example-project/src/components/ui/Formatting/CustomFormatsSection.svelte
@@ -168,6 +168,7 @@
     width: 35%;
     text-transform: uppercase;
     font-weight: normal;
+    font-size: 14px;
     color: var(--grey-800);
   }
   button {

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -18,7 +18,7 @@ from table`
 <form>
   <div class="container">
     <div class="panel">
-      <h1>Value Formatting</h1>
+      <h2>Value Formatting</h2>
       <p>Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted in Evidence.</p><p>Apply format tags by including them at the end of column names. For example:</p> 
       <div class=code-container>
         <Prism language="sql" code={exampleQuery}/>
@@ -26,7 +26,7 @@ from table`
       <p></p>
     </div>
     <div class="panel">
-      <h1>Built in Format Tags</h1>
+      <h2>Built in Format Tags</h2>
       <p>All of the built in format tags are listed below for reference.</p>
       <CollapsibleTableSection headerText={"Dates"} expanded={false}>
         <BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter(d => d.formatCategory === "date")}/>
@@ -42,7 +42,7 @@ from table`
       </CollapsibleTableSection>
     </div>
     <div class="panel">
-      <h1>Custom Format Tags</h1>
+      <h2>Custom Format Tags</h2>
       <p>
         Add new format tags to your project. Custom format tags use <a class=docs-link target=none href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68">excel-style format codes.</a>
       </p>
@@ -76,7 +76,7 @@ from table`
   }
   .panel {
     border-top: 1px solid var(--grey-200);
-    padding: 1em;
+    padding: 0em 1em 1em 1em;
   }
 
   .panel:first-of-type {

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -93,8 +93,9 @@ aside.sidebar {
 }
 
 .project-title{
-		margin: 0 0 0.3em 0; 
-		padding-top: 0.2em;
+	font-size: 1.2em;	
+	margin: 0 0 0.3em 0; 
+	padding-top: 0.2em;
 	}
 .sticky {
     position: sticky;

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -95,7 +95,7 @@ aside.sidebar {
 .project-title{
 	font-size: 1.2em;	
 	margin: 0 0 0.3em 0; 
-	padding-top: 0.2em;
+	padding-top: 0.3em;
 	}
 .sticky {
     position: sticky;

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -26,7 +26,7 @@
 <aside class="sidebar" class:open>
     <div class="sticky">
         <div class=nav-header>
-            <a href='/' on:click={() => open = !open}><h1 class=project-title>Evidence</h1></a>
+            <a href='/' on:click={() => open = !open}><div class=project-title>Evidence</div></a>
         </div>
         <nav>
 			{#if folderList}
@@ -92,6 +92,13 @@ aside.sidebar {
     border-right: 1px solid var(--grey-300);
 }
 
+.project-title{
+		font-size: 1.2em;
+		font-weight: bold;
+		color: var(--grey-800);
+		margin: 0 0 0.3em 0; 
+		padding-top: 0.3em;
+	}
 .sticky {
     position: sticky;
     top: 0;
@@ -309,6 +316,7 @@ span.alert-icon {
 	aside.open {
 		left: 0;
 	}
+
 
 	div.nav-footer {
 		display: none ;

--- a/sites/example-project/src/components/ui/Sidebar.svelte
+++ b/sites/example-project/src/components/ui/Sidebar.svelte
@@ -26,7 +26,7 @@
 <aside class="sidebar" class:open>
     <div class="sticky">
         <div class=nav-header>
-            <a href='/' on:click={() => open = !open}><div class=project-title>Evidence</div></a>
+            <a href='/' on:click={() => open = !open}><h2 class=project-title>Evidence</h2></a>
         </div>
         <nav>
 			{#if folderList}
@@ -93,11 +93,8 @@ aside.sidebar {
 }
 
 .project-title{
-		font-size: 1.2em;
-		font-weight: bold;
-		color: var(--grey-800);
 		margin: 0 0 0.3em 0; 
-		padding-top: 0.3em;
+		padding-top: 0.2em;
 	}
 .sticky {
     position: sticky;

--- a/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
@@ -17,7 +17,7 @@
 <form>
 <div class=container>
     <div class=panel> 
-        <h1>Telemetry</h1>
+        <h2>Telemetry</h2>
         <p>Evidence collects anonymous usage data to help us understand how often the tool is being used.</p>
         <CollapsibleTableSection headerText="More" expanded={false}>
         <p>Each time you run a query, we get the following pieces of information:
@@ -63,7 +63,7 @@
 
     .panel {
         border-top: 1px solid var(--grey-200);
-        padding:1.0em;
+        padding: 0em 1em 1em 1em;
     }
 
     .panel:first-of-type {

--- a/sites/example-project/src/components/ui/VersionControl/VersionControlPanel.svelte
+++ b/sites/example-project/src/components/ui/VersionControl/VersionControlPanel.svelte
@@ -12,7 +12,7 @@
 <div class=container>
 
     <div class=panel> 
-    <h1>Version Control</h1>
+    <h2>Version Control</h2>
         Use version control to keep track of changes to your project. A published git repo is needed if you want to deploy your Evidence project online.
     
         <div class=git-item>
@@ -81,7 +81,7 @@
 
     .panel {
         border-top: 1px solid var(--grey-200);
-        padding:1.0em;
+        padding: 0em 1em 1em 1em;
     }
 
     .panel:first-of-type {

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -132,20 +132,20 @@
 
     .title {
         font-size: 0.8em;
-        font-weight: bold;
+        font-weight: 500;
         color: var(--grey-700);
         text-shadow: 1px solid white;
     }
 
     .value{
         font-size: 1.2em;
-        font-weight: bold;
+        font-weight: 500;
         color: var(--grey-700);
     }
 
     .comparison{
         font-size: .65em;
-        font-weight: bold;
+        font-weight: 500;
         font-family: var(--ui-compact-font-family);
     }
 

--- a/sites/example-project/src/pages/text-and-metrics/markdown.md
+++ b/sites/example-project/src/pages/text-and-metrics/markdown.md
@@ -10,32 +10,32 @@
 
 ##### Heading Level 5
 
-# Lists
-## Unordered List
+## Lists
+### Unordered List
 - Item 1
 - Item 2
 - Item 3
 
-## Unordered List with Sub-items
+### Unordered List with Sub-items
 - Item 1
   - Sub-item A
   - Sub-item B
 - Item 2
 - Item 3
 
-## Ordered List
+### Ordered List
 1. Item 1
 1. Item 2
 1. Item 3
 
-## Ordered List with Sub-items
+### Ordered List with Sub-items
 1. Item 1
    1. Sub-item A
    1. Sub-item B
 1. Item 2
 1. Item 3
 
-# Text Decoration
+## Text Decoration
 **Bold**  
 *Italic*  
 ~~Strikethrough~~  
@@ -47,7 +47,7 @@ Text<sub>subscript</sub>
 ## Highlighting
 This is how you <mark>highlight some text.</mark>
 
-# Blockquotes
+## Blockquotes
 
 > This is a blockquote.
 
@@ -60,23 +60,23 @@ It can be nice to be able to use italics selectively in blockquotes
 >
 > -- _Garfield_
 
-# Code
+## Code
 `let x = 100`
 
-# Horizontal Rule
+## Horizontal Rule
 Three asterisks create a horizontal rule:
 ***
 
-# Links
+## Links
 Link to [Google](https://google.com)
 
-# URLs & Email Addresses
+## URLs & Email Addresses
 <https://google.com>  
 <fake@example.com>
 
-# Images
+## Images
 ![fav](/favicon.ico)
-# Tables
+## Tables
 | Column One | Column Two | Column Three |
 |:----------:|:----------:|:----------:|
 | A | B | C |

--- a/sites/example-project/src/pages/text-and-metrics/markdown.md
+++ b/sites/example-project/src/pages/text-and-metrics/markdown.md
@@ -10,6 +10,8 @@
 
 ##### Heading Level 5
 
+###### Heading Level 6
+
 ## Lists
 ### Unordered List
 - Item 1

--- a/sites/example-project/src/pages/text-and-metrics/text.md
+++ b/sites/example-project/src/pages/text-and-metrics/text.md
@@ -12,7 +12,7 @@ inter retinentibus inaniter pontum! `pages/index.md`
 
 
 
-## Pascua tigres inde
+### Pascua tigres inde
 
 Domino cuncta dicenda. Serpente paludem et nubes Cithaeron alios mihi non.
 
@@ -23,7 +23,7 @@ Domino cuncta dicenda. Serpente paludem et nubes Cithaeron alios mihi non.
 - Et vocem inquit
 - Dum aequi Xanthique minantia nec taurum
 
-## Aniles orantem Saeculaque pars a aetas nostrum
+#### Aniles orantem Saeculaque pars a aetas nostrum
 
 Opposuitque solis ausis vivo est adventum rudis, nunc fuerant: si
 [laedi](http://sic-conamine.org/), et. Nostro verba et celer purpura utraque

--- a/sites/example-project/src/pages/text-and-metrics/value-component.md
+++ b/sites/example-project/src/pages/text-and-metrics/value-component.md
@@ -8,7 +8,7 @@ select 1000 as total_sales_usd
 
 The successful value metric is <Value data={summary}/> and shows up inline.
 
-# Value Errors
+## Value Errors
 
 Errors in the Value component are inlined into your text. Here's an example of an empty Value tag: <Value/> which will return an error, but will stay within your text. You can hover over the error to see an error message describing the problem.
 
@@ -19,7 +19,7 @@ Errors in the Value component are inlined into your text. Here's an example of a
 * Non-existent row with correct column: <Value data={summary} column=total_calls row=20/>
 * Wrong query result name: error `abc is not defined` will appear at page-level
 
-# Value Placeholders
+## Value Placeholders
 If you like to mock up reports before you're ready to fill in real data, you can also override the Value error with a **placeholder**. Input the text you want to use as your placeholder and it will appear in blue font with square brackets, inline with your text.
 
 Here are a few examples of placeholders: 


### PR DESCRIPTION
## Why?
- We've had feedback that there isn't enough distinction between some of our H1 - H6 styles. 
- H3 and below are not very useful as they are not very visualy distinct from `<p>` text size wise.
- Sub-lists contain gaps after final bullet that breaks list flow

## What?
This contains some **reasonably major stylistic updates** to the default styling of Evidence projects:
- **More visual contrast between H1 - H6 using sizes**: This brings Evidence in line with [more typical web standards](https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings) for reading
- Removing margin after sub-lists
- Adding slight margin separating list items

## Questions

- This will change how H1 tags should be used. It will now probably not be suitable to use aside from the top of a page. (and instead use H2s) Does this matter?
- The overall change will increase the vertical space occupied by headings (especially H1, H2), which somewhat reduces the information density. Is this trade off worth it?


### Headings

Before:

<img width="1328" alt="CleanShot 2022-11-29 at 10 18 19@2x" src="https://user-images.githubusercontent.com/58074498/204598686-4528ee26-1f31-4a60-a91b-592f8cfeb4d8.png">

After:

<img width="1412" alt="CleanShot 2022-11-29 at 10 19 13@2x" src="https://user-images.githubusercontent.com/58074498/204598740-fb720443-3302-42e4-b522-4ab0b299159c.png">

### Lists: 

Before: 

<img width="683" alt="image" src="https://user-images.githubusercontent.com/58074498/204599616-79542db7-f962-49b4-9bb4-185b7b3aa9c7.png">

After:

<img width="735" alt="image" src="https://user-images.githubusercontent.com/58074498/204599432-6dc0a175-9de8-4517-913c-c0cc020d0a20.png">


