### PR TITLE
add separate download data option to charts

### DIFF
--- a/.changeset/famous-coins-invent.md
+++ b/.changeset/famous-coins-invent.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": minor
+---
+
+Add data download option to Charts

--- a/sites/example-project/src/components/ui/DownloadData.svelte
+++ b/sites/example-project/src/components/ui/DownloadData.svelte
@@ -27,11 +27,13 @@
 
 <button type="button" class={$$props.class} on:click={downloadData(data)}>
     <span>{text}</span>
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
+    <slot>
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
+    </slot>
   </button>
 
 <style>
-    svg {
+    button :global(svg) {
         stroke: var(--grey-400);
         margin-top: auto;
         margin-bottom: auto;
@@ -59,7 +61,7 @@
         color: var(--grey-500);
     }
 
-    button:hover svg {
+    button:hover :global(svg) {
         stroke: var(--grey-500);
     }
     

--- a/sites/example-project/src/components/ui/DownloadData.svelte
+++ b/sites/example-project/src/components/ui/DownloadData.svelte
@@ -3,6 +3,8 @@
 
     export let data;
     export let queryID;
+    export let text = 'Download';
+
     export let downloadData = (data) => {
         const options = { 
             fieldSeparator: ',',
@@ -24,7 +26,7 @@
 </script>
 
 <button type="button" class={$$props.class} on:click={downloadData(data)}>
-    <span>Download</span>
+    <span>{text}</span>
     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"></path></svg>
   </button>
 

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -675,7 +675,7 @@ $: {
 {#if !error}
 
 <slot></slot>
-<ECharts config={$config} {height} {width}/>
+<ECharts config={$config} {height} {width} {data}/>
 
 {:else}
 

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -36,7 +36,9 @@
 
 <EchartsCopyTarget {config} {height} {width} {copying}/> 
 
+{#if data}
 <DownloadData text="Download data" {data} class=download-button />
+{/if}
 <DownloadData text="Save image" class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}}>
   <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><path d="M20.4 14.5L16 10 4 20"></path></svg>
 </DownloadData>

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -37,7 +37,9 @@
 <EchartsCopyTarget {config} {height} {width} {copying}/> 
 
 <DownloadData text="Download data" {data} class=download-button />
-<DownloadData text="Save Chart" class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}} />
+<DownloadData text="Save image" class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}}>
+  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><path d="M20.4 14.5L16 10 4 20"></path></svg>
+</DownloadData>
 
 </div>
 

--- a/sites/example-project/src/components/viz/ECharts.svelte
+++ b/sites/example-project/src/components/viz/ECharts.svelte
@@ -9,6 +9,8 @@
     export let height = '291px'
     export let width = '100%'
 
+    export let data;
+
     let downloadChart = false;
     let copying = false
 
@@ -34,7 +36,8 @@
 
 <EchartsCopyTarget {config} {height} {width} {copying}/> 
 
-<DownloadData class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}} />
+<DownloadData text="Download data" {data} class=download-button />
+<DownloadData text="Save Chart" class=download-button downloadData={() => {downloadChart = true; setTimeout(() => { downloadChart = false}, 0);}} />
 
 </div>
 


### PR DESCRIPTION
### Description
Resolves #528 

Hopefully, this is what was requested.

- DownloadData now has text as prop ("Download Data", "Save Image", etc). Might be good to rename (DownloadButton)
- Data added as prop to ECharts component
- Echarts now has download option for Chart PNG and CSV data

Before:
 
<img width="444" alt="Screen Shot 2022-12-14 at 7 47 36 PM" src="https://user-images.githubusercontent.com/14843458/207746283-6091d03c-249d-4ac6-8aa7-9f0b6f990db9.png">

After:

https://user-images.githubusercontent.com/14843458/207746387-3914617d-e623-474d-91bd-a65443d3fd4f.mp4

