### PR TITLE
fix: corrected install command

### DIFF
--- a/.changeset/fifty-mangos-sneeze.md
+++ b/.changeset/fifty-mangos-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+fix install command

--- a/sites/example-project/src/components/ui/Deployment/VercelDeploy.svelte
+++ b/sites/example-project/src/components/ui/Deployment/VercelDeploy.svelte
@@ -34,7 +34,7 @@
 
 <div class='setting-row'>
     <span class='setting'>Install Command</span>  
-    <div class='setting-value'><VariableCopy text={'build/'}/> </div>
+    <div class='setting-value'><VariableCopy text={'npm install'}/> </div>
 </div>
 
 


### PR DESCRIPTION
### Description
Fix install command which previously said "build/"

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)


After: 
<img width="787" alt="image" src="https://user-images.githubusercontent.com/58074498/207641068-957906cc-36d8-4e8c-b368-1849ed3c4652.png">
