### PR TITLE
Fix mysql ssl option

### DIFF
--- a/.changeset/wise-hounds-watch.md
+++ b/.changeset/wise-hounds-watch.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/mysql": patch
+---
+
+Fix mysql SSL option

--- a/packages/mysql/index.cjs
+++ b/packages/mysql/index.cjs
@@ -78,9 +78,25 @@ const runQuery = async (queryString, database) => {
             database: database ? database.database : process.env["MYSQL_DATABASE"] || process.env["database"] || process.env["DATABASE"],
             password: database ? database.password : process.env["MYSQL_PASSWORD"] || process.env["password"] || process.env["PASSWORD"],
             port: database ? database.port : process.env["MYSQL_PORT"] || process.env["port"] || process.env["PORT"],
-            ssl: database ? database.ssl : process.env["MYSQL_SSL"] || process.env["ssl"] || process.env["SSL"],
             socketPath: database ? database.socketPath : process.env["MYSQL_SOCKETPATH"] || process.env["socketPath"] || process.env["SOCKETPATH"],
             decimalNumbers: true
+        }
+        
+        let ssl_opt = database ? database.ssl : process.env["MYSQL_SSL"] || process.env["ssl"] || process.env["SSL"]
+        
+        if (ssl_opt === "true") {
+            credentials = Object.assign(credentials, {ssl: {}});
+        } else if (ssl_opt === "Amazon RDS") {
+            credentials = Object.assign(credentials, {ssl: 'Amazon RDS'});
+        } else if (ssl_opt === 'false' || ssl_opt === '' || ssl_opt === undefined) {
+            credentials = credentials
+        } else {
+            try {
+                let obj = JSON.parse(ssl_opt);
+                credentials = Object.assign(credentials, {ssl: obj});
+            } catch (e) {
+                console.log(e)
+            }
         }
 
         var pool = mysql.createPool(credentials);


### PR DESCRIPTION
### Description
The current mysql connection for evidence is not working, even if the ssl option is not set. This is because 'true' is not a valid option for mysql2, as seen in this example: https://github.com/sidorares/node-mysql2/tree/07a429d9765dcbb24af4264654e973847236e0de/examples/ssl

This PR addresses the following issues:

* Users can set ssl to `true`
* Users can set ssl to `Amazon RDS`
* Users can set ssl to `JSON` string in order to handle more complex situations, such as https://mariadb.com/kb/en/nodejs-connection-options/#two-way-ssl-authentication
More information can be found here: https://github.com/evidence-dev/evidence/pull/518#issuecomment-1399571132

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
