### PR TITLE
Add map links

### DIFF
--- a/.changeset/blue-tables-prove.md
+++ b/.changeset/blue-tables-prove.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Add link function to US map

--- a/sites/example-project/src/components/modules/echartsMap.js
+++ b/sites/example-project/src/components/modules/echartsMap.js
@@ -5,9 +5,11 @@ export default(node, option, renderer) => {
 
     registerMap('US', usStateMap);
 
+    let hasLink = option.hasLink;
+
     const chart = init(node, 'none', {renderer: 'svg'});   
 
-	chart.setOption(option);
+	chart.setOption(option.config);
       
     let resizeObserver
     const containerElement = document.querySelector('div.content > article')
@@ -19,6 +21,14 @@ export default(node, option, renderer) => {
         })
     }
     
+    if(hasLink){
+        chart.on('click', function (params) {
+            if(params.data && params.data.link){
+                window.location = params.data.link;
+            }
+        });    
+    }
+
     if (window.ResizeObserver && containerElement) {
         resizeObserver = new ResizeObserver(resizeChart)
         resizeObserver.observe(containerElement)
@@ -28,7 +38,7 @@ export default(node, option, renderer) => {
 
     return {
 		update(option){
-			chart.setOption(option, true, true);
+			chart.setOption(option.config, true, true);
 		},
         destroy() {
             if (resizeObserver) {

--- a/sites/example-project/src/components/viz/EChartsMap.svelte
+++ b/sites/example-project/src/components/viz/EChartsMap.svelte
@@ -12,6 +12,8 @@
 
     export let data;
 
+    export let hasLink = false;
+
     let downloadChart = false;
     let copying = false
     let hovering = false
@@ -31,7 +33,7 @@
         margin-bottom: 10px;
         overflow: visible;
     "
-    use:echartsMap={config}
+    use:echartsMap={{config, hasLink}}
 />
 
 <EchartsCopyTarget {config} {height} {width} {copying}/> 

--- a/sites/example-project/src/components/viz/USMap.svelte
+++ b/sites/example-project/src/components/viz/USMap.svelte
@@ -17,6 +17,9 @@
 
     export let title = undefined;
     export let subtitle = undefined;
+    
+    export let link = undefined;
+    let hasLink = link !== undefined;
 
     let chartType = "US State Map";
     let error;
@@ -100,6 +103,9 @@
       for(let i=0; i<data.length; i++){
         mapData[i].name = data[i][state];
         mapData[i].value = data[i][value];
+        if(link){
+          mapData[i].link = data[i][link];
+        }
       }
 
       config = {
@@ -234,7 +240,16 @@
 
 {#if !error}
 
-<EChartsMap {config} {data}/>
+<EChartsMap {config} {data} {hasLink}/>
+
+{#if link}
+  {#each data as row}
+    {#if row[link] !== undefined}
+      <!-- svelte-ignore a11y-missing-content -->
+      <a href={row[link]} style="display: none;">{row[link]}</a>
+    {/if}
+  {/each}
+{/if}
 
 {:else}
 

--- a/sites/example-project/src/pages/states/[state].md
+++ b/sites/example-project/src/pages/states/[state].md
@@ -1,0 +1,132 @@
+```state_current
+select "CA" as state, "2022-12" as month, 198 as value
+union all
+select "NY" as state, "2022-12" as month, 321 as value
+union all
+select "TX" as state, "2022-12" as month, 321 as value
+union all
+select "AL" as state, "2022-12" as month, 321 as value
+union all
+select "DC" as state, "2022-12" as month, 321 as value
+union all
+select "FL" as state, "2022-12" as month, 321 as value
+union all
+select "GA" as state, "2022-12" as month, 321 as value
+union all
+select "ID" as state, "2022-12" as month, 321 as value
+union all
+select "IL" as state, "2022-12" as month, 321 as value
+union all
+select "LA" as state, "2022-12" as month, 321 as value
+union all
+select "MO" as state, "2022-12" as month, 321 as value
+union all
+select "MI" as state, "2022-12" as month, 321 as value
+union all
+select "MS" as state, "2022-12" as month, 321 as value
+union all
+select "NE" as state, "2022-12" as month, 321 as value
+union all
+select "NV" as state, "2022-12" as month, 321 as value
+union all
+select "OH" as state, "2022-12" as month, 321 as value
+union all
+select "OK" as state, "2022-12" as month, 321 as value
+union all
+select "PA" as state, "2022-12" as month, 321 as value
+union all
+select "RI" as state, "2022-12" as month, 321 as value
+union all
+select "CT" as state, "2022-12" as month, 321 as value
+union all
+select "SD" as state, "2022-12" as month, 321 as value
+union all
+select "ND" as state, "2022-12" as month, 321 as value
+union all
+select "MT" as state, "2022-12" as month, 321 as value
+union all
+select "UT" as state, "2022-12" as month, 321 as value
+union all
+select "VA" as state, "2022-12" as month, 321 as value
+union all
+select "WV" as state, "2022-12" as month, 321 as value
+
+```
+
+```state_trend
+select "CA" as state, date("2022-01-01") as month, 100 as value
+union all
+select "CA" as state, date("2022-02-01") as month, 103 as value
+union all
+select "CA" as state, date("2022-03-01") as month, 106 as value
+union all
+select "CA" as state, date("2022-04-01") as month, 111 as value
+union all
+select "CA" as state, date("2022-05-01") as month, 121 as value
+union all
+select "CA" as state, date("2022-06-01") as month, 102 as value
+union all
+select "CA" as state, date("2022-07-01") as month, 112 as value
+union all
+select "CA" as state, date("2022-08-01") as month, 103 as value
+union all
+select "CA" as state, date("2022-09-01") as month, 98 as value
+union all
+select "CA" as state, date("2022-10-01") as month, 121 as value
+union all
+select "CA" as state, date("2022-11-01") as month, 146 as value
+union all
+select "CA" as state, date("2022-12-01") as month, 198 as value
+union all
+select "NY" as state, date("2022-01-01") as month, 200 as value
+union all
+select "NY" as state, date("2022-02-01") as month, 203 as value
+union all
+select "NY" as state, date("2022-03-01") as month, 206 as value
+union all
+select "NY" as state, date("2022-04-01") as month, 211 as value
+union all
+select "NY" as state, date("2022-05-01") as month, 222 as value
+union all
+select "NY" as state, date("2022-06-01") as month, 235 as value
+union all
+select "NY" as state, date("2022-07-01") as month, 265 as value
+union all
+select "NY" as state, date("2022-08-01") as month, 288 as value
+union all
+select "NY" as state, date("2022-09-01") as month, 312 as value
+union all
+select "NY" as state, date("2022-10-01") as month, 285 as value
+union all
+select "NY" as state, date("2022-11-01") as month, 292 as value
+union all
+select "NY" as state, date("2022-12-01") as month, 321 as value
+union all
+select "TX" as state, date("2022-01-01") as month, 250 as value
+union all
+select "TX" as state, date("2022-02-01") as month, 223 as value
+union all
+select "TX" as state, date("2022-03-01") as month, 236 as value
+union all
+select "TX" as state, date("2022-04-01") as month, 261 as value
+union all
+select "TX" as state, date("2022-05-01") as month, 182 as value
+union all
+select "TX" as state, date("2022-06-01") as month, 85 as value
+union all
+select "TX" as state, date("2022-07-01") as month, 95 as value
+union all
+select "TX" as state, date("2022-08-01") as month, 212 as value
+union all
+select "TX" as state, date("2022-09-01") as month, 312 as value
+union all
+select "TX" as state, date("2022-10-01") as month, 285 as value
+union all
+select "TX" as state, date("2022-11-01") as month, 292 as value
+union all
+select "TX" as state, date("2022-12-01") as month, 321 as value
+```
+
+# Detail for {$page.params.state}
+<LineChart data={state_trend.filter(d => d.state === $page.params.state)} x=month y=value/>
+

--- a/sites/example-project/src/pages/states/index.md
+++ b/sites/example-project/src/pages/states/index.md
@@ -1,0 +1,22 @@
+```state_current
+select "CA" as state, "2022-12" as month, 198 as value, "states/CA" as state_link
+union all
+select "NY" as state, "2022-12" as month, 321 as value, "states/NY" as state_link
+union all
+select "TX" as state, "2022-12" as month, 321 as value, "states/TX" as state_link
+```
+
+```most_recent_month
+select max(month) as month from ${state_current}
+```
+
+<USMap 
+    data={state_current} 
+    state=state 
+    value=value 
+    abbreviations=true
+    link=state_link
+    title="Sales by State"
+    subtitle="{most_recent_month[0].month}"
+/>
+


### PR DESCRIPTION
### Description
Adds a `link` property to the USMap component, which lets you pass a column of links to the map. When you click on each state, it takes you to the link provided:
![CleanShot 2023-01-30 at 12 44 42](https://user-images.githubusercontent.com/12602440/215592306-4ccf9816-0e3b-4ca4-ae0d-4569722184f7.gif)


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
