### PR TITLE
Add a11y to QueryViewer, DownloadData, BreadCrumbs, ECharts, DataTable Components

### DIFF
--- a/.changeset/nice-ghosts-stare.md
+++ b/.changeset/nice-ghosts-stare.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Add accessibility to QueryViewer, DataTable, BreadCrumbs, ECharts, and DownloadData

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -59,9 +59,9 @@
         {#if $pageHasQueries}
             <span transition:blur|local>
                 {#if $showQueries}
-                <button class="dev-controls hide" on:click={toggleQueries}>Hide Queries</button>
+                <button type="button" class="dev-controls hide" on:click={toggleQueries}>Hide Queries</button>
                 {:else}
-                <button class="dev-controls show" on:click={toggleQueries}>Show Queries</button>
+                <button type="button" class="dev-controls show" on:click={toggleQueries}>Show Queries</button>
                 {/if}
             </span>
         {/if}

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -59,9 +59,9 @@
         {#if $pageHasQueries}
             <span transition:blur|local>
                 {#if $showQueries}
-                <span class="dev-controls hide" on:click={toggleQueries}>Hide Queries</span>
+                <button class="dev-controls hide" on:click={toggleQueries}>Hide Queries</button>
                 {:else}
-                <span class="dev-controls show" on:click={toggleQueries}>Show Queries</span>
+                <button class="dev-controls show" on:click={toggleQueries}>Show Queries</button>
                 {/if}
             </span>
         {/if}
@@ -69,7 +69,7 @@
 </div>
 
 <style>
-    div{
+    div {
         padding: 0 0.5em 0 1.5em;
         box-sizing: border-box;
         width: 100%;
@@ -79,33 +79,34 @@
   		scrollbar-width: none;  
     }
 
-    span.container{
+    span.container {
         display: flex;
         justify-content: space-between;
+        align-items: center;
     }
 
-    span{
+    span, button {
         font-size: small;
         font-family: var(--ui-font-family-compact);
         -webkit-font-smoothing: antialiased;
         color:var(--grey-700)
     }
 
-    a{
+    a {
         text-transform: capitalize;
         text-decoration: none;
         color: var(--grey-700);
     }
-    a:hover{
+    a:hover {
         color:var(--grey-999);
         transition:all 0.2s;
     }
 
-    span.dev-controls {
+    button.dev-controls {
         float: right;
         text-align: center;
-        margin: 0 0 0 1.5em; 
-        padding: 0.05em 0.25em 0.05em 0.25em;
+        margin: 0 0 0 1.5em;
+        padding: 0.25em 1em 0.25em 1em;
         border: 1px solid var(--grey-300);
         border-radius: 3px;
         font-size: 0.8em;
@@ -115,16 +116,16 @@
         -webkit-user-select: none;
         -moz-user-select: none;
         -webkit-font-smoothing: antialiased;
-        width: 8em;
+        width: 9em;
         transition:box-shadow 350ms;
     }
 
-    span.dev-controls:hover{
+    button.dev-controls:hover {
         box-shadow: 0 5px 5px 2px var(--grey-100);
         transition:all 350ms;
     }
 
-    span.dev-controls.show{
+    button.dev-controls.show {
 		background: -webkit-linear-gradient(315deg, var(--blue-600) 0%, var(--green-600) 75%);
         text-decoration: none;
 		-webkit-background-clip: text;
@@ -134,7 +135,7 @@
      }
 
      @media (max-width: 600px) {
-        span.dev-controls {
+        button.dev-controls {
             display: none;
         }
     }

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -104,6 +104,7 @@
 
     button.dev-controls {
         float: right;
+        background-color: transparent;
         text-align: center;
         margin: 0 0 0 1.5em;
         padding: 0.25em 1em 0.25em 1em;
@@ -139,9 +140,5 @@
             display: none;
         }
     }
-     
-
-
-
 
 </style>

--- a/sites/example-project/src/components/ui/DownloadData.svelte
+++ b/sites/example-project/src/components/ui/DownloadData.svelte
@@ -3,11 +3,7 @@
 
     export let data;
     export let queryID;
-    export let onHover = false;
-    export let hovering;
-
-
-    function downloadData(data) {
+    export let downloadData = (data) => {
         const options = { 
             fieldSeparator: ',',
             quoteStrings: '"',
@@ -22,15 +18,15 @@
  
         const csvExporter = new ExportToCsv(options);
       
-        csvExporter.generateCsv(data);
+        csvExporter.generateCsv(data);     
     }
 
 </script>
 
-<span class=download-icon class:download-icon-hidden={onHover} class:active={hovering} on:click={downloadData(data)}>
+<button class={$$props.class} on:click={downloadData(data)}>
     <span>Download</span>
     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
-</span>
+  </button>
 
 <style>
     svg {
@@ -39,15 +35,13 @@
         margin-bottom: auto;
     }
 
-    .download-icon {
+    button {
         display: grid;
         grid-row: auto;
         grid-template-columns: auto auto;
         gap: 3px;
         float: right;
         /* margin-left: 5px; */
-        margin-top: 3px;
-        margin-right: 7px;
         cursor: pointer;
         font-family: sans-serif;
         font-size: 0.7rem;
@@ -55,26 +49,20 @@
         vertical-align: text-top;
         justify-items: center;
         position:relative;
+        background-color: transparent;
+        border: none;
     }
 
-    .download-icon-hidden {
-        visibility: hidden;
-    }
-
-    .download-icon:hover {
+    button:hover {
         color: var(--grey-500);
     }
 
-    .download-icon:hover svg {
+    button:hover svg {
         stroke: var(--grey-500);
     }
-
-    .active {
-        visibility: visible;
-    }
-
+    
     @media print {
-        .download-icon {
+        button {
             display: none;
         }
     }

--- a/sites/example-project/src/components/ui/DownloadData.svelte
+++ b/sites/example-project/src/components/ui/DownloadData.svelte
@@ -23,7 +23,7 @@
 
 </script>
 
-<button class={$$props.class} on:click={downloadData(data)}>
+<button type="button" class={$$props.class} on:click={downloadData(data)}>
     <span>Download</span>
     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
   </button>

--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -71,7 +71,7 @@
     <!-- Title -->
     <div class="container" transition:slide|local>
       <div class="container-a">
-        <button on:click={toggleSQL} class="title">
+        <button type="button" on:click={toggleSQL} class="title">
           <ChevronToggle toggled={$showSQL}/> {queryID}
         </button>
         <!-- Compile Toggle  -->
@@ -90,7 +90,7 @@
           {/if}
       </div>
       <!-- Status -->
-      <button class = {"status-bar" + (error ? " error": " success") + ($showResults ? " open": " closed")} on:click={toggleResults}>
+      <button type="button" class = {"status-bar" + (error ? " error": " success") + ($showResults ? " open": " closed")} on:click={toggleResults}>
           {#if error}
             {#if dev && error.message === "Missing database credentials"}
               {error.message}.

--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -71,9 +71,9 @@
     <!-- Title -->
     <div class="container" transition:slide|local>
       <div class="container-a">
-        <div on:click={toggleSQL} class="title">
-          <span><ChevronToggle toggled={$showSQL}/> {queryID}</span>
-        </div>
+        <button on:click={toggleSQL} class="title">
+          <ChevronToggle toggled={$showSQL}/> {queryID}
+        </button>
         <!-- Compile Toggle  -->
           {#if $showSQL && showCompilerToggle}
             <CompilerToggle bind:showCompiled = {showCompiled}/>
@@ -90,8 +90,7 @@
           {/if}
       </div>
       <!-- Status -->
-      <div class = {"status-bar" + (error ? " error": " success") + ($showResults ? " open": " closed")} on:click={toggleResults}>  
-        <span> 
+      <button class = {"status-bar" + (error ? " error": " success") + ($showResults ? " open": " closed")} on:click={toggleResults}>
           {#if error}
             {#if dev && error.message === "Missing database credentials"}
               {error.message}.
@@ -104,9 +103,8 @@
           {:else}
               ran successfully but no data was returned
           {/if}
-        </span>  
       <!-- Results -->
-      </div>
+      </button>
         {#if queryResult.length > 0 && !error && $showResults}
             <DataTable data={queryResult} {queryID}/>
         {/if}
@@ -224,29 +222,31 @@
       color: var(--blue-700);
     }
 
-    div.title {
-        border-top-left-radius: 6px;
-        border-top-right-radius: 6px;
+    button {
+        font-family: var(--ui-font-family-compact);
+        -webkit-font-smoothing: antialiased;
+        font-size: 12px; 
+        -webkit-user-select: none;
+        user-select: none;
+        white-space:nowrap;
+        text-align: left;
+        width: 100%;
         background-color: var(--grey-100);
-        border-top: 1px solid var(--grey-200);
+        border: none;
         border-left: 1px solid var(--grey-200);
         border-right: 1px solid var(--grey-200);
         margin-bottom: 0px;
         cursor: pointer;
+        padding: 5px;
     }
 
-    span{
-        font-family: var(--ui-font-family-compact);
-        -webkit-font-smoothing: antialiased;
-        font-size: 12px; 
-        padding: 0 6px;
-        -webkit-user-select: none;
-        user-select: none;
-        white-space:nowrap;
-
+    button.title {
+      border-top: 1px solid var(--grey-200);
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px;
     }
 
-    div.results {
+    button.results {
         padding:0.3em 0.6em;
         margin-top: 0px;
         background-color: white;

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -105,7 +105,7 @@
 </div>
 {/if}
 
-<DownloadData {data} {queryID} />
+<DownloadData class=download-button {data} {queryID} />
 
 </div>
 
@@ -171,7 +171,6 @@ span {
   -webkit-font-smoothing: antialiased;
   font-size: 0.8em;
   float: right;
-
 }
 
 
@@ -192,29 +191,33 @@ span {
   background-color: white;
 }
 
-  .container::-webkit-scrollbar {
-    height: var(--scrollbar-size);
-    width: var(--scrollbar-size);
-  }
-  .container::-webkit-scrollbar-track {
-    background-color: var(--scrollbar-track-color);
-  }
-  .container::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-color);
-    border-radius: 7px;
-    background-clip: padding-box;
-  }
-  .container::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-active-color);
-  }
-  .container::-webkit-scrollbar-thumb:vertical {
-    min-height: var(--scrollbar-minlength);
-    border: 3px solid transparent;
-  }
-  .container::-webkit-scrollbar-thumb:horizontal {
-    min-width: var(--scrollbar-minlength);
-    border: 3px solid transparent;
-  }
+.container::-webkit-scrollbar {
+  height: var(--scrollbar-size);
+  width: var(--scrollbar-size);
+}
+.container::-webkit-scrollbar-track {
+  background-color: var(--scrollbar-track-color);
+}
+.container::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-color);
+  border-radius: 7px;
+  background-clip: padding-box;
+}
+.container::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-active-color);
+}
+.container::-webkit-scrollbar-thumb:vertical {
+  min-height: var(--scrollbar-minlength);
+  border: 3px solid transparent;
+}
+.container::-webkit-scrollbar-thumb:horizontal {
+  min-width: var(--scrollbar-minlength);
+  border: 3px solid transparent;
+}
+
+.results-pane :global(.download-button) {
+  margin-top: 10px;
+}
 
 table{
   width:100%;

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -188,7 +188,7 @@
         </div>
       {/if}
     </div>
-    <DownloadData {data} {queryID} onHover={true} {hovering} />
+    <DownloadData class=download-button {data} {queryID} />
   </div>
 {:else}
   <ErrorChart {error} chartType="Data Table" />
@@ -249,12 +249,13 @@
     line-height: 2em;
   }
 
-  span {
-    font-family: var(--ui-font-family-compact);
-    -webkit-font-smoothing: antialiased;
-    font-size: 0.8em;
-    float: right;
-    color: grey;
+  .table-container :global(.download-button) {
+    visibility: hidden;
+  }
+
+  .table-container:hover :global(.download-button) {
+    visibility: visible;
+    margin-top: 10px;
   }
 
   .container {

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -258,6 +258,14 @@
     margin-top: 10px;
   }
 
+  span {
+    font-family: var(--ui-font-family-compact);
+    -webkit-font-smoothing: antialiased;
+    font-size: 0.8em;
+    float: right;
+    color: grey;
+  }
+
   .container {
     width: 100%;
     overflow-x: auto;

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -33,10 +33,10 @@
 
 <EchartsCopyTarget {config} {height} {width} {copying}/> 
 
-<span class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}}>
+<button class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}}>
   <span>Download</span>
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
-</span>
+</button>
 
 </div>
 
@@ -111,6 +111,8 @@
       vertical-align: text-top;
       justify-items: center;
       position:relative;
+      background-color: transparent;
+      border: none;
   }
 
   .download-icon:hover {

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -2,6 +2,7 @@
     import echarts from "$lib/modules/echarts";
     import echartsCanvasDownload from "$lib/modules/echartsCanvasDownload";
     import EchartsCopyTarget from "./EchartsCopyTarget.svelte";
+    import DownloadData from "../ui/DownloadData.svelte";
 
     export let config = undefined;    
 
@@ -33,10 +34,7 @@
 
 <EchartsCopyTarget {config} {height} {width} {copying}/> 
 
-<button class=download-icon on:click={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}}>
-  <span>Download</span>
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
-</button>
+<DownloadData class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}} />
 
 </div>
 
@@ -63,10 +61,6 @@
       break-inside: avoid;
     }
 
-    .download-icon {
-      display: none;
-    }
-
     .chart-container {
       padding: 0;
     }
@@ -83,43 +77,13 @@
     padding-bottom: 15px;
   }
 
-  .chart-container:hover .download-icon {
+  .chart-container :global(.download-button) {
+    visibility: hidden;
+  }
+
+  .chart-container:hover :global(.download-button) {
     visibility: visible;
+    margin-top: -10px;
+    margin-right: 16px;
   }
-
-
-  svg {
-      stroke: var(--grey-400);
-      margin-top: auto;
-      margin-bottom: auto;
-  }
-
-  .download-icon {
-      visibility: hidden;
-      display: grid;
-      grid-row: auto;
-      grid-template-columns: auto auto;
-      gap: 3px;
-      float: right;
-      /* margin-left: 5px; */
-      margin-top: -10px;
-      margin-right: 16px;
-      cursor: pointer;
-      font-family: sans-serif;
-      font-size: 0.7rem;
-      color: var(--grey-400);
-      vertical-align: text-top;
-      justify-items: center;
-      position:relative;
-      background-color: transparent;
-      border: none;
-  }
-
-  .download-icon:hover {
-      color: var(--grey-500);
-  }
-  .download-icon:hover svg {
-      stroke: var(--grey-500);
-  }
-
 </style>


### PR DESCRIPTION
### Description
Part of #489 

Most of these changes involved replacing `spans` with `button` tags and then styling them to match as they were before.

### DownloadData
Turned into a button for a11y.
Made `downloadData` function a prop w/ default.
Hover effect for DownloadData now through CSS in the parent component.
Updated ECharts and DataTable to both use DownloadData, both should still download the appropriate files for the user.


Before (ECharts):

https://user-images.githubusercontent.com/14843458/207218051-c8f5def8-5b56-44fd-a167-e1cb6bbc8f24.mov

After (ECharts):

https://user-images.githubusercontent.com/14843458/207218250-41123c2e-6bbf-42d7-8788-9ec207235f69.mov

Before (DataTable):

https://user-images.githubusercontent.com/14843458/207218701-9dc4aa0c-457f-4cff-b783-793ea3556103.mov

After (DataTable):

https://user-images.githubusercontent.com/14843458/207360872-9d3476c5-a1eb-4579-9fc6-13ca49c75012.mov

### BreadCrumbs
Updated 'Show/Hide Query' to be a11y and is now a button.

Before:

https://user-images.githubusercontent.com/14843458/207219412-733200af-fbc8-47ac-aef1-134a5fa09981.mov

After:

https://user-images.githubusercontent.com/14843458/207219521-726590e6-687d-4656-a92e-e2c42d5aad7a.mov

### QueryViewer
Updated to be a11y and is also now using buttons.

Before:

https://user-images.githubusercontent.com/14843458/207220000-ab9c934b-02e1-4163-b0bd-6ae0870b59a6.mov

After:

https://user-images.githubusercontent.com/14843458/207220121-8b0faec4-ebfb-403f-9242-fcd3fcac0e0c.mov


