### PR TITLE
Add Prerelease Github Action

### DIFF
--- a/.changeset/violet-squids-protect.md
+++ b/.changeset/violet-squids-protect.md
@@ -1,0 +1,20 @@
+---
+"@evidence-dev/bigquery": patch
+"@evidence-dev/db-commons": patch
+"@evidence-dev/db-orchestrator": patch
+"@evidence-dev/duckdb": patch
+"@evidence-dev/evidence": patch
+"evidence-vscode": patch
+"@evidence-dev/mysql": patch
+"@evidence-dev/postgres": patch
+"@evidence-dev/preprocess": patch
+"@evidence-dev/redshift": patch
+"@evidence-dev/snowflake": patch
+"@evidence-dev/sqlite": patch
+"@evidence-dev/telemetry": patch
+"evidence-docs": patch
+"@evidence-dev/components": patch
+"evidence-test-environment": patch
+---
+
+Addition of a "next" release tag in-sync with main branch

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,5 +25,4 @@ jobs:
       - name: Publish tag:next to npm registry
         run: pnpm run release:next
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Prerelease
 on:
   push:
     branches:
-      - main
+      - 594-set-up-pre-release-branch
 jobs:
   prerelease:
     if: github.repository == 'evidence-dev/evidence'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry
-        run: VERSION=$(git rev-parse --short HEAD); pnpm -r exec npm pkg set version="0.0.0-$VERSION"; pnpm publish --tag next --no-git-checks --dry-run
+        run: release:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry
-        run: release:next
+        run: pnpm release:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,35 @@
+name: Prerelease
+
+on:
+  push:
+    branches:
+      # temporary for testing the feature, will move to main
+      - 594-set-up-pre-release-branch
+jobs:
+  prerelease:
+    if: github.repository == 'evidence-dev/evidence'
+    name: Prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2.2.1
+        with:
+          version: 6.23.2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release:next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Prerelease
 on:
   push:
     branches:
-      - 594-set-up-pre-release-branch
+      - main
 jobs:
   prerelease:
     if: github.repository == 'evidence-dev/evidence'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry
-        run: pnpm release:next
+        run: VERSION=$(git rev-parse --short HEAD); pnpm -r exec npm pkg set version="0.0.0-$VERSION"; pnpm publish --tag next --no-git-checks --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry
         run: pnpm run release:next
         env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,8 +3,7 @@ name: Prerelease
 on:
   push:
     branches:
-      # temporary for testing the feature, will move to main
-      - 594-set-up-pre-release-branch
+      - main
 jobs:
   prerelease:
     if: github.repository == 'evidence-dev/evidence'
@@ -14,7 +13,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
       - uses: pnpm/action-setup@v2.2.1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
       - name: Publish tag:next to npm registry
         run: pnpm run release:next

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish tag:next to npm registry
-        run: pnpm release:next
+        run: pnpm run release:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,11 +25,8 @@ jobs:
           node-version: 16.x
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release:next
+      - name: Publish tag:next to npm registry
+        run: pnpm release:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"build:dev-workspace": "pnpm --filter ./sites/example-project build", 
 		"build:production": "VITE_BUILD_STRICT=true pnpm --filter ./sites/example-project build", 
 		"release": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm changeset publish",
+		"release:next": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm publish --tag next",
 		"test": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --frozen-lockfile && pnpm -r test",
 		"postinstall": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --ignore-scripts "
 	}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"build:dev-workspace": "pnpm --filter ./sites/example-project build", 
 		"build:production": "VITE_BUILD_STRICT=true pnpm --filter ./sites/example-project build", 
 		"release": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm changeset publish",
-		"release:next": "VERSION=$(git rev-parse --short HEAD) && pnpm -r exec npm pkg set version=0.0.0-\"$VERSION\" && pnpm -r publish --tag next --no-git-checks --dry-run",
+		"release:next": "VERSION=$(git rev-parse --short HEAD) && pnpm -r exec npm pkg set version=0.0.0-\"$VERSION\" && pnpm install --frozen-lockfile && pnpm -r publish --tag next --no-git-checks",
 		"test": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --frozen-lockfile && pnpm -r test",
 		"postinstall": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --ignore-scripts "
 	}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"build:dev-workspace": "pnpm --filter ./sites/example-project build", 
 		"build:production": "VITE_BUILD_STRICT=true pnpm --filter ./sites/example-project build", 
 		"release": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm changeset publish",
-		"release:next": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm publish --tag next",
+		"release:next": "VERSION=$(git rev-parse --short HEAD) && pnpm -r exec npm pkg set version=0.0.0-\"$VERSION\" && pnpm -r publish --tag next --no-git-checks --dry-run",
 		"test": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --frozen-lockfile && pnpm -r test",
 		"postinstall": "pnpm --filter ./sites/example-project package && pnpm --filter ./packages/evidence build && pnpm install --ignore-scripts "
 	}


### PR DESCRIPTION
### Description

We will `pre-release` on merge with `main` allowing to test, before major release. On `npm` registry the tag `next` will be `sync` with the latest changes on `main`


### Demo Project on `next`

![594-npm-next-tag](https://user-images.githubusercontent.com/10125507/215891132-6b3218c0-bf4d-41ae-baac-698e326962f7.gif)


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
