### PR TITLE
Override old style numbers in BigValue

### DIFF
--- a/.changeset/heavy-shoes-bathe.md
+++ b/.changeset/heavy-shoes-bathe.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fixes BigValue comparison styling for Windows

--- a/sites/example-project/src/components/viz/BigValue.svelte
+++ b/sites/example-project/src/components/viz/BigValue.svelte
@@ -155,6 +155,7 @@
         font-size: .65em;
         font-weight: 500;
         font-family: var(--ui-compact-font-family);
+        font-feature-settings: normal;
     }
 
     .comparison-type {


### PR DESCRIPTION
### Description
Makes BigValue comparison numbers more consistent. On Windows, the numbers were previously appearing as shifted due to the old fashioned number styling.

#### Before
<img width="214" alt="bigvaluewindows" src="https://user-images.githubusercontent.com/12602440/213496268-40fea371-289a-4123-b4bc-e3994019bd0b.PNG">

#### After
<img width="214" alt="bigvaluenormal" src="https://user-images.githubusercontent.com/12602440/213496281-66144512-67f3-410a-82d9-14509f03d589.PNG">

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
