### PR TITLE
Fix datatable error reactivity

### DIFF
--- a/.changeset/gorgeous-geese-stare.md
+++ b/.changeset/gorgeous-geese-stare.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix reactivity of DataTable on errors

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -94,6 +94,8 @@
           }
       }
 
+      error = undefined;
+
   } catch (e) {
       error = e.message;
   }
@@ -231,10 +233,6 @@
   $: tableData = $props.columns.length > 0 ? dataSubset(data, $props.columns.map(d => d.id)) : data;
 
 </script>
-
-{#if $props.error}
-<ErrorChart/>
-{/if}
 
 {#if !error}
 


### PR DESCRIPTION
### Description
DataTable had a reactivity issue where the error state would persist even after the data object changed. This PR adds a fix so when the data is updated, the error state is reset to undefined.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
