### PR TITLE
Fix/documentation footer

### DIFF
--- a/.changeset/rude-fans-learn.md
+++ b/.changeset/rude-fans-learn.md
@@ -1,0 +1,5 @@
+---
+"evidence-docs": patch
+---
+
+Footer alignment was corrected

--- a/sites/docs/src/theme/Footer/index.js
+++ b/sites/docs/src/theme/Footer/index.js
@@ -4,15 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import {useThemeConfig} from '@docusaurus/theme-common';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './styles.module.css';
-import ThemedImage from '@theme/ThemedImage';
+import React from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import { useThemeConfig } from "@docusaurus/theme-common";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import styles from "./styles.module.css";
+import ThemedImage from "@theme/ThemedImage";
 
-function FooterLink({to, href, label, prependBaseUrlToHref, ...props}) {
+function FooterLink({ to, href, label, prependBaseUrlToHref, ...props }) {
   const toUrl = useBaseUrl(to);
   const normalizedHref = useBaseUrl(href, {
     forcePrependBaseUrl: true,
@@ -27,19 +27,20 @@ function FooterLink({to, href, label, prependBaseUrlToHref, ...props}) {
         : {
             to: toUrl,
           })}
-      {...props}>
+      {...props}
+    >
       {label}
     </Link>
   );
 }
 
-const FooterLogo = ({sources, alt}) => (
+const FooterLogo = ({ sources, alt }) => (
   <ThemedImage className="footer__logo" alt={alt} sources={sources} />
 );
 
 function Footer() {
-  const {footer} = useThemeConfig();
-  const {copyright, links = [], logo = {}} = footer || {};
+  const { footer } = useThemeConfig();
+  const { copyright, links = [], logo = {} } = footer || {};
   const sources = {
     light: useBaseUrl(logo.src),
     dark: useBaseUrl(logo.srcDark || logo.src),
@@ -51,21 +52,22 @@ function Footer() {
 
   return (
     <footer
-      className={clsx('footer', {
-        'footer--dark': footer.style === 'dark',
-      })}>
-      <div className="container">
+      className={clsx("footer", {
+        "footer--dark": footer.style === "dark",
+      })}
+    >
+      <div className={styles.footer__container}>
         {links && links.length > 0 && (
-          <div className="row footer__links">
+          <div className={`row ${styles.footer__links}`}>
             {links.map((linkItem, i) => (
-              <div key={i} className="col footer__col">
+              <div key={i} className={`col ${styles.footer__col}`}>
                 {linkItem.title != null ? (
                   <h4 className="footer__title">{linkItem.title}</h4>
                 ) : null}
                 {linkItem.items != null &&
                 Array.isArray(linkItem.items) &&
                 linkItem.items.length > 0 ? (
-                  <ul className="footer__items">
+                  <ul className={styles.footer__items}>
                     {linkItem.items.map((item, key) =>
                       item.html ? (
                         <li
@@ -80,7 +82,7 @@ function Footer() {
                         <li key={item.href || item.to} className="footer__item">
                           <FooterLink {...item} />
                         </li>
-                      ),
+                      )
                     )}
                   </ul>
                 ) : null}
@@ -113,9 +115,19 @@ function Footer() {
           </div>
         )}
       </div>
-      <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script> 
-<noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
-  </footer>
+      <script
+        async
+        defer
+        src="https://scripts.simpleanalyticscdn.com/latest.js"
+      ></script>
+      <noscript>
+        <img
+          src="https://queue.simpleanalyticscdn.com/noscript.gif"
+          alt=""
+          referrerpolicy="no-referrer-when-downgrade"
+        />
+      </noscript>
+    </footer>
   );
 }
 

--- a/sites/docs/src/theme/Footer/styles.module.css
+++ b/sites/docs/src/theme/Footer/styles.module.css
@@ -7,9 +7,49 @@
 
 .footerLogoLink {
   opacity: 0.5;
-  transition: opacity var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+  transition: opacity var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
 }
 
 .footerLogoLink:hover {
   opacity: 1;
+}
+
+.footer__items {
+  list-style: none;
+  padding: 0;
+}
+
+.footer__container {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.footer__col {
+  text-align: center;
+  padding: 0 5em;
+}
+
+@media only screen and (max-width: 600px) {
+  .footer__col {
+    padding: 0;
+  }
+
+  .footer__links {
+    gap: 2rem;
+  }
+}
+
+@media only screen and (min-width: 600px) {
+  .footer__links {
+    gap: 1rem;
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .footer__col {
+    text-align: left;
+  }
 }


### PR DESCRIPTION
### Description
<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes. 
-->

The footer at the [documentation site](https://docs.evidence.dev/usage-statistics) was not centered correctly, with this pull request I aim to correct the alignment of the footer providing a more visually pleasant interface.

### Before
![image](https://user-images.githubusercontent.com/30534965/207737503-3b9b058f-e209-46c2-b153-ad3bae45deba.png)

### After
![image](https://user-images.githubusercontent.com/30534965/207737617-d911294c-2fb5-4b5b-acaa-8cec4a96e630.png)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
