### PR TITLE
fix datatable download button and spacing

### DIFF
--- a/.changeset/rotten-frogs-knock.md
+++ b/.changeset/rotten-frogs-knock.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix for data download button in DataTable

--- a/sites/docs/docs/features/data-table.md
+++ b/sites/docs/docs/features/data-table.md
@@ -171,7 +171,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 ### All Options
 * **data** - query name, wrapped in curly braces
-* **rows** - (Optional) # of rows to show in the table before paginating results. Default is 10 rows
+* **rows** - (Optional) # of rows to show in the table before paginating results. Default is 10 rows. Use `rows=all` to show all rows in the table.
 * **rowNumbers** - (Optional) true | false - turns on or off row index numbers (off by default)
 * **rowLines** - (Optional) true | false - turns on or off borders at the bottom of each row (on by default)
 * **rowShading** - (Optional) true | false - shades every second row in light grey (off by default)

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -572,6 +572,7 @@
       user-select: none;
       text-align: right; 
       margin-top: 0.5em; 
+      margin-bottom: 1.8em;
       font-variant-numeric: tabular-nums;
   }
 

--- a/sites/example-project/src/components/viz/DataTable.svelte
+++ b/sites/example-project/src/components/viz/DataTable.svelte
@@ -34,7 +34,7 @@
 
   let marginTop = '1.5em';
   let marginBottom = '1em';
-  let paddingBottom = '1.5em';
+  let paddingBottom = '0em';
 
   // Table features
   export let search = false;
@@ -425,7 +425,15 @@
           <MdLastPage/>
       </div></button>
   </div>
+    {#if downloadable}
         <DownloadData class=download-button data={tableData} display={hovering}/>
+    {/if}
+</div>
+{:else}
+<div class=table-footer>
+    {#if downloadable}
+        <DownloadData class=download-button data={tableData} display={hovering}/>
+    {/if}
 </div>
 {/if}
 
@@ -617,6 +625,14 @@
     color: var(--grey-500);
   }
 
+  .table-footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin: 10px 0px;
+    font-size: 12px;
+    height: 9px
+  }
 
 /* Remove number buttons in input box*/
   .page-input::-webkit-outer-spin-button,

--- a/sites/example-project/src/components/viz/SearchBar.svelte
+++ b/sites/example-project/src/components/viz/SearchBar.svelte
@@ -23,7 +23,7 @@
         border-radius: 4px;
         height: 22px;
         position: relative;
-        margin: 10px 3px 10px 3px;
+        margin: 25px 3px 10px 3px;
     }
 
 


### PR DESCRIPTION
### Description
Fixes the following in DataTable:
- Enables `downloadable` option to turn on/off download button
- Fixes download button not appearing on non-paginated tables
- Cleans up spacing below the table
- Documents the `rows=all` feature

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
