### PR TITLE
minimal venn diagram implementation

### DIFF
--- a/.changeset/smart-adults-think.md
+++ b/.changeset/smart-adults-think.md
@@ -1,0 +1,6 @@
+---
+"@evidence-dev/preprocess": patch
+"@evidence-dev/components": patch
+---
+
+Adds a minimal venn diagram to available components.

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -58,6 +58,7 @@ const createDefaultProps = function(filename, componentDevelopmentMode, fileQuer
         import { pageHasQueries, routeHash } from '@evidence-dev/components/ui/stores';
         import { setContext, getContext, beforeUpdate } from 'svelte';
         import BigLink from '${componentSource}/ui/BigLink.svelte';
+        import VennDiagram from '${componentSource}/diagrams/VennDiagram.svelte';
         import Value from '${componentSource}/viz/Value.svelte';
         import BigValue from '${componentSource}/viz/BigValue.svelte';
         import Chart from '${componentSource}/viz/Chart.svelte';

--- a/sites/example-project/src/components/diagrams/VennDiagram.svelte
+++ b/sites/example-project/src/components/diagrams/VennDiagram.svelte
@@ -1,0 +1,166 @@
+<script>
+  let radius = 25;
+
+  export let overlaps = [
+    "A", // A Only
+    "AB", // A and B
+    "BC", // B and C
+    "AC", // A and C
+    "ABC", // A, B and C
+  ];
+  export let labels = ["ACRONYM CO", "GRID REIT", "First Malaysian"];
+  export let amounts = [1232430, 254856548, 36524982];
+
+  // Equilateral triangle of centers
+  let side = radius;
+  let height = (Math.sqrt(3) / 2) * side;
+  let origin = { x: 50 - side / 2, y: 50 + height / 2 };
+  let apothem = height / 3;
+
+  // Distance to labels, apothem of outer triangle
+  let distanceToLabels =
+    (height + radius + Math.sin((30 * Math.PI) / 180) * radius) / 3;
+
+  // Circles
+  let circles = [
+    { x: 50 + "%", y: 50 - height / 2 + "%", class: "a" },
+    { x: 50 - side / 2 + "%", y: 50 + height / 2 + "%", class: "b" },
+    { x: 50 + side / 2 + "%", y: 50 + height / 2 + "%", class: "c" },
+  ];
+
+  let intercets;
+
+  $: distanceToLabels,
+    (intercets = [
+      // A only 
+      {
+        x: 50,
+        y: origin.y - 2*apothem - distanceToLabels,
+        value: overlaps[0]?.toLocaleString("en-GB", { style: "percent" }) ?? ""
+      },
+      // ABC
+      {
+        x: 50,
+        y: origin.y - apothem,
+        value: overlaps[4]?.toLocaleString("en-GB", { style: "percent" }) ?? "",
+      },
+      {
+        x: 50 - distanceToLabels * Math.cos((30 * Math.PI) / 180),
+        y:
+          origin.y -
+          apothem -
+          distanceToLabels * Math.sin((30 * Math.PI) / 180),
+        value: overlaps[3]?.toLocaleString("en-GB", { style: "percent" }) ?? "",
+      },
+      {
+        x: 50 + distanceToLabels * Math.cos((30 * Math.PI) / 180),
+        y:
+          origin.y -
+          apothem -
+          distanceToLabels * Math.sin((30 * Math.PI) / 180),
+        value: overlaps[1]?.toLocaleString("en-GB", { style: "percent" }) ?? "",
+      },
+      {
+        x: 50,
+        y: origin.y - apothem + distanceToLabels,
+        value: overlaps[2]?.toLocaleString("en-GB", { style: "percent" }) ?? "",
+      },
+    ]);
+</script>
+
+<div class="container">
+  <svg class="main">
+    <!-- Circles -->
+    {#each circles as circle}
+      <circle
+        class={circle.class}
+        cx={circle.x}
+        cy={circle.y}
+        r={radius + "%"}
+      />
+    {/each}
+    <!-- Intersect Labels -->
+    {#each intercets as intersect}
+      <text
+        x={intersect.x + "%"}
+        y={intersect.y + "%"}
+        dominant-baseline="middle"
+        text-anchor="middle"
+      >
+        {intersect.value}
+      </text>
+    {/each}
+
+    <!-- Circle labels -->
+    <text x="0%" y="1%" dominant-baseline="hanging" class="label-a">{labels[0] ?? ''}</text>
+    <text x="0%" y="6%" dominant-baseline="hanging" class="label-a">{amounts[0]?.toLocaleString('en-gb') ?? ''}</text>
+
+    <text x="0%" y="94%" class="label-b">{labels[2]  ?? ''}</text>
+    <text x="0%" y="99%" class="label-b">{amounts[2]?.toLocaleString('en-gb')  ?? ''}</text>
+
+    <text x="100%" y="94%" text-anchor="end" class="label-c">{labels[1]  ?? ''}</text>
+    <text x="100%" y="99%" text-anchor="end" class="label-c">{amounts[1]?.toLocaleString('en-gb')  ?? ''}</text>
+
+  </svg>
+</div>
+
+<style>
+  svg.main {
+    height: 16em;
+    width: 16em;
+  }
+
+  text {
+    font: 0.7em var(--monospace-font-family);
+    stroke: none;
+  }
+
+  circle {
+    pointer-events: all;
+    fill-opacity: 0.1;
+  }
+
+  .a {
+    stroke: var(--blue-500);
+    fill: var(--blue-500);
+  }
+
+  .b {
+    stroke: var(--green-500);
+    fill: var(--green-500);
+  }
+
+  .c {
+    /* stroke:#fb923c; */
+    fill: #8b5cf6;
+    stroke: #8b5cf6;
+    /* fill: #fb923c; */
+    /* fill: #06b6d4; 
+    stroke: #06b6d4;  */
+    /* stroke: var(--pu-500);
+    /* fill: var(--pu-500); */
+  }
+
+  .label-a {
+    fill: var(--blue-800);
+  }
+
+  .label-b {
+    fill: var(--green-800);
+  }
+
+  .label-c {
+    fill: #8b5cf6;
+    /* fill: #fb923c; */
+  }
+
+  div.container {
+
+    display:flex;
+    margin: 1.5em 0;
+    align-items: center;
+    justify-items: flex-end;
+  }
+
+
+</style>

--- a/sites/example-project/src/pages/text-and-metrics/diagrams.md
+++ b/sites/example-project/src/pages/text-and-metrics/diagrams.md
@@ -1,0 +1,41 @@
+# Tantum protulit caligine petunt
+
+## Uno sine at nunc pontus rectorque umeros
+
+Lorem markdownum nivea redimitus. In rector in, flumine adimunt, cinctum, dolore
+pallada senectus dixit? Crematisregia fetus Io locus viscera redde lucida
+discede?
+
+<VennDiagram
+    labels={["Title A", "Title B", "Title C"]}
+    amounts={["AMOUNT A", "AMOUNT B", "AMOUNT C"]}
+    overlaps={["A", "AB", "BC", "AC", "ABC"]}
+/>
+
+Est qui conciderant, parte haud effugit dixerat. Retentas Pelasga vivunt;
+attigimus restabat exitus. Praedaeque ademit. _Vix_ eundem, saevarum et nescia
+inter retinentibus inaniter pontum! `pages/index.md`
+
+### Pascua tigres inde
+
+Domino cuncta dicenda. Serpente paludem et nubes Cithaeron alios mihi non.
+
+- Cernit traxerunt oras devolvere opibusque gerit Tatiusque
+- Aethere mihi pirithoi fontes concretaque hic obuncis
+- Solitas fibras aures et verba hiatus et
+- Secutum idonea
+- Et vocem inquit
+- Dum aequi Xanthique minantia nec taurum
+
+#### Aniles orantem Saeculaque pars a aetas nostrum
+
+Opposuitque solis ausis vivo est adventum rudis, nunc fuerant: si
+[laedi](http://sic-conamine.org/), et. Nostro verba et celer purpura utraque
+parvas, indicat quaeritis adhaesi negate. Exsangue sibique Minos Echidnaeae
+miseranda infelix nunc dapes iunctisque praetereunt abluere moenia ferunt aere
+innuba.
+
+1. Seque nepotemque colla
+2. Ego sanguine iphis Tartara crudeles et et
+3. Peritura auro tulit harenis sucos
+4. Per turbata caput


### PR DESCRIPTION
### Description
This implements a simple Venn Diagram per a customer request. 

This is sufficient for their use case, but it is not ready for prime-time. Propose we leave this undocumented, and open an issue for a broader diagrams suite in the future. 

* Does not offer robust data handling. Overlap percentages, labels, and amounts are supplied directly through props which accept arrays. Live data would be supplied using `query[row].column` syntax. 
* No automatic calculation of overlap percentages. There are a variety of approaches to calculating these, and we're not enforcing any one. For example, sets expressed as a percentage of a total records, sets expressed as a percentage of a single category of records etc.  
* No format handling -- default percentages for overlaps, en-gb for record counts. 

## Syntax 

```
<VennDiagram
    labels={["Title A", "Title B", "Title C"]}
    amounts={["AMOUNT A", "AMOUNT B", "AMOUNT C"]}
    overlaps={["A", "AB", "BC", "AC", "ABC"]}
/>
```

## Screenshot 

<img width="591" alt="CleanShot 2023-01-26 at 21 14 57@2x" src="https://user-images.githubusercontent.com/6857673/214995930-88cd1bbf-5e86-4942-8e53-c1d068fede37.png">

