### PR TITLE
Fix scoping of img styling in tables

### DIFF
--- a/.changeset/sharp-melons-love.md
+++ b/.changeset/sharp-melons-love.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fixes default image styling

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -19,11 +19,13 @@ img {
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
-}	
-
-article > img {
 	max-width: 100%;
 	border-radius: 4px;
+}	
+
+td > img {
+	max-width: unset;
+	border-radius: unset;
 }
 
 body {


### PR DESCRIPTION
### Description
When the new DataTable was released last week, it turned off the default styling for images inside of tables. It also inadvertently turned off default image styling across the project. This PR returns the default image styling to the project and removes it only for images within a table cell.

Fixes #578

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
