### PR TITLE
add max-width to BigValue titles

### DIFF
--- a/.changeset/purple-cherries-begin.md
+++ b/.changeset/purple-cherries-begin.md
@@ -1,0 +1,6 @@
+---
+"evidence-docs": minor
+"@evidence-dev/components": minor
+---
+
+Add maxWidth and minWidth style props to BigValue component. Default set for minWidth to give smaller BigValues more room.

--- a/sites/docs/docs/features/charts/big-value.md
+++ b/sites/docs/docs/features/charts/big-value.md
@@ -16,7 +16,7 @@ hide_table_of_contents: false
     comparison='monthly_growth' 
     sparkline='date'
     comparisonTitle="Month over Month"
-    --max-width='1em'
+    maxWidth='10em'
 /> 
 ```
 
@@ -37,8 +37,8 @@ Multiple cards will align themselves into a row.
 * **title** - (Optional) title of the card. Defaults to the title of the value column.
 * **comparisonTitle** - (Optional) text to the right of the comparison. Defaults to the title of the comparison column.
 * **downIsGood** - (Optional) if present, negative comparison values appear in green, and positive values appear in red. 
-* **--min-width** - (Optional) overrides min-width of component, 25% by default. 
-* **--max-width** - (Optional) adds a max-width to the component, none by default. 
+* **minWidth** - (Optional) overrides min-width of component, 18% by default. 
+* **maxWidth** - (Optional) adds a max-width to the component, none by default. 
 
 
 

--- a/sites/docs/docs/features/charts/big-value.md
+++ b/sites/docs/docs/features/charts/big-value.md
@@ -16,6 +16,7 @@ hide_table_of_contents: false
     comparison='monthly_growth' 
     sparkline='date'
     comparisonTitle="Month over Month"
+    --max-width='1em'
 /> 
 ```
 
@@ -36,7 +37,8 @@ Multiple cards will align themselves into a row.
 * **title** - (Optional) title of the card. Defaults to the title of the value column.
 * **comparisonTitle** - (Optional) text to the right of the comparison. Defaults to the title of the comparison column.
 * **downIsGood** - (Optional) if present, negative comparison values appear in green, and positive values appear in red. 
-
+* **--min-width** - (Optional) overrides min-width of component, 25% by default. 
+* **--max-width** - (Optional) adds a max-width to the component, none by default. 
 
 
 

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -103,10 +103,10 @@
 
 
 <style>
-	:root {
+    :root {
         --min-width: 25%;
         --max-width: none;
-	}
+    }
     :global(.sparkline svg) {
         height: 16px;
     }

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -90,11 +90,11 @@
         {/if}
     </div> 
     {#if comparison}
-        <p class=comparison style={`color:${comparisonColor}`}> 
+        <div class=comparison style={`color:${comparisonColor}`}> 
             {@html positive ? "&#9650;" : "&#9660;"} 
-            <Value {data} column={comparison}/> 
-            <span class="comparison-type">{comparisonTitle}</span>
-        </p> 
+            <p><Value {data} column={comparison}/></p>
+            <p class="comparison-type">{comparisonTitle}</p>
+        </div> 
     {/if}
     {/if}
 </div>  
@@ -137,13 +137,14 @@
         text-shadow: 1px solid white;
     }
 
-    .value{
+    .value {
         font-size: 1.2em;
         font-weight: bold;
         color: var(--grey-700);
     }
 
-    .comparison{
+    .comparison {
+        display: flex;
         font-size: .65em;
         font-weight: bold;
         font-family: var(--ui-compact-font-family);
@@ -152,6 +153,8 @@
     .comparison-type {
         color: var(--grey-700);
         font-weight: normal;
+        max-width: 15em;
+        margin-left: 0.5em;
     }
 
 </style> 

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -11,11 +11,15 @@
     export let comparison = null
     export let sparkline = null 
 
-    export let title =  null
+    export let title = null
     export let comparisonTitle = null 
 
     // Delta controls 
     export let downIsGood = false
+
+    export let maxWidth = "none"
+    export let minWidth = "18%"
+
     let positive = true
     let comparisonColor = "var(--grey-700)"
 
@@ -65,7 +69,13 @@
 </script>
 
 
-<div class=container>
+<div
+    class=container 
+    style={`
+        min-width: ${minWidth};
+        max-width: ${maxWidth};
+    `}
+>
     {#if error}
     <ErrorChart chartType="Big Value" error={error.message}/>
     {:else}
@@ -99,14 +109,7 @@
     {/if}
 </div>  
 
-
-
-
 <style>
-    :root {
-        --min-width: 25%;
-        --max-width: none;
-    }
     :global(.sparkline svg) {
         height: 16px;
     }
@@ -129,8 +132,6 @@
         user-select: none;
         -webkit-user-select:none ;
         vertical-align:top;
-        min-width: var(--min-width);
-        max-width: var(--max-width);
     }
     p {
         margin: 0;

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -90,11 +90,11 @@
         {/if}
     </div> 
     {#if comparison}
-        <div class=comparison style={`color:${comparisonColor}`}> 
+        <p class=comparison style={`color:${comparisonColor}`}> 
             {@html positive ? "&#9650;" : "&#9660;"} 
-            <p><Value {data} column={comparison}/></p>
-            <p class="comparison-type">{comparisonTitle}</p>
-        </div> 
+            <Value {data} column={comparison}/>
+            <span class="comparison-type">{comparisonTitle}</span>
+        </p> 
     {/if}
     {/if}
 </div>  
@@ -124,7 +124,9 @@
         align-items: center;
         user-select: none;
         -webkit-user-select:none ;
-        vertical-align:top; 
+        vertical-align:top;
+        min-width: 25%;
+        max-width: 1em;
     }
     p {
         margin: 0;
@@ -153,7 +155,6 @@
     .comparison-type {
         color: var(--grey-700);
         font-weight: normal;
-        max-width: 15em;
         margin-left: 0.5em;
     }
 

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -103,6 +103,10 @@
 
 
 <style>
+	:root {
+        --min-width: 25%;
+        --max-width: none;
+	}
     :global(.sparkline svg) {
         height: 16px;
     }
@@ -125,8 +129,8 @@
         user-select: none;
         -webkit-user-select:none ;
         vertical-align:top;
-        min-width: 25%;
-        max-width: 1em;
+        min-width: var(--min-width);
+        max-width: var(--max-width);
     }
     p {
         margin: 0;

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -146,7 +146,6 @@
     }
 
     .comparison {
-        display: flex;
         font-size: .65em;
         font-weight: bold;
         font-family: var(--ui-compact-font-family);
@@ -155,7 +154,6 @@
     .comparison-type {
         color: var(--grey-700);
         font-weight: normal;
-        margin-left: 0.5em;
     }
 
 </style> 


### PR DESCRIPTION
Resolves #494 

- Add a max-width to BigValue comparison titles
- Left align title to end of Value rather than start

Before:
<img width="578" alt="Screen Shot 2022-12-09 at 12 41 16 AM" src="https://user-images.githubusercontent.com/14843458/206632424-19892460-706f-427f-9be1-a7af4686c6a9.png">

After:
<img width="593" alt="Screen Shot 2022-12-09 at 12 40 40 AM" src="https://user-images.githubusercontent.com/14843458/206632827-9318f43d-1f64-4e3c-8fbe-da0e65a1d460.png">



