### PR TITLE
Fix value formatting in datatable

### DIFF
--- a/.changeset/long-rocks-care.md
+++ b/.changeset/long-rocks-care.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix for value formatting in DataTable

--- a/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/sites/example-project/src/components/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -89,9 +89,9 @@
                        {formatValue(cell, columnSummary[j].format, columnSummary[j].columnUnitSummary)}
                     </td>
                   {:else if columnSummary[j].type === 'date'}
-                  <td class="string" style="width:{columnWidths}%" title={formatValue(cell, columnSummary[j].format)}>
+                  <td class="string" style="width:{columnWidths}%" title={formatValue(cell, columnSummary[j].format, columnSummary[j].columnUnitSummary)}>
                     <div >
-                        {formatValue(cell, columnSummary[j].format)}
+                        {formatValue(cell, columnSummary[j].format, columnSummary[j].columnUnitSummary)}
                     </div>
                   </td>
                   {:else if columnSummary[j].type === 'string'}

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -381,16 +381,16 @@
                         >
                         {#if column.linkLabel != undefined}
                             {#if row[column.linkLabel] != undefined}
-                                {formatValue(row[column.linkLabel], safeExtractColumn(column).format)}
+                                {formatValue(row[column.linkLabel], safeExtractColumn(column).format, safeExtractColumn(column).columnUnitSummary)}
                             {:else}
                                 {column.linkLabel}
                             {/if}
                         {:else}
-                            {formatValue(row[column.id], safeExtractColumn(column).format)}
+                            {formatValue(row[column.id], safeExtractColumn(column).format, safeExtractColumn(column).columnUnitSummary)}
                         {/if}
                     </a>
                   {:else}
-                    {formatValue(row[column.id], safeExtractColumn(column).format)}
+                    {formatValue(row[column.id], safeExtractColumn(column).format, safeExtractColumn(column).columnUnitSummary)}
                   {/if}
                 </td>
               {/each}
@@ -399,7 +399,7 @@
               <td 
               class="{column.type}"
               class:row-lines={rowLines}
-              >{formatValue(row[column.id], column.format)}</td>
+              >{formatValue(row[column.id], column.format, column.columnUnitSummary)}</td>
               {/each}
           {/if}
       </tr>


### PR DESCRIPTION
### Description
Value formatting in DataTable was missing the "units" portion of our formatting system (e.g., summarizing numbers to "k", "M", etc.). This PR adds that feature back in.

#### Before:
<img width="580" alt="dt-format-before" src="https://user-images.githubusercontent.com/12602440/216106130-22f0e542-01a8-4524-ad64-808399fd0173.png">

#### After:
<img width="578" alt="dt-format-after" src="https://user-images.githubusercontent.com/12602440/216106134-97ece9d6-db9d-41eb-b5e2-affb3ad70178.png">


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
