### PR TITLE
Turn off chart sort by default

### DIFF
--- a/.changeset/tiny-grapes-appear.md
+++ b/.changeset/tiny-grapes-appear.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Removes sort by default for Charts (Bar, Line, Area)

--- a/sites/docs/docs/features/charts/area-chart.md
+++ b/sites/docs/docs/features/charts/area-chart.md
@@ -64,7 +64,7 @@ hide_table_of_contents: false
 <tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
-<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default sort is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>handleMissing</td>	<td>Treatment of missing values in the dataset</td>	<td class='tcenter'>-</td>	<td class='tcenter'>gap | connect | zero</td>	<td class='tcenter'>gap (single series) | zero (multi-series)</td>	</tr>
 </table>																																																	

--- a/sites/docs/docs/features/charts/bar-chart.md
+++ b/sites/docs/docs/features/charts/bar-chart.md
@@ -150,7 +150,7 @@ If you create a bar chart with many x-axis items (e.g., names of departments), E
 <tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
-<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default sort is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false </td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 </table>																																																	
 

--- a/sites/docs/docs/features/charts/line-chart.md
+++ b/sites/docs/docs/features/charts/line-chart.md
@@ -72,7 +72,7 @@ Evidence will automatically pick the first column as `x` and use all other numer
 <tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column to use for the x-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
-<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>handleMissing</td>	<td>Treatment of missing values in the dataset</td>	<td class='tcenter'>-</td>	<td class='tcenter'>gap | connect | zero</td>	<td class='tcenter'>gap</td>	</tr>
 </table>																																																	

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -74,7 +74,7 @@
     xGridlines = (xGridlines === "true" || xGridlines === true);
     export let xAxisLabels = true;
     xAxisLabels = (xAxisLabels === "true" || xAxisLabels === true);
-    export let sort = true; // sorts x values in case x is out of order in dataset (e.g., would create line chart that is out of order)
+    export let sort = false; // sorts x values in case x is out of order in dataset (e.g., would create line chart that is out of order)
     sort = (sort === "true" || sort === true);
 
     // Y axis:
@@ -327,6 +327,11 @@ $: {
                 getSortedData(data, y, false) 
                 : getSortedData(data, x, true) 
             : data;
+
+        // Always sort time axes by x - this prevents the lines from being drawn out of order
+        if(xDataType === "time"){
+            data = getSortedData(data, x, true);
+        }
     
     // ---------------------------------------------------------------------------------------
     // Standardize date columns


### PR DESCRIPTION
### Description

Mutiple users found the automatic sorting behaviour confusing.

This removes sort by default behaviour for Chart components (AreaChart, BarChart, LineChart)
Sort will now be determined by the data order in the query.

(This does not affect date / time based axes, which will still be sorted chronologically)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

## Before

<img width="647" alt="image" src="https://user-images.githubusercontent.com/58074498/208930071-f1b02d28-e0d5-45b8-a1db-8c774c3b9147.png">

## After

<img width="599" alt="image" src="https://user-images.githubusercontent.com/58074498/208929842-1bf0c683-bbad-46c1-be11-3d8196e9c2ca.png">