### PR TITLE
Fix the menu button disappearing in the sidebar

### DIFF
--- a/.changeset/popular-cameras-carry.md
+++ b/.changeset/popular-cameras-carry.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": minor
+---
+
+Fix the menu button disappearing in the sidebar

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -39,6 +39,7 @@
 
 	button.open {
 		margin-top: 0.8em;
+		transition: all 0.1s ease-in;
 	}
 	
 	.open svg {

--- a/sites/example-project/src/components/ui/Hamburger.svelte
+++ b/sites/example-project/src/components/ui/Hamburger.svelte
@@ -2,7 +2,7 @@
 	export let open = false
 </script>
 
-<button class:open on:click={() => open = !open}>
+<button aria-label="hamburger menu" class:open on:click={() => open = !open}>
 	<svg width=32 height=24>
 		<line id="top" x1=0 y1=2  x2=32 y2=2/>
 		<line id="middle" x1=0 y1=12 x2=32 y2=12/>
@@ -36,9 +36,17 @@
         font-size: 16px;
         background-color: hsla(217, 33%, 97%, 0);
 	}
+
+	button.open {
+		margin-top: 0.8em;
+	}
 	
 	.open svg {
 		transform: scale(0.7);
+	}
+
+	svg {
+		transform: scale(0.85);
 	}
 	
 	.open #top {

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -279,12 +279,12 @@ aside.toc {
 		top: 0;
 		right: 0;
 		background-color: rgba(255, 255, 255, 0.73);
-    -webkit-backdrop-filter: blur(10px) saturate(1.8);
-    backdrop-filter: blur(10px) saturate(1.8);
+		-webkit-backdrop-filter: blur(10px) saturate(1.8);
+		backdrop-filter: blur(10px) saturate(1.8);
 	}
 	.header-button.open {
 		z-index: 7;
-    	width: fit-content;
+		width: fit-content;
 		background-color: transparent;
 		backdrop-filter: none;
 	}

--- a/sites/example-project/src/pages/__layout.svelte
+++ b/sites/example-project/src/pages/__layout.svelte
@@ -143,6 +143,8 @@
 	{#if $page.path !== '/settings'}
 		<div class="header-bar">
 			<Header {menu} {folderList}/>
+		</div>
+		<div class="header-button" class:open>
 			<Hamburger bind:open/>
 		</div>
 	{/if}
@@ -235,6 +237,7 @@ aside.toc {
     -webkit-backdrop-filter: blur(10px) saturate(1.8);
     backdrop-filter: blur(10px) saturate(1.8);
 }
+
 @media (max-width: 1440px) {
 	div.content {
 		grid-template-columns: 1fr;
@@ -263,6 +266,28 @@ aside.toc {
 }
 
 @media (max-width: 850px) {
+
+	.header-bar {
+		width: 90%;
+	}
+	.header-button {
+		z-index: 2;
+		position: fixed;
+		display: flex;
+		justify-content: end;
+		width: 10%;
+		top: 0;
+		right: 0;
+		background-color: rgba(255, 255, 255, 0.73);
+    -webkit-backdrop-filter: blur(10px) saturate(1.8);
+    backdrop-filter: blur(10px) saturate(1.8);
+	}
+	.header-button.open {
+		z-index: 7;
+    	width: fit-content;
+		background-color: transparent;
+		backdrop-filter: none;
+	}
 	.grid {
 		display: grid;
 		grid-template-areas:


### PR DESCRIPTION
### Description

The sidebar was overflowing over the hamburger menu button. I was able to fix it by dividing the `header-bar` into two entities.

**Note:** I didn't want to change the structure of the `menu/nav` as I am new to the project. I went for mainly `css` change.

#### Before

![572-before-menu](https://user-images.githubusercontent.com/10125507/213567601-91800e0e-2eab-4feb-a856-0f5929391158.gif)


#### After

![572-after-menu](https://user-images.githubusercontent.com/10125507/213567617-523cbec7-17af-45b0-b732-58612cf83f65.gif)


### Checklist


- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
