### PR TITLE
Fix minor spacing in settings

### DIFF
--- a/.changeset/heavy-pillows-know.md
+++ b/.changeset/heavy-pillows-know.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Minor spacing fixes in settings menu

--- a/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
@@ -97,7 +97,7 @@
         </div>
         {/if}
         {#if testResult}
-        <div class=panel transition:slide|local>
+        <div class="panel test-result" transition:slide|local>
             {#await testResult}
                 <span class="indicator running" /><span>Testing connection</span>
             {:then result} 
@@ -231,6 +231,10 @@ h3 {
 
 .panel:first-of-type {
     border-top:none;
+}
+
+.panel.test-result {
+    padding-top: 1em;
 }
 
 select {

--- a/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Formatting/FormattingSettingsPanel.svelte
@@ -7,8 +7,7 @@
   import CurrencyFormatGrid from "./CurrencyFormatGrid.svelte";
   import Prism from "../QueryViewerSupport/Prismjs.svelte";
 
-  let exampleQuery = `
-select 
+  let exampleQuery = `select 
   growth as growth_pct, -- formatted as a percentage
   sales as sales_usd    -- formatted as US dollars
 from table` 


### PR DESCRIPTION
### Description

#### Before
<img width="777" alt="CleanShot 2023-01-19 at 11 22 23@2x" src="https://user-images.githubusercontent.com/12602440/213496946-b427ac8e-e1a9-45c0-81ee-3afe30899a74.png">

<img width="743" alt="CleanShot 2023-01-19 at 11 22 32@2x" src="https://user-images.githubusercontent.com/12602440/213496943-5e6fb4b5-9024-4111-b3a6-6fb10045749e.png">

#### After
<img width="773" alt="CleanShot 2023-01-19 at 11 23 19@2x" src="https://user-images.githubusercontent.com/12602440/213496987-674d9884-6341-4947-bc01-8c01d885cb69.png">
<img width="748" alt="CleanShot 2023-01-19 at 11 23 12@2x" src="https://user-images.githubusercontent.com/12602440/213496989-206b1c47-ea48-4d70-a44e-5d62c002f34d.png">


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
