### PR TITLE
Table image and url support

### DIFF
--- a/sites/example-project/src/components/viz/Column.svelte
+++ b/sites/example-project/src/components/viz/Column.svelte
@@ -17,6 +17,7 @@
     export let title = undefined;
     export let align = undefined;
     export let img = false;
+    export let link;
     export let height;
     export let width;
     if(align === "centre"){ align = "center"};
@@ -28,6 +29,7 @@
         img: img,
         height: height,
         width: width,
+        link: link,
     }
 
     props.update(d => {

--- a/sites/example-project/src/components/viz/Column.svelte
+++ b/sites/example-project/src/components/viz/Column.svelte
@@ -16,12 +16,18 @@
 
     export let title = undefined;
     export let align = undefined;
+    export let img = false;
+    export let height;
+    export let width;
     if(align === "centre"){ align = "center"};
 
     let options = {
         id: id,
         title: title,
         align: align,
+        img: img,
+        height: height,
+        width: width,
     }
 
     props.update(d => {

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -342,6 +342,11 @@
                       width: {column.width};
                       "
                   />
+                  {:else if column.link}
+                    <a 
+                        href={row[column.link]}>
+                        {formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}
+                    </a>
                   {:else}
                   {formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}
                   {/if}

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -328,8 +328,24 @@
                   class="{columnSummary.filter(d => d.id === column.id)[0].type}"
                   class:row-lines={rowLines}
                   style="
-                      text-align: {column.align};
-                  ">{formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}</td>
+                        text-align: {column.align};
+                        height: {column.height};
+                        width: {column.width};
+                  ">
+                  {#if column.img}
+                  <img 
+                  src={row[column.img]} 
+                  alt={row[column.id]} 
+                  style="
+                      margin: 0.5em auto 0.5em auto;
+                      height: {column.height};
+                      width: {column.width};
+                      "
+                  />
+                  {:else}
+                  {formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}
+                  {/if}
+                  </td>
               {/each}
           {:else}
               {#each columnSummary as column, i}

--- a/sites/example-project/src/pages/tables/new-tables.md
+++ b/sites/example-project/src/pages/tables/new-tables.md
@@ -64,6 +64,7 @@ select date('2020-05-26') as date, 100 as value_usd, 'Zimbabwe' as country, 'A' 
 >
     <Column id=country/>
     <Column id=country img=flag height=50px/>
+    <Column id=country link=flag/>
     <Column id=category/>
     <Column id=country_id/>
     <Column id=date/>

--- a/sites/example-project/src/pages/tables/new-tables.md
+++ b/sites/example-project/src/pages/tables/new-tables.md
@@ -1,63 +1,73 @@
 ```tableq
-select date('2020-04-30') as date, 87 as value_usd, 'Austria' as country, 'B' as category, 100384 as country_id
+select date('2020-04-30') as date, 87 as value_usd, 'Austria' as country, 'B' as category, 100384 as country_id, 'AT' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AT.png' as flag
 union all
-select date('2020-05-01') as date, 9594 as value_usd, 'Australia' as country, 'C' as category, 104942 as country_id
+select date('2020-05-01') as date, 95 as value_usd, 'Australia' as country, 'C' as category, 104942 as country_id, 'AU' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AU.png' as flag
 union all
-select date('2020-05-02') as date, 16328 as value_usd, 'Brazil' as country, 'A' as category, 100842 as country_id
+select date('2020-05-02') as date, 163 as value_usd, 'Brazil' as country, 'A' as category, 100842 as country_id, 'BR' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/BR.png' as flag
 union all
-select date('2020-05-03') as date, 174 as value_usd, 'Canada' as country, 'A' as category, 104975 as country_id
+select date('2020-05-03') as date, 174 as value_usd, 'Canada' as country, 'A' as category, 104975 as country_id, 'CA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CA.png' as flag
 union all
-select date('2020-05-04') as date, 214 as value_usd, 'Chile' as country, 'B' as category, 100644 as country_id
+select date('2020-05-04') as date, 214 as value_usd, 'Chile' as country, 'B' as category, 100644 as country_id, 'CL' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CL.png' as flag
 union all
-select date('2020-05-05') as date, 342 as value_usd, 'Denmark' as country, 'B' as category, 102948 as country_id
+select date('2020-05-05') as date, 342 as value_usd, 'Denmark' as country, 'B' as category, 102948 as country_id, 'DK' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/DK.png' as flag
 union all
-select date('2020-05-06') as date, 331 as value_usd, 'Estonia' as country, 'D' as category, 102495 as country_id
+select date('2020-05-06') as date, 331 as value_usd, 'Estonia' as country, 'D' as category, 102495 as country_id, 'EE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/EE.png' as flag
 union all
-select date('2020-05-07') as date, 98 as value_usd, 'Finland' as country, 'B' as category, 104962 as country_id
+select date('2020-05-07') as date, 98 as value_usd, 'Finland' as country, 'B' as category, 104962 as country_id, 'FI' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/FI.png' as flag
 union all
-select date('2020-05-08') as date, 128 as value_usd, 'Ghana' as country, 'C' as category, 100599 as country_id
+select date('2020-05-08') as date, 128 as value_usd, 'Ghana' as country, 'C' as category, 100599 as country_id, 'GH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/GH.png' as flag
 union all
-select date('2020-05-09') as date, 153 as value_usd, 'Honduras' as country, 'D' as category, 102494 as country_id
+select date('2020-05-09') as date, 153 as value_usd, 'Honduras' as country, 'D' as category, 102494 as country_id, 'HN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/HN.png' as flag
 union all
-select date('2020-05-10') as date, 384 as value_usd, 'India' as country, 'A' as category, 101948 as country_id
+select date('2020-05-10') as date, 384 as value_usd, 'India' as country, 'A' as category, 101948 as country_id, 'IN' as country_code,  'https://flaglog.com/codes/standardized-rectangle-120px/IN.png' as flag
 union all
-select date('2020-05-11') as date, 234 as value_usd, 'Ireland' as country, 'B' as category, 100987 as country_id
+select date('2020-05-11') as date, 234 as value_usd, 'Ireland' as country, 'B' as category, 100987 as country_id, 'IE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/IE.png' as flag
 union all
-select date('2020-05-12') as date, 67 as value_usd, 'Jamaica' as country, 'C' as category, 101248 as country_id
+select date('2020-05-12') as date, 67 as value_usd, 'Jamaica' as country, 'C' as category, 101248 as country_id, 'JM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/JM.png' as flag
 union all
-select date('2020-05-13') as date, 125 as value_usd, 'Kenya' as country, 'C' as category, 101947 as country_id
+select date('2020-05-13') as date, 125 as value_usd, 'Kenya' as country, 'C' as category, 101947 as country_id, 'KE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/KE.png' as flag
 union all
-select date('2020-05-14') as date, 118 as value_usd, 'Lebanon' as country, 'D' as category, 108849 as country_id
+select date('2020-05-14') as date, 118 as value_usd, 'Lebanon' as country, 'D' as category, 108849 as country_id, 'LB' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/LB.png' as flag
 union all
-select date('2020-05-15') as date, 263 as value_usd, 'Mexico' as country, 'B' as category, 100763 as country_id
+select date('2020-05-15') as date, 263 as value_usd, 'Mexico' as country, 'B' as category, 100763 as country_id, 'MX' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/MX.png' as flag
 union all
-select date('2020-05-16') as date, 211 as value_usd, 'Nigeria' as country, 'A' as category, 100837 as country_id
+select date('2020-05-16') as date, 211 as value_usd, 'Nigeria' as country, 'A' as category, 100837 as country_id, 'NG' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/NG.png' as flag
 union all
-select date('2020-05-17') as date, 192 as value_usd, 'Oman' as country, 'D' as category, 100993 as country_id
+select date('2020-05-17') as date, 192 as value_usd, 'Oman' as country, 'D' as category, 100993 as country_id, 'OM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/OM.png' as flag
 union all
-select date('2020-05-18') as date, 59 as value_usd, 'Philippines' as country, 'D' as category, 104128 as country_id
+select date('2020-05-18') as date, 59 as value_usd, 'Philippines' as country, 'D' as category, 104128 as country_id, 'PH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/PH.png' as flag
 union all
-select date('2020-05-19') as date, 113 as value_usd, 'Qatar' as country, 'C' as category, 100181 as country_id
+select date('2020-05-19') as date, 113 as value_usd, 'Qatar' as country, 'C' as category, 100181 as country_id, 'QA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/QA.png' as flag
 union all
-select date('2020-05-20') as date, 190 as value_usd, 'Romania' as country, 'A' as category, 101384 as country_id
+select date('2020-05-20') as date, 190 as value_usd, 'Romania' as country, 'A' as category, 101384 as country_id, 'RO' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/RO.png' as flag
 union all
-select date('2020-05-21') as date, 190 as value_usd, 'Sweden' as country, 'B' as category, 101847 as country_id
+select date('2020-05-21') as date, 190 as value_usd, 'Sweden' as country, 'B' as category, 101847 as country_id, 'SE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/SE.png' as flag
 union all
-select date('2020-05-22') as date, 248 as value_usd, 'Thailand' as country, 'C' as category, 104837 as country_id
+select date('2020-05-22') as date, 248 as value_usd, 'Thailand' as country, 'C' as category, 104837 as country_id, 'TH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/TH.png' as flag
 union all
-select date('2020-05-23') as date, 168 as value_usd, 'Ukraine' as country, 'C' as category, 101938 as country_id
+select date('2020-05-23') as date, 168 as value_usd, 'Ukraine' as country, 'C' as category, 101938 as country_id, 'UA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/UA.png' as flag
 union all
-select date('2020-05-24') as date, 101 as value_usd, 'Vietnam' as country, 'A' as category, 104948 as country_id
+select date('2020-05-24') as date, 101 as value_usd, 'Vietnam' as country, 'A' as category, 104948 as country_id, 'VN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/VN.png' as flag
 union all
-select date('2020-05-25') as date, 67 as value_usd, 'Yemen' as country, 'B' as category, 100774 as country_id
+select date('2020-05-25') as date, 67 as value_usd, 'Yemen' as country, 'B' as category, 100774 as country_id, 'YE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/YE.png' as flag
 union all
-select date('2020-05-26') as date, 100 as value_usd, 'Zimbabwe' as country, 'A' as category, 100337 as country_id
+select date('2020-05-26') as date, 100 as value_usd, 'Zimbabwe' as country, 'A' as category, 100337 as country_id, 'ZW' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/ZW.png' as flag
 ```
 
-<DataTable data={tableq} search=true sortable=true rows=10 downloadable=true>
-    <Column id=date/>
-    <Column id=country_id label = "Country ID" align=center/>
+
+<DataTable 
+    data={tableq}
+    rowNumbers=true 
+    fontSize=medium
+    search
+    formatColumnTitles=true
+>
     <Column id=country/>
+    <Column id=country img=flag height=50px/>
     <Column id=category/>
-    <Column id=value_usd/>
+    <Column id=country_id/>
+    <Column id=date/>
 </DataTable>
+
+
+


### PR DESCRIPTION
### Description
- Possible way of adding URL and link support
- But would be good to be able to allow adding arbitrary <slot> which would be more powerful than this

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

After:
<img width="761" alt="image" src="https://user-images.githubusercontent.com/58074498/210540789-4db23538-5644-423f-b865-b0680a60bd21.png">

