### PR TITLE
fix: remove header bar from printed content

### DIFF
--- a/.changeset/tricky-goats-suffer.md
+++ b/.changeset/tricky-goats-suffer.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Prevent header shading showing up in PDF / print export

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -279,6 +279,10 @@ aside.toc {
   main * {
     visibility: hidden;
   }
+
+  .header-bar {
+	visibility: hidden;
+  }
   article, article * {
     visibility: visible;
   }


### PR DESCRIPTION
## Before
Shading / blurring at top of page in export
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/58074498/212418422-24f060e9-de32-4dae-860c-6e55c0a571ae.png">

## After

<img width="1030" alt="image" src="https://user-images.githubusercontent.com/58074498/212418469-b8be3749-a1af-477d-a3a7-c0b27035c94d.png">


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
