### PR TITLE
Reduce imports from echarts library

### DIFF
--- a/.changeset/many-cobras-warn.md
+++ b/.changeset/many-cobras-warn.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Reduces size of imports from echarts library

--- a/sites/example-project/src/components/modules/echarts.js
+++ b/sites/example-project/src/components/modules/echarts.js
@@ -1,9 +1,9 @@
-import * as echarts from 'echarts';
+import {registerTheme, init} from 'echarts';
 import {colours} from './colours'
 
 
 export default(node, option, renderer) => {
-	echarts.registerTheme('evidence-light', {
+	registerTheme('evidence-light', {
         "grid": {
             "left": "0%",
             "right": "4%",
@@ -435,7 +435,7 @@ export default(node, option, renderer) => {
         }
     });
 
-    const chart = echarts.init(node, 'evidence-light', {renderer: 'svg'});   
+    const chart = init(node, 'evidence-light', {renderer: 'svg'});   
 
 	chart.setOption(option);
 

--- a/sites/example-project/src/components/modules/echartsCanvasDownload.js
+++ b/sites/example-project/src/components/modules/echartsCanvasDownload.js
@@ -1,11 +1,11 @@
-import * as echarts from 'echarts';
+import {registerTheme, init} from 'echarts';
 import download from 'downloadjs';
 import {colours} from './colours'
 
 
 export default(node, option) => {
 
-	echarts.registerTheme('evidence-light', {
+	registerTheme('evidence-light', {
         "grid": {
             "left": "0%",
             "right": "4%",
@@ -437,7 +437,7 @@ export default(node, option) => {
         }
     });
 
-    const chart = echarts.init(node, 'evidence-light', {renderer: 'canvas'});   
+    const chart = init(node, 'evidence-light', {renderer: 'canvas'});   
 
     option.animation = false
 

--- a/sites/example-project/src/components/modules/echartsCopy.js
+++ b/sites/example-project/src/components/modules/echartsCopy.js
@@ -1,9 +1,9 @@
-import * as echarts from 'echarts';
+import {registerTheme, init} from 'echarts';
 import {colours} from './colours'
 
 
 export default(node, option, renderer) => {
-	echarts.registerTheme('evidence-light', 
+	registerTheme('evidence-light', 
     {
         "grid": {
             "left": "0%",
@@ -436,7 +436,7 @@ export default(node, option, renderer) => {
         }
     });
 
-    const chart = echarts.init(node, 'evidence-light', {renderer: 'canvas'});   
+    const chart = init(node, 'evidence-light', {renderer: 'canvas'});   
     option.animation = false // disable animation
 
 	chart.setOption(option);


### PR DESCRIPTION
### Description
Previously, we were importing the full echarts library wherever it was used in the project, even though we only use 2 functions each time we import it. This PR reduces the imports to only the required functions. Thanks @Winterhart for the suggestion!

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
