### PR TITLE
Optional schema field for postgres connector

### DIFF
--- a/.changeset/pretty-knives-attend.md
+++ b/.changeset/pretty-knives-attend.md
@@ -1,0 +1,6 @@
+---
+"@evidence-dev/postgres": patch
+"@evidence-dev/components": patch
+---
+
+Adds optional schema field for postgres connector

--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -114,6 +114,14 @@ const runQuery = async (queryString, database) => {
         })
 
         var pool = new Pool(credentials);
+
+        // Set schema if specified. Can't be done using the connection string / credentials. See issue: https://github.com/brianc/node-postgres/issues/1123#issuecomment-501510375 & solution: https://node-postgres.com/apis/pool#events
+        const schema = database ? database.schema : process.env["POSTGRES_SCHEMA"] || process.env["schema"] || process.env["SCHEMA"];
+        if (schema) {
+            pool.on('connect', (client) => {
+                client.query(`SET search_path TO ${schema}`)
+            })
+        }
         var result = await pool.query(queryString)
 
         const standardizedRows = await standardizeResult(result.rows);

--- a/sites/example-project/src/components/ui/Databases/PostgresForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/PostgresForm.svelte
@@ -52,7 +52,17 @@
 			placeholder: '5432',
 			value: credentials.port ?? ''
 		},
+		{
+			id: 'schema',
+			label: 'Schema',
+			type: 'text',
+			optional: true,
+			override: false,
+			placeholder: 'public',
+			value: credentials.schema ?? '',
+			additionalInstructions: 'The default schema to run queries against.'
 
+		},
 		{
 			id: 'ssl',
 			label: 'SSL',


### PR DESCRIPTION
## Context:
- Some users separate production and development data environments using different schemas.
- Currently, you have to specify the schema you are referencing per query. 
   - This means there is no easy way to have the change the schema, would resort to a find-replace or similar

## Solution:
Add a config option that lets a user specify a default schema either with:
- The settings UI (suitable for dev environments)

<img width="600" alt="image" src="https://user-images.githubusercontent.com/58074498/206563373-220a6358-d9f8-4329-97ee-074e314cc824.png">

- An env variable (suitable for production environments)

<img width="600" alt="image" src="https://user-images.githubusercontent.com/58074498/206563856-557da37b-0734-4f63-90bf-0b6b65ee6a8d.png">

## Note:
- Should add schema support for other databases in the future