### PR TITLE
Fix date format example input

### DIFF
--- a/.changeset/long-zebras-share.md
+++ b/.changeset/long-zebras-share.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Changes custom date format example input

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -119,7 +119,7 @@ export const defaultExample = (valueType) => {
     case "number":
       return 1234;
     case "date":
-      return "Jan 3, 2022";
+      return "2022-01-03";
     default:
       return undefined;
   }


### PR DESCRIPTION
### Description
When creating a custom date format, the example input string shown in the settings panel was "Jan 3, 2022". This string doesn't work with our formatting system because we expect to receive dates in the format `YYYY-MM-DD` from our database connectors. This PR changes the default example input string for custom date formats to "2022-01-03".

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
