### PR TITLE
Fix treatment of nulls in charts

### DIFF
--- a/.changeset/odd-snails-deliver.md
+++ b/.changeset/odd-snails-deliver.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fixes treatment of nulls in charts

--- a/sites/example-project/src/components/modules/getCompletedData.js
+++ b/sites/example-project/src/components/modules/getCompletedData.js
@@ -116,7 +116,9 @@ export default function getCompletedData(data, x, y, series, nullsZero=false, fi
             filledData = tidy(
                 data,
                 complete(
-                    [x, series]
+                    [x, series],
+                    // Nully values in the x and series columns to be treated as nulls
+                    {[series]: null, [x]: null}
                 )
             )
         }

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -49,7 +49,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
             }
         
             // Set series name:
-            seriesName = seriesDistinct[i];
+            seriesName = seriesDistinct[i] ?? "null";
 
             tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
             seriesConfig.push(tempConfig);
@@ -86,7 +86,7 @@ export default function getSeriesConfig(data, x, y, series, swapXY, baseConfig, 
                 }
 
                 // Set series name:
-                seriesName = seriesDistinct[i] + " - " + columnSummary[y[j]].title;
+                seriesName = (seriesDistinct[i] ?? "null") + " - " + columnSummary[y[j]].title;
                 tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
                 seriesConfig.push(tempConfig);
             }


### PR DESCRIPTION
### Description
This PR fixes 2 issues regarding nulls in charts:
1. Fixes #541 - null series previously did not appear in the chart legend
2. Null values shifting across the x axis in some scenarios - this only happened when a series entry was missing in the dataset

The second issue was caused by our series completion function - the function was completing the dataset with undefined values rather than nulls, which led the chart to ignore those rows in the dataset when calculating the position of rectangles in the chart area.

Below is a before and after on that issue:

#### Before
<img width="545" alt="CleanShot 2023-01-10 at 17 28 11@2x" src="https://user-images.githubusercontent.com/12602440/211678924-a7341194-6eac-441e-9bbc-a4e5511fb3a1.png">

#### After
<img width="541" alt="CleanShot 2023-01-10 at 17 28 31@2x" src="https://user-images.githubusercontent.com/12602440/211678933-8e759ce8-dd09-432a-9e7e-d4ba632c495e.png">

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
