### PR TITLE
Add more error handling in DataTable

### DIFF
--- a/.changeset/stupid-papayas-jam.md
+++ b/.changeset/stupid-papayas-jam.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": minor
+---
+
+Addition of error handling on <DataTable .../> with unknown or missing column.id fixing #580

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -253,13 +253,13 @@
    * @param column
    */
   function safeExtractColumn(column) {
-    const foundCol = columnSummary.filter(d => d.id === column.id)
-    if (foundCol === undefined || foundCol.length !== 1 ){
-        error = (column.id === undefined) ? "please add an id properties to all the <Column ... /> element" : `column ${column.id} not found`
-        return ""
+    const foundCols = columnSummary.filter(d => d.id === column.id)
+    if (foundCols === undefined || foundCols.length !== 1 ){
+        error = (column.id === undefined) ? "please add an id property to all the <Column ... />" : `column ${column.id} not found`
+        return
     }
 
-    return foundCol[0]
+    return foundCols[0]
   }
 
   let tableData

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -111,7 +111,7 @@
     }
 
 
-      error = undefined;
+     error = undefined;
 
   } catch (e) {
       error = e.message;
@@ -248,12 +248,27 @@
       })
   }
 
+  /**
+   * Will find the matching column in columnSummary or throw an error if not found
+   * @param column
+   */
+  function safeExtractColumn(column) {
+    const foundCol = columnSummary.filter(d => d.id === column.id)
+    if (foundCol === undefined || foundCol.length !== 1 ){
+        error = (column.id === undefined) ? "please add an id properties to all the <Column ... /> element" : `column ${column.id} not found`
+        return ""
+    }
+
+    return foundCol[0]
+  }
+
   let tableData
   $: tableData = $props.columns.length > 0 ? dataSubset(data, $props.columns.map(d => d.id)) : data;
 
+
 </script>
 
-{#if !error}
+{#if error === undefined}
 
 <slot></slot>
 <div class="table-container" transition:slide|local style="margin-top:{marginTop}; margin-bottom:{marginBottom}; padding-bottom: {paddingBottom}" on:mouseenter={() => hovering = true} on:mouseleave={() => hovering = false}>
@@ -275,7 +290,7 @@
           {#if $props.columns.length > 0}
               {#each $props.columns as column, i}
                   <th
-                      class="{columnSummary.filter(d => d.id === column.id)[0].type}"
+                      class="{safeExtractColumn(column).type}"
                       style="
                       text-align: {column.align};
                       color: {headerFontColor};
@@ -284,7 +299,7 @@
                       "
                       on:click={sortable ? sort(column.id) : ''}
                   >
-                      {column.title ? column.title : formatColumnTitles ? columnSummary.filter(d => d.id === column.id)[0].title : columnSummary.filter(d => d.id === column.id)[0].id}
+                      {column.title ? column.title : formatColumnTitles ? safeExtractColumn(column).title : safeExtractColumn(column).id}
                       {#if sortBy.col === column.id}
                           <SortIcon ascending={sortBy.ascending}/>
                       {/if}
@@ -341,7 +356,7 @@
           {#if $props.columns.length > 0}
               {#each $props.columns as column, i}
                   <td 
-                  class="{columnSummary.filter(d => d.id === column.id)[0].type}"
+                  class="{safeExtractColumn(column).type}"
                   class:row-lines={rowLines}
                   style="
                       text-align: {column.align};
@@ -365,16 +380,16 @@
                         >
                         {#if column.linkLabel != undefined}
                             {#if row[column.linkLabel] != undefined}
-                                {formatValue(row[column.linkLabel], columnSummary.filter(d => d.id === column.linkLabel)[0].format)}
+                                {formatValue(row[column.linkLabel], safeExtractColumn(column).format)}
                             {:else}
                                 {column.linkLabel}
                             {/if}
                         {:else}
-                            {formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}
+                            {formatValue(row[column.id], safeExtractColumn(column).format)}
                         {/if}
                     </a>
                   {:else}
-                    {formatValue(row[column.id], columnSummary.filter(d => d.id === column.id)[0].format)}
+                    {formatValue(row[column.id], safeExtractColumn(column).format)}
                   {/if}
                 </td>
               {/each}

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -364,7 +364,7 @@
                       height: {column.height};
                       width: {column.width};
                   ">
-                  {#if column.contentType === "image"}
+                  {#if column.contentType === "image" && row[column.id] !== undefined}
                     <img 
                     src={row[column.id]} 
                     alt={column.alt ? row[column.alt] : row[column.id].replace(/^(.*[\\\/])/g, "").replace(/[.][^.]+$/g, "")} 
@@ -374,7 +374,7 @@
                         width: {column.width};
                         "
                     />
-                  {:else if column.contentType === "link"}
+                  {:else if column.contentType === "link" && row[column.id] !== undefined}
                     <a 
                         href={row[column.id]}
                         target={column.openInNewTab ? "_blank" : ""}

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -58,7 +58,7 @@
   export let showLinkCol = false; // hides link column when columns have not been explicitly selected
   showLinkCol = (showLinkCol === "true" || showLinkCol === true);
 
-  let error = undefined;
+  let error = undefined
 
   // ---------------------------------------------------------------------------------------
   // Add props to store to let child components access them
@@ -109,9 +109,6 @@
     for(let i=0; i<columnSummary.length; i++){
             columnSummary[i].show = (showLinkCol === false && columnSummary[i].id === link) ? false : true
     }
-
-
-     error = undefined;
 
   } catch (e) {
       error = e.message;
@@ -255,8 +252,8 @@
   function safeExtractColumn(column) {
     const foundCols = columnSummary.filter(d => d.id === column.id)
     if (foundCols === undefined || foundCols.length !== 1 ){
-        error = (column.id === undefined) ? "please add an id property to all the <Column ... />" : `column ${column.id} not found`
-        return
+        error = (column.id === undefined) ? new Error("please add an id property to all the <Column ... />") : new Error(`column ${column.id} not found`)
+        return ""
     }
 
     return foundCols[0]

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -252,7 +252,11 @@
   function safeExtractColumn(column) {
     const foundCols = columnSummary.filter(d => d.id === column.id)
     if (foundCols === undefined || foundCols.length !== 1 ){
-        error = (column.id === undefined) ? new Error("please add an id property to all the <Column ... />") : new Error(`column ${column.id} not found`)
+        error = (column.id === undefined) ? new Error(`please add an "id" property to all the <Column ... />`) : new Error(`column with id: "${column.id}" not found`)
+        if(strictBuild){
+            throw error
+        }
+        console.warn(error.message)
         return ""
     }
 


### PR DESCRIPTION
### Description

Adding error if `<Column />` `id` is not found in the table or if it doesn't contain any `id`. 

- The `error` is also sent to the `console` in `dev` mode 
- The `error` will fail the build in `strict` mode.

![580-column-unknown](https://user-images.githubusercontent.com/10125507/215186414-b97dfb13-6a5f-4a3d-a41a-158ab753e675.gif)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
