### PR TITLE
Patch fix for 100% stacked charts

### DIFF
--- a/.changeset/orange-cameras-smile.md
+++ b/.changeset/orange-cameras-smile.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix 100% stacked chart reactivity

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -160,6 +160,8 @@
 
     let missingCols = [];
 
+    let originalRun = true;
+
     // Error Handling:
 
     let inputCols = [];
@@ -248,6 +250,19 @@ $: {
             throw Error(new Intl.ListFormat().format(missingCols) + " are required");
         }
 
+        // Fix for stacked100 overwriting y variable. Bandaid fix - not a long-term solution:
+        if(stacked100 === true && y.includes("_pct") && originalRun === false){
+            if(typeof y === 'object'){
+                for(let i=0; i<y.length; i++){
+                    y[i] = y[i].replace("_pct", "")
+                }
+                originalRun = false;
+            } else {
+                y = y.replace("_pct", "")
+                originalRun = false;
+            }
+        }
+
         // Check the inputs supplied to the chart:
         if(x){inputCols.push(x)};
         if(y){
@@ -276,8 +291,10 @@ $: {
                 for(let i=0; i<y.length; i++){
                     y[i] = y[i] + '_pct'
                 }
+                originalRun = false;
             } else {
                 y = y + '_pct'
+                originalRun = false;
             }
 
             // Re-run column summary for new columns (not ideal):
@@ -673,6 +690,8 @@ $: {
         props.update(d => { return {...d, error} })
     }
 }
+
+$: data
 
 </script>
 


### PR DESCRIPTION
### Description
This PR adds a patch fix to 100% stacked charts to avoid them erroring out on changes to the data object or page.

Here is the rough approach to building 100% stacked charts:
- In Chart.svelte, we receive the y column(s) as inputted by the user (e.g., `sales`)
- The total of the y column is calculated
- Each y column value is divided by the y column total to get the percentage for use in the stack
- Once the stacked percentages are calculated, the y variable name is overwritten as `y + "_pct"` (e.g., `sales_pct`)

The problem appears when the chart re-runs reactively (either from a change to the `data` object or to the page):
- Chart.svelte's script tag re-runs, but the `y` variable has not been reset to the original name supplied by the user (e.g., it still shows up as `sales_pct`)
- Chart.svelte runs a check of the inputted columns and throws an error when it can't find `sales_pct` in the dataset

### Naive Fix
The naive fix to this is to remove "_pct" from the y variable so Chart.svelte can find it in the dataset. We only want to do this if it's a 100% stacked chart and if it's not the first run of the chart.

This PR adds a new variable `originalRun` which is `true` when the chart loads, and is set to `false` when the y variable is overwritten. A check has been added in Chart.svelte which will reset the y variable when it finds `originalRun===false`.

This is a bandaid fix to get 100% stacked charts working. The fix doesn't negatively impact our other charts, but it doesn't solve the root cause of the issue, which is that the y variable is not reset to the original value supplied by the user when 100% stacked charts re-run reactively.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
