### PR TITLE
Fix `formatTitle` function regex

### DIFF
--- a/.changeset/famous-bats-change.md
+++ b/.changeset/famous-bats-change.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Bug fix for column title formatting

--- a/sites/example-project/src/components/modules/formatTitle.js
+++ b/sites/example-project/src/components/modules/formatTitle.js
@@ -18,7 +18,7 @@ export default function formatTitle(column, columnFormat) {
     // Set name to proper casing:
     function toTitleCase(str) {
         return str.replace(
-        /\w\S*/g,
+        /\S*/g,
         function(txt) {
             if(!acronyms.includes(txt) && !lowercase.includes(txt)){
                 return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();


### PR DESCRIPTION
### Description
The `formatTitle` function currently only looks for A-Z characters when capitalizing column title names. This PR fixes the regex to allow for any characters in the column name to be recognized by the function.

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

### Before
<img width="608" alt="CleanShot 2022-12-12 at 12 38 35@2x" src="https://user-images.githubusercontent.com/12602440/207622761-114ae97f-1695-4aac-be81-7899ca3e96bb.png">

### After
<img width="610" alt="CleanShot 2022-12-12 at 16 37 36@2x" src="https://user-images.githubusercontent.com/12602440/207622788-027d0f37-f21f-40fb-bf8c-f72e7f818d38.png">

