### PR TITLE
Add port and ssl options to mysql form

### DIFF
--- a/.changeset/stupid-guests-juggle.md
+++ b/.changeset/stupid-guests-juggle.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Add port and ssl options to MySQL form

--- a/sites/example-project/src/components/ui/Databases/MysqlForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/MysqlForm.svelte
@@ -10,6 +10,8 @@
         database: credentials.database,
         user: credentials.user,
         password: credentials.password,
+        port: credentials.port,
+        ssl: credentials.ssl,
         socketPath: credentials.socketPath
     }
 
@@ -49,6 +51,24 @@
             override: false,
             placeholder: "password", 
             value: credentials.password ?? ""
+        },
+        {
+            id: "port", 
+            label: "Port", 
+            type: "text", 
+            optional: true, 
+            override: false,
+            placeholder: "3306", 
+            value: credentials.port ?? ""
+        },
+        {
+            id: "ssl", 
+            label: "SSL", 
+            type: "text", 
+            optional: true, 
+            override: false,
+            placeholder: "true", 
+            value: credentials.ssl ?? ""
         },
         {
             id: "socketPath", 


### PR DESCRIPTION
### Description
This PR adds options for `port` and `ssl` to the MySQL database connector form on the Settings page. These options are a part of our MySQL connector, but I missed them when I added options to the settings form the first time. Thanks @hooopo for pointing this out.

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

### Before
<img width="777" alt="CleanShot 2022-12-13 at 16 49 11@2x" src="https://user-images.githubusercontent.com/12602440/207451255-93f1e029-0b3e-452a-b003-d512e5fe70b5.png">

### After
<img width="769" alt="CleanShot 2022-12-13 at 16 48 37@2x" src="https://user-images.githubusercontent.com/12602440/207451264-a8f82a1a-e157-4a75-b529-cba48a23772a.png">
