### PR TITLE
CSV Support

### DIFF
--- a/.changeset/hip-deers-look.md
+++ b/.changeset/hip-deers-look.md
@@ -1,0 +1,8 @@
+---
+"@evidence-dev/csv": minor
+"@evidence-dev/db-orchestrator": minor
+"@evidence-dev/evidence": minor
+"@evidence-dev/components": minor
+---
+
+Add CSV connector

--- a/packages/csv/.gitignore
+++ b/packages/csv/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/csv/index.cjs
+++ b/packages/csv/index.cjs
@@ -1,0 +1,4 @@
+const runQuery = require('@evidence-dev/duckdb')
+
+module.exports = runQuery
+

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@evidence-dev/csv",
+  "version": "0.0.1",
+  "description": "Redshift driver for Evidence projects",
+  "main": "index.cjs",
+  "author": "Sean Hughes",
+  "license": "MIT",
+  "scripts": {
+    "test": "uvu test test.js"
+  },
+  "dependencies": {
+    "@evidence-dev/duckdb": "workspace:^",
+    "@evidence-dev/db-commons": "workspace:^"
+  },
+  "type": "module"
+}

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -12,5 +12,8 @@
     "@evidence-dev/duckdb": "workspace:^",
     "@evidence-dev/db-commons": "workspace:^"
   },
+  "devDependencies": {
+    "dotenv": "^16.0.1"
+  },
   "type": "module"
 }

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evidence-dev/csv",
   "version": "0.0.1",
-  "description": "Redshift driver for Evidence projects",
+  "description": "CSV driver for Evidence projects, based on DuckDB driver",
   "main": "index.cjs",
   "author": "Sean Hughes",
   "license": "MIT",

--- a/packages/csv/test/test.js
+++ b/packages/csv/test/test.js
@@ -1,0 +1,34 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import runQuery from '../index.cjs';
+import { TypeFidelity } from '@evidence-dev/db-commons';
+import 'dotenv/config';
+
+let results;
+
+test('query runs', async () => {
+    try{
+        results = await runQuery("select 100 as number_col, current_date as date_col, current_timestamp as timestamp_col, 'Evidence' as string_col, false as bool_col");
+        console.log(results);
+        assert.instance(results.rows, Array);
+        assert.instance(results.columnTypes, Array);
+        assert.type(results.rows[0], "object");
+        assert.equal(results.rows[0].number_col, 100);
+
+        let actualColumnTypes = results.columnTypes.map(columnType => columnType.evidenceType);
+        let actualColumnNames = results.columnTypes.map(columnType => columnType.name);
+        let actualTypePrecisions = results.columnTypes.map(columnType => columnType.typeFidelity);
+
+        let expectedColumnTypes = ['number', 'date', 'date', 'string', 'boolean'];
+        let expectedColumnNames = ['number_col', 'date_col', 'timestamp_col', 'string_col', 'bool_col'];
+        let expectedTypePrecision = Array(5).fill(TypeFidelity.INFERRED);
+
+        assert.equal(true, (expectedColumnTypes.length === actualColumnTypes.length && expectedColumnTypes.every((value, index) => value === actualColumnTypes[index])));
+        assert.equal(true, (expectedColumnNames.length === actualColumnNames.length && expectedColumnNames.every((value, index) => value === actualColumnNames[index])));
+        assert.equal(true, (expectedTypePrecision.length === actualTypePrecisions.length && expectedTypePrecision.every((value, index) => value === actualTypePrecisions[index])));
+    } catch(e) {
+        throw Error(e)
+    }
+})
+
+test.run();

--- a/packages/db-orchestrator/package.json
+++ b/packages/db-orchestrator/package.json
@@ -13,6 +13,7 @@
     "@evidence-dev/redshift": "workspace:^",
     "@evidence-dev/sqlite": "workspace:^",
     "@evidence-dev/duckdb": "workspace:^",
+    "@evidence-dev/csv": "workspace:^",
     "@evidence-dev/telemetry": "workspace:^",
     "@evidence-dev/db-commons": "workspace:^",
     "blueimp-md5": "2.18.0",

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -85,7 +85,8 @@ const watchPatterns =
     [
       {'sourceRelative': './pages/','targetRelative':'./.evidence/template/src/pages/','filePattern':'**'} // markdown pages
       ,{'sourceRelative': './static/','targetRelative':'./.evidence/template/static/','filePattern':'**'} // static files (eg images)
-      ,{'sourceRelative': './components/','targetRelative':'./.evidence/template/src/components/','filePattern':'**'} // custome components
+      ,{'sourceRelative': './sources/','targetRelative':'./.evidence/template/sources/','filePattern':'**'} // source files (eg csv files)
+      ,{'sourceRelative': './components/','targetRelative':'./.evidence/template/src/components/','filePattern':'**'} // custom components
       ,{'sourceRelative': '.','targetRelative':'./.evidence/template/src/','filePattern':'app.css'} // custom theme file
     ]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,12 @@ importers:
     specifiers:
       '@evidence-dev/db-commons': workspace:^
       '@evidence-dev/duckdb': workspace:^
+      dotenv: ^16.0.1
     dependencies:
       '@evidence-dev/db-commons': link:../db-commons
       '@evidence-dev/duckdb': link:../duckdb
+    devDependencies:
+      dotenv: 16.0.1
 
   packages/db-commons:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -50,12 +50,12 @@ importers:
       export-to-csv: 0.2.1
       git-remote-origin-url: 4.0.0
       prettier: 2.6.2
-      prettier-plugin-svelte: 2.7.0_prettier@2.6.2+svelte@3.53.1
+      prettier-plugin-svelte: 2.7.0_dhgc3nm4qbaahazvwcpyr4wtfe
       prismjs: 1.29.0
       ssf: 0.11.2
       svelte: 3.53.1
       svelte-icons: 2.1.0
-      svelte2tsx: 0.4.7_svelte@3.53.1+typescript@4.5.4
+      svelte2tsx: 0.4.7_7uyzgzkbjy6f7owetbs6ny3nau
       typescript: 4.5.4
       uvu: 0.5.2
       vite: 2.9.5
@@ -176,13 +176,13 @@ importers:
       '@types/mocha': 9.0.0
       '@types/node': 14.17.9
       '@types/vscode': 1.63.0
-      '@typescript-eslint/eslint-plugin': 5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3
-      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 5.7.0_26qnnnmunc2nf2ry66bpj4is4m
+      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
       '@vscode/test-electron': 1.6.2
       eslint: 8.4.1
       glob: 7.1.7
       mocha: 9.1.3
-      ts-loader: 9.2.6_typescript@4.4.4+webpack@5.65.0
+      ts-loader: 9.2.6_ohqq63mdhocqvr4wpaakehweqe
       typescript: 4.4.4
       webpack: 5.65.0_webpack-cli@4.9.1
       webpack-cli: 4.9.1_webpack@5.65.0
@@ -217,7 +217,7 @@ importers:
     dependencies:
       blueimp-md5: 2.19.0
       fs-extra: 9.1.0
-      mdsvex: 0.10.6_svelte@3.53.1
+      mdsvex: 0.10.6
       remark-parse: 8.0.2
       unified: 9.2.1
       unist-util-visit: 2.0.3
@@ -283,10 +283,10 @@ importers:
       remark-math: '3'
       url-loader: ^4.1.1
     dependencies:
-      '@docusaurus/core': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/preset-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/core': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/preset-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@svgr/webpack': 5.5.0
       clsx: 1.1.1
@@ -330,6 +330,7 @@ importers:
       cross-env: 7.0.3
       fs-extra: 10.0.1
       jest: 28.1.2
+    publishDirectory: ../../packages/components
 
   sites/test-env:
     specifiers:
@@ -3282,7 +3283,7 @@ packages:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
     dev: false
 
-  /@docsearch/react/3.3.0_react-dom@17.0.2+react@17.0.2:
+  /@docsearch/react/3.3.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -3306,7 +3307,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/core/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3326,15 +3327,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0
-      '@docusaurus/utils-common': 2.1.0
-      '@docusaurus/utils-validation': 2.1.0
+      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
+      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3346,7 +3347,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
+      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3362,16 +3363,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
+      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
+      react-dev-utils: 12.0.1_webpack@5.74.0
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
+      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3380,7 +3381,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3406,7 +3407,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/core/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
+  /@docusaurus/core/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3426,15 +3427,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils': 2.1.0
+      '@docusaurus/utils-common': 2.1.0
+      '@docusaurus/utils-validation': 2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
+      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3446,7 +3447,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
+      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3462,16 +3463,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
+      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
+      react-dev-utils: 12.0.1_webpack@5.74.0
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
+      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3480,7 +3481,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3524,7 +3525,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_6e39cab45d9f22ba28fa56595d174ac9:
+  /@docusaurus/mdx-loader/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3548,7 +3549,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3559,7 +3560,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/mdx-loader/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3583,7 +3584,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3594,21 +3595,21 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/module-type-aliases/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/module-type-aliases/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@types/history': 4.7.11
       '@types/react': 18.0.24
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -3617,17 +3618,17 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-blog/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-blog/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3660,18 +3661,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-docs/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@types/react-router-config': 5.0.6
@@ -3703,16 +3704,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-content-pages/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
@@ -3738,20 +3739,20 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-debug/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-json-view: 1.21.3_react-dom@17.0.2+react@17.0.2
+      react-json-view: 1.21.3_sfoxds7t5ydpegc3knd667wn6m
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -3772,15 +3773,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-google-analytics/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3803,15 +3804,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-google-gtag/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3834,16 +3835,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/plugin-sitemap/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3870,25 +3871,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/preset-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-debug': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-google-analytics': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-google-gtag': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-sitemap': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/theme-search-algolia': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-debug': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-google-analytics': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-google-gtag': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-sitemap': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/theme-search-algolia': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3921,22 +3922,22 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@docusaurus/theme-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/theme-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/theme-translations': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3973,60 +3974,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
+  /@docusaurus/theme-common/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/utils': 2.1.0
-      '@types/history': 4.7.11
-      '@types/react': 18.0.24
-      '@types/react-router-config': 5.0.6
-      clsx: 1.2.1
-      parse-numeric-range: 1.3.0
-      prism-react-renderer: 1.3.5_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      tslib: 2.4.0
-      utility-types: 3.10.0
-    transitivePeerDependencies:
-      - '@docusaurus/types'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@swc/css'
-      - bufferutil
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - lightningcss
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-    dev: false
-
-  /@docusaurus/theme-common/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
-    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
-    engines: {node: '>=16.14'}
-    peerDependencies:
-      react: ^16.8.4 || ^17.0.0
-      react-dom: ^16.8.4 || ^17.0.0
-    dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
-      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@types/history': 4.7.11
       '@types/react': 18.0.24
@@ -4057,18 +4016,60 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
+  /@docusaurus/theme-common/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.1.0
+      '@types/history': 4.7.11
+      '@types/react': 18.0.24
+      '@types/react-router-config': 5.0.6
+      clsx: 1.2.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 1.3.5_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/theme-search-algolia/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
     resolution: {integrity: sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.3.0_react-dom@17.0.2+react@17.0.2
-      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docsearch/react': 3.3.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
-      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
       '@docusaurus/theme-translations': 2.1.0
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -4111,7 +4112,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/types/2.1.0_react-dom@17.0.2+react@17.0.2:
+  /@docusaurus/types/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
@@ -4123,7 +4124,7 @@ packages:
       joi: 17.6.4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
+      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
       utility-types: 3.10.0
       webpack: 5.74.0
       webpack-merge: 5.8.0
@@ -4155,7 +4156,7 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       tslib: 2.4.0
     dev: false
 
@@ -4217,7 +4218,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4237,7 +4238,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
       '@svgr/webpack': 6.5.1
       file-loader: 6.2.0_webpack@5.74.0
       fs-extra: 10.1.0
@@ -4250,7 +4251,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
+      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -5559,7 +5560,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3:
+  /@typescript-eslint/eslint-plugin/5.7.0_26qnnnmunc2nf2ry66bpj4is4m:
     resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5570,8 +5571,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0_eslint@8.4.1+typescript@4.4.4
-      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
+      '@typescript-eslint/experimental-utils': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
+      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
       '@typescript-eslint/scope-manager': 5.7.0
       debug: 4.3.2
       eslint: 8.4.1
@@ -5585,7 +5586,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.7.0_eslint@8.4.1+typescript@4.4.4:
+  /@typescript-eslint/experimental-utils/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
     resolution: {integrity: sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5603,7 +5604,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.7.0_eslint@8.4.1+typescript@4.4.4:
+  /@typescript-eslint/parser/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
     resolution: {integrity: sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5772,7 +5773,7 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
 
-  /@webpack-cli/configtest/1.1.0_webpack-cli@4.9.1+webpack@5.65.0:
+  /@webpack-cli/configtest/1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm:
     resolution: {integrity: sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
@@ -6248,7 +6249,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6256,7 +6257,7 @@ packages:
   /axios/0.27.2_debug@3.2.7:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -6287,7 +6288,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_f645c55d63e77e0aacb83a76bcc9695b:
+  /babel-loader/8.2.5_6zc4kxld457avlfyhj3lzsljlm:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -6550,6 +6551,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /bonjour-service/1.0.14:
@@ -6732,6 +6735,8 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
     dev: false
     optional: true
 
@@ -6757,6 +6762,8 @@ packages:
       ssri: 9.0.1
       tar: 6.1.11
       unique-filename: 2.0.1
+    transitivePeerDependencies:
+      - bluebird
     dev: false
 
   /cacheable-request/6.1.0:
@@ -7198,6 +7205,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -7416,7 +7425,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /css-minimizer-webpack-plugin/4.2.2_clean-css@5.3.1+webpack@5.74.0:
+  /css-minimizer-webpack-plugin/4.2.2_kwz7aenajwsweas6icw5ncsgdy:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7699,12 +7708,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -7926,6 +7945,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -7935,6 +7956,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /diff-sequences/28.1.1:
@@ -8079,6 +8102,7 @@ packages:
     dependencies:
       duckdb: 0.6.1
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -8091,6 +8115,7 @@ packages:
       node-addon-api: 4.3.0
       node-gyp: 9.3.0
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -8863,6 +8888,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /extend-shallow/2.0.1:
@@ -9050,6 +9077,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-cache-dir/3.3.1:
@@ -9130,7 +9159,7 @@ packages:
         optional: true
     dev: false
 
-  /follow-redirects/1.15.2_debug@3.2.7:
+  /follow-redirects/1.15.2:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -9138,11 +9167,9 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 3.2.7
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.2_c312d410e43e390b1aefa8571ea033a1:
+  /fork-ts-checker-webpack-plugin/6.5.2_webpack@5.74.0:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9162,7 +9189,6 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      eslint: 8.18.0
       fs-extra: 9.1.0
       glob: 7.1.7
       memfs: 3.4.7
@@ -9170,7 +9196,6 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 4.5.4
       webpack: 5.74.0
     dev: false
 
@@ -9990,7 +10015,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -11446,6 +11471,7 @@ packages:
       socks-proxy-agent: 7.0.0
       ssri: 9.0.1
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
 
@@ -11470,6 +11496,7 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 8.0.1
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -11550,7 +11577,7 @@ packages:
     resolution: {integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==}
     dev: false
 
-  /mdsvex/0.10.6_svelte@3.53.1:
+  /mdsvex/0.10.6:
     resolution: {integrity: sha512-aGRDY0r5jx9+OOgFdyB9Xm3EBr9OUmcrTDPWLB7a7g8VPRxzPy4MOBmcVYgz7ErhAJ7bZ/coUoj6aHio3x/2mA==}
     peerDependencies:
       svelte: 3.x
@@ -11558,7 +11585,6 @@ packages:
       '@types/unist': 2.0.6
       prism-svelte: 0.4.7
       prismjs: 1.24.1
-      svelte: 3.53.1
       vfile-message: 2.0.4
     dev: false
 
@@ -12030,6 +12056,7 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -12050,6 +12077,7 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: false
 
@@ -12798,7 +12826,7 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: false
 
-  /postcss-loader/7.0.1_postcss@8.4.14+webpack@5.74.0:
+  /postcss-loader/7.0.1_m6qh27jiicejwnzfgs742cokpe:
     resolution: {integrity: sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -13420,7 +13448,7 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prettier-plugin-svelte/2.7.0_prettier@2.6.2+svelte@3.53.1:
+  /prettier-plugin-svelte/2.7.0_dhgc3nm4qbaahazvwcpyr4wtfe:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -13499,6 +13527,11 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
     dev: false
 
   /promise-retry/2.0.1:
@@ -13698,9 +13731,15 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-dev-utils/12.0.1_c312d410e43e390b1aefa8571ea033a1:
+  /react-dev-utils/12.0.1_webpack@5.74.0:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.1.2
@@ -13711,7 +13750,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_c312d410e43e390b1aefa8571ea033a1
+      fork-ts-checker-webpack-plugin: 6.5.2_webpack@5.74.0
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13726,11 +13765,11 @@ packages:
       shell-quote: 1.7.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.74.0
     transitivePeerDependencies:
       - eslint
-      - typescript
+      - supports-color
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dom/17.0.2_react@17.0.2:
@@ -13752,7 +13791,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-helmet-async/1.3.0_react-dom@17.0.2+react@17.0.2:
+  /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -13775,7 +13814,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-json-view/1.21.3_react-dom@17.0.2+react@17.0.2:
+  /react-json-view/1.21.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -13795,7 +13834,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-loadable-ssr-addon-v5-slorber/1.0.1_4e32ce23c6949bd47cf53d21bd84df08:
+  /react-loadable-ssr-addon-v5-slorber/1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -13807,7 +13846,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /react-router-config/5.1.1_react-router@5.3.4+react@17.0.2:
+  /react-router-config/5.1.1_2dl5roaqnyqqppnjni7uetnb3a:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
@@ -14485,6 +14524,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /seq-queue/0.0.5:
@@ -14520,6 +14561,8 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.35
       parseurl: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /serve-static/1.15.0:
@@ -14530,6 +14573,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -14904,6 +14949,7 @@ packages:
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -15190,7 +15236,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.7_svelte@3.53.1+typescript@4.5.4:
+  /svelte2tsx/0.4.7_7uyzgzkbjy6f7owetbs6ny3nau:
     resolution: {integrity: sha512-1HqRb8+I8H0Gli0+w8nTmyZgbtO/jJE3g27cNKYFyN0GMdpOh0CRmiWuMH1k9N2JugkviI7wqETanqJTR0SI+A==}
     peerDependencies:
       svelte: ^3.24
@@ -15517,7 +15563,7 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: false
 
-  /ts-loader/9.2.6_typescript@4.4.4+webpack@5.65.0:
+  /ts-loader/9.2.6_ohqq63mdhocqvr4wpaakehweqe:
     resolution: {integrity: sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -15956,7 +16002,7 @@ packages:
       schema-utils: 3.1.1
     dev: false
 
-  /url-loader/4.1.1_file-loader@6.2.0+webpack@5.74.0:
+  /url-loader/4.1.1_u4acmn7fe6yqgbrqzialkgh5lu:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16322,7 +16368,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@webpack-cli/configtest': 1.1.0_webpack-cli@4.9.1+webpack@5.65.0
+      '@webpack-cli/configtest': 1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm
       '@webpack-cli/info': 1.4.0_webpack-cli@4.9.1
       '@webpack-cli/serve': 1.6.0_webpack-cli@4.9.1
       colorette: 2.0.16

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -50,12 +50,12 @@ importers:
       export-to-csv: 0.2.1
       git-remote-origin-url: 4.0.0
       prettier: 2.6.2
-      prettier-plugin-svelte: 2.7.0_dhgc3nm4qbaahazvwcpyr4wtfe
+      prettier-plugin-svelte: 2.7.0_prettier@2.6.2+svelte@3.53.1
       prismjs: 1.29.0
       ssf: 0.11.2
       svelte: 3.53.1
       svelte-icons: 2.1.0
-      svelte2tsx: 0.4.7_7uyzgzkbjy6f7owetbs6ny3nau
+      svelte2tsx: 0.4.7_svelte@3.53.1+typescript@4.5.4
       typescript: 4.5.4
       uvu: 0.5.2
       vite: 2.9.5
@@ -73,6 +73,14 @@ importers:
     devDependencies:
       dotenv: 16.0.1
 
+  packages/csv:
+    specifiers:
+      '@evidence-dev/db-commons': workspace:^
+      '@evidence-dev/duckdb': workspace:^
+    dependencies:
+      '@evidence-dev/db-commons': link:../db-commons
+      '@evidence-dev/duckdb': link:../duckdb
+
   packages/db-commons:
     specifiers:
       fs-extra: 10.0.0
@@ -82,6 +90,7 @@ importers:
   packages/db-orchestrator:
     specifiers:
       '@evidence-dev/bigquery': workspace:^
+      '@evidence-dev/csv': workspace:^
       '@evidence-dev/db-commons': workspace:^
       '@evidence-dev/duckdb': workspace:^
       '@evidence-dev/mysql': workspace:^
@@ -95,6 +104,7 @@ importers:
       fs-extra: 9.1.0
     dependencies:
       '@evidence-dev/bigquery': link:../bigquery
+      '@evidence-dev/csv': link:../csv
       '@evidence-dev/db-commons': link:../db-commons
       '@evidence-dev/duckdb': link:../duckdb
       '@evidence-dev/mysql': link:../mysql
@@ -163,13 +173,13 @@ importers:
       '@types/mocha': 9.0.0
       '@types/node': 14.17.9
       '@types/vscode': 1.63.0
-      '@typescript-eslint/eslint-plugin': 5.7.0_26qnnnmunc2nf2ry66bpj4is4m
-      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
+      '@typescript-eslint/eslint-plugin': 5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3
+      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
       '@vscode/test-electron': 1.6.2
       eslint: 8.4.1
       glob: 7.1.7
       mocha: 9.1.3
-      ts-loader: 9.2.6_ohqq63mdhocqvr4wpaakehweqe
+      ts-loader: 9.2.6_typescript@4.4.4+webpack@5.65.0
       typescript: 4.4.4
       webpack: 5.65.0_webpack-cli@4.9.1
       webpack-cli: 4.9.1_webpack@5.65.0
@@ -204,7 +214,7 @@ importers:
     dependencies:
       blueimp-md5: 2.19.0
       fs-extra: 9.1.0
-      mdsvex: 0.10.6
+      mdsvex: 0.10.6_svelte@3.53.1
       remark-parse: 8.0.2
       unified: 9.2.1
       unist-util-visit: 2.0.3
@@ -270,10 +280,10 @@ importers:
       remark-math: '3'
       url-loader: ^4.1.1
     dependencies:
-      '@docusaurus/core': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/preset-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-common': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/preset-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-common': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@svgr/webpack': 5.5.0
       clsx: 1.1.1
@@ -317,7 +327,6 @@ importers:
       cross-env: 7.0.3
       fs-extra: 10.0.1
       jest: 28.1.2
-    publishDirectory: ../../packages/components
 
   sites/test-env:
     specifiers:
@@ -3270,7 +3279,7 @@ packages:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
     dev: false
 
-  /@docsearch/react/3.3.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docsearch/react/3.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -3294,7 +3303,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
+  /@docusaurus/core/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3314,15 +3323,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
-      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils': 2.1.0
+      '@docusaurus/utils-common': 2.1.0
+      '@docusaurus/utils-validation': 2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
+      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3334,7 +3343,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
+      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3350,16 +3359,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
+      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_webpack@5.74.0
+      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
+      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3368,7 +3377,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3394,7 +3403,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/core/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/core/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
     resolution: {integrity: sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3414,15 +3423,15 @@ packages:
       '@babel/traverse': 7.20.0
       '@docusaurus/cssnano-preset': 2.1.0
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.1.0
-      '@docusaurus/utils-common': 2.1.0
-      '@docusaurus/utils-validation': 2.1.0
+      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
+      '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.14
-      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
+      babel-loader: 8.2.5_f645c55d63e77e0aacb83a76bcc9695b
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -3434,7 +3443,7 @@ packages:
       copy-webpack-plugin: 11.0.0_webpack@5.74.0
       core-js: 3.26.0
       css-loader: 6.7.1_webpack@5.74.0
-      css-minimizer-webpack-plugin: 4.2.2_kwz7aenajwsweas6icw5ncsgdy
+      css-minimizer-webpack-plugin: 4.2.2_clean-css@5.3.1+webpack@5.74.0
       cssnano: 5.1.13_postcss@8.4.14
       del: 6.1.1
       detect-port: 1.3.0
@@ -3450,16 +3459,16 @@ packages:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       postcss: 8.4.14
-      postcss-loader: 7.0.1_m6qh27jiicejwnzfgs742cokpe
+      postcss-loader: 7.0.1_postcss@8.4.14+webpack@5.74.0
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1_webpack@5.74.0
+      react-dev-utils: 12.0.1_c312d410e43e390b1aefa8571ea033a1
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
-      react-loadable-ssr-addon-v5-slorber: 1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba
+      react-loadable-ssr-addon-v5-slorber: 1.0.1_4e32ce23c6949bd47cf53d21bd84df08
       react-router: 5.3.4_react@17.0.2
-      react-router-config: 5.1.1_2dl5roaqnyqqppnjni7uetnb3a
+      react-router-config: 5.1.1_react-router@5.3.4+react@17.0.2
       react-router-dom: 5.3.4_react@17.0.2
       rtl-detect: 1.0.4
       semver: 7.3.8
@@ -3468,7 +3477,7 @@ packages:
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       tslib: 2.4.0
       update-notifier: 5.1.0
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       wait-on: 6.0.1
       webpack: 5.74.0
       webpack-bundle-analyzer: 4.7.0
@@ -3512,7 +3521,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
+  /@docusaurus/mdx-loader/2.1.0_6e39cab45d9f22ba28fa56595d174ac9:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3536,7 +3545,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3547,7 +3556,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/mdx-loader/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/mdx-loader/2.1.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3571,7 +3580,7 @@ packages:
       tslib: 2.4.0
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3582,21 +3591,21 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/module-type-aliases/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/module-type-aliases/2.1.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@types/history': 4.7.11
       '@types/react': 18.0.24
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -3605,17 +3614,17 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-blog/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-content-blog/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3648,18 +3657,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-content-docs/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       '@types/react-router-config': 5.0.6
@@ -3691,16 +3700,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-content-pages/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
@@ -3726,20 +3735,20 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-debug/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-json-view: 1.21.3_sfoxds7t5ydpegc3knd667wn6m
+      react-json-view: 1.21.3_react-dom@17.0.2+react@17.0.2
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -3760,15 +3769,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-google-analytics/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3791,15 +3800,15 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-google-gtag/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3822,16 +3831,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/plugin-sitemap/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3858,25 +3867,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/preset-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-debug': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-google-analytics': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-google-gtag': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-sitemap': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-classic': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/theme-search-algolia': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-debug': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-google-analytics': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-google-gtag': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-sitemap': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-classic': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/theme-search-algolia': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3909,22 +3918,22 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@docusaurus/theme-classic/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/theme-classic/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/theme-translations': 2.1.0
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-common': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -3961,60 +3970,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
+  /@docusaurus/theme-common/2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca:
     resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
-      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
-      '@types/history': 4.7.11
-      '@types/react': 18.0.24
-      '@types/react-router-config': 5.0.6
-      clsx: 1.2.1
-      parse-numeric-range: 1.3.0
-      prism-react-renderer: 1.3.5_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      tslib: 2.4.0
-      utility-types: 3.10.0
-    transitivePeerDependencies:
-      - '@docusaurus/types'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@swc/css'
-      - bufferutil
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - lightningcss
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-    dev: false
-
-  /@docusaurus/theme-common/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
-    engines: {node: '>=16.14'}
-    peerDependencies:
-      react: ^16.8.4 || ^17.0.0
-      react-dom: ^16.8.4 || ^17.0.0
-    dependencies:
-      '@docusaurus/mdx-loader': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-pages': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/mdx-loader': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
       '@docusaurus/utils': 2.1.0
       '@types/history': 4.7.11
       '@types/react': 18.0.24
@@ -4045,18 +4012,60 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.1.0_ny44vnc5t4rlukh2kzmv2f2kze:
+  /@docusaurus/theme-common/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
+    resolution: {integrity: sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/mdx-loader': 2.1.0_6e39cab45d9f22ba28fa56595d174ac9
+      '@docusaurus/module-type-aliases': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/plugin-content-blog': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/plugin-content-pages': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
+      '@types/history': 4.7.11
+      '@types/react': 18.0.24
+      '@types/react-router-config': 5.0.6
+      clsx: 1.2.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 1.3.5_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.4.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/theme-search-algolia/2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97:
     resolution: {integrity: sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.3.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/core': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docsearch/react': 3.3.0_react-dom@17.0.2+react@17.0.2
+      '@docusaurus/core': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/plugin-content-docs': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/theme-common': 2.1.0_ny44vnc5t4rlukh2kzmv2f2kze
+      '@docusaurus/plugin-content-docs': 2.1.0_0e4ae5dfcfbe0cf02e9d41c8e39089ca
+      '@docusaurus/theme-common': 2.1.0_af2ff39a71a4bcaf71b3bc1b75a88c97
       '@docusaurus/theme-translations': 2.1.0
       '@docusaurus/utils': 2.1.0_@docusaurus+types@2.1.0
       '@docusaurus/utils-validation': 2.1.0_@docusaurus+types@2.1.0
@@ -4099,7 +4108,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@docusaurus/types/2.1.0_sfoxds7t5ydpegc3knd667wn6m:
+  /@docusaurus/types/2.1.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
@@ -4111,7 +4120,7 @@ packages:
       joi: 17.6.4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-helmet-async: 1.3.0_react-dom@17.0.2+react@17.0.2
       utility-types: 3.10.0
       webpack: 5.74.0
       webpack-merge: 5.8.0
@@ -4143,7 +4152,7 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       tslib: 2.4.0
     dev: false
 
@@ -4205,7 +4214,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4225,7 +4234,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/logger': 2.1.0
-      '@docusaurus/types': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@svgr/webpack': 6.5.1
       file-loader: 6.2.0_webpack@5.74.0
       fs-extra: 10.1.0
@@ -4238,7 +4247,7 @@ packages:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.4.0
-      url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@5.74.0
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -5547,7 +5556,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/5.7.0_26qnnnmunc2nf2ry66bpj4is4m:
+  /@typescript-eslint/eslint-plugin/5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3:
     resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5558,8 +5567,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
-      '@typescript-eslint/parser': 5.7.0_cdb22lpylddt4wvlwp2rexorcy
+      '@typescript-eslint/experimental-utils': 5.7.0_eslint@8.4.1+typescript@4.4.4
+      '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
       '@typescript-eslint/scope-manager': 5.7.0
       debug: 4.3.2
       eslint: 8.4.1
@@ -5573,7 +5582,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
+  /@typescript-eslint/experimental-utils/5.7.0_eslint@8.4.1+typescript@4.4.4:
     resolution: {integrity: sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5591,7 +5600,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.7.0_cdb22lpylddt4wvlwp2rexorcy:
+  /@typescript-eslint/parser/5.7.0_eslint@8.4.1+typescript@4.4.4:
     resolution: {integrity: sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5760,7 +5769,7 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
 
-  /@webpack-cli/configtest/1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm:
+  /@webpack-cli/configtest/1.1.0_webpack-cli@4.9.1+webpack@5.65.0:
     resolution: {integrity: sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
@@ -6275,7 +6284,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_6zc4kxld457avlfyhj3lzsljlm:
+  /babel-loader/8.2.5_f645c55d63e77e0aacb83a76bcc9695b:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -6538,8 +6547,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /bonjour-service/1.0.14:
@@ -6722,8 +6729,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: false
     optional: true
 
@@ -6749,8 +6754,6 @@ packages:
       ssri: 9.0.1
       tar: 6.1.11
       unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
     dev: false
 
   /cacheable-request/6.1.0:
@@ -7192,8 +7195,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /concat-map/0.0.1:
@@ -7412,7 +7413,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /css-minimizer-webpack-plugin/4.2.2_kwz7aenajwsweas6icw5ncsgdy:
+  /css-minimizer-webpack-plugin/4.2.2_clean-css@5.3.1+webpack@5.74.0:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7695,22 +7696,12 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -7932,8 +7923,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -7943,8 +7932,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /diff-sequences/28.1.1:
@@ -8089,7 +8076,6 @@ packages:
     dependencies:
       duckdb: 0.6.1
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -8102,7 +8088,6 @@ packages:
       node-addon-api: 4.3.0
       node-gyp: 9.3.0
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -8875,8 +8860,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /extend-shallow/2.0.1:
@@ -9064,8 +9047,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-cache-dir/3.3.1:
@@ -9158,7 +9139,7 @@ packages:
       debug: 3.2.7
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.2_webpack@5.74.0:
+  /fork-ts-checker-webpack-plugin/6.5.2_c312d410e43e390b1aefa8571ea033a1:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9178,6 +9159,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
+      eslint: 8.18.0
       fs-extra: 9.1.0
       glob: 7.1.7
       memfs: 3.4.7
@@ -9185,6 +9167,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
+      typescript: 4.5.4
       webpack: 5.74.0
     dev: false
 
@@ -11460,7 +11443,6 @@ packages:
       socks-proxy-agent: 7.0.0
       ssri: 9.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: false
 
@@ -11485,7 +11467,6 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -11566,7 +11547,7 @@ packages:
     resolution: {integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==}
     dev: false
 
-  /mdsvex/0.10.6:
+  /mdsvex/0.10.6_svelte@3.53.1:
     resolution: {integrity: sha512-aGRDY0r5jx9+OOgFdyB9Xm3EBr9OUmcrTDPWLB7a7g8VPRxzPy4MOBmcVYgz7ErhAJ7bZ/coUoj6aHio3x/2mA==}
     peerDependencies:
       svelte: 3.x
@@ -11574,6 +11555,7 @@ packages:
       '@types/unist': 2.0.6
       prism-svelte: 0.4.7
       prismjs: 1.24.1
+      svelte: 3.53.1
       vfile-message: 2.0.4
     dev: false
 
@@ -12045,7 +12027,6 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: false
     optional: true
@@ -12066,7 +12047,6 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: false
 
@@ -12815,7 +12795,7 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: false
 
-  /postcss-loader/7.0.1_m6qh27jiicejwnzfgs742cokpe:
+  /postcss-loader/7.0.1_postcss@8.4.14+webpack@5.74.0:
     resolution: {integrity: sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -13437,7 +13417,7 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prettier-plugin-svelte/2.7.0_dhgc3nm4qbaahazvwcpyr4wtfe:
+  /prettier-plugin-svelte/2.7.0_prettier@2.6.2+svelte@3.53.1:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -13516,11 +13496,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: false
 
   /promise-retry/2.0.1:
@@ -13720,7 +13695,7 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-dev-utils/12.0.1_webpack@5.74.0:
+  /react-dev-utils/12.0.1_c312d410e43e390b1aefa8571ea033a1:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -13733,7 +13708,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_webpack@5.74.0
+      fork-ts-checker-webpack-plugin: 6.5.2_c312d410e43e390b1aefa8571ea033a1
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13750,7 +13725,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
-      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -13775,7 +13749,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
+  /react-helmet-async/1.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -13798,7 +13772,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-json-view/1.21.3_sfoxds7t5ydpegc3knd667wn6m:
+  /react-json-view/1.21.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -13818,7 +13792,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-loadable-ssr-addon-v5-slorber/1.0.1_jyzm4i6gssn5i7hvhuq33bg7ba:
+  /react-loadable-ssr-addon-v5-slorber/1.0.1_4e32ce23c6949bd47cf53d21bd84df08:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -13830,7 +13804,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /react-router-config/5.1.1_2dl5roaqnyqqppnjni7uetnb3a:
+  /react-router-config/5.1.1_react-router@5.3.4+react@17.0.2:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
@@ -14508,8 +14482,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /seq-queue/0.0.5:
@@ -14545,8 +14517,6 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.35
       parseurl: 1.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serve-static/1.15.0:
@@ -14557,8 +14527,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -14933,7 +14901,6 @@ packages:
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: false
@@ -15220,7 +15187,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.7_7uyzgzkbjy6f7owetbs6ny3nau:
+  /svelte2tsx/0.4.7_svelte@3.53.1+typescript@4.5.4:
     resolution: {integrity: sha512-1HqRb8+I8H0Gli0+w8nTmyZgbtO/jJE3g27cNKYFyN0GMdpOh0CRmiWuMH1k9N2JugkviI7wqETanqJTR0SI+A==}
     peerDependencies:
       svelte: ^3.24
@@ -15547,7 +15514,7 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: false
 
-  /ts-loader/9.2.6_ohqq63mdhocqvr4wpaakehweqe:
+  /ts-loader/9.2.6_typescript@4.4.4+webpack@5.65.0:
     resolution: {integrity: sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -15986,7 +15953,7 @@ packages:
       schema-utils: 3.1.1
     dev: false
 
-  /url-loader/4.1.1_u4acmn7fe6yqgbrqzialkgh5lu:
+  /url-loader/4.1.1_file-loader@6.2.0+webpack@5.74.0:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16352,7 +16319,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@webpack-cli/configtest': 1.1.0_5mkmpm5yhygs4kjlquk5gjvbjm
+      '@webpack-cli/configtest': 1.1.0_webpack-cli@4.9.1+webpack@5.65.0
       '@webpack-cli/info': 1.4.0_webpack-cli@4.9.1
       '@webpack-cli/serve': 1.6.0_webpack-cli@4.9.1
       colorette: 2.0.16

--- a/sites/example-project/src/components/ui/Databases/CSVForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/CSVForm.svelte
@@ -1,5 +1,6 @@
 <script>    
     import IoIosHelpCircleOutline from 'svelte-icons/io/IoIosHelpCircleOutline.svelte'
+    import Prism from "../QueryViewerSupport/Prismjs.svelte";
 
 	export let credentials;
 	export let existingCredentials;
@@ -30,9 +31,22 @@
         disableSave = false;
     }
 
+    let sourcesQuery = `select * from 'sources/myfile.csv'` 
+    let absoluteQuery = `select * from '/Users/myname/Documents/myfile.csv'`
+
 </script>
 
-<p style="margin-top: 15px;">Evidence uses DuckDB SQL syntax to query CSV files. <a class=docs-link href='https://duckdb.org/docs/sql/query_syntax/select' target='_blank' rel="noreferrer" >See the DuckDB docs for reference on query syntax</a></p>
+<p style="margin-top: 15px;">Evidence supports querying of local CSV files. CSV querying is powered by DuckDB - <a class=docs-link href='https://duckdb.org/docs/sql/query_syntax/select' target='_blank' rel="noreferrer" >see the DuckDB docs for reference on query syntax</a></p>
+
+<p>We recommend setting up a <code>sources</code> directory in the root of your Evidence project to store CSV files. You can then query them using this syntax:</p>
+<div class=code-container>
+    <Prism language="sql" code={sourcesQuery}/>
+</div>
+
+<p style="margin-top: 15px;">You can also pass in an absolute filepath:</p>
+<div class=code-container>
+    <Prism language="sql" code={absoluteQuery}/>
+</div>
 
 <div class=input-item>
     <label for={opts[0].id}>
@@ -170,6 +184,13 @@
 
     .docs-link:hover {
         color: var(--blue-800);
+    }
+
+    div.code-container {
+        background-color: var(--grey-100);
+        border: 1px solid var(--grey-200);
+        overflow: auto;
+        border-radius: 4px;
     }
 
 </style>

--- a/sites/example-project/src/components/ui/Databases/CSVForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/CSVForm.svelte
@@ -1,0 +1,175 @@
+<script>    
+    import IoIosHelpCircleOutline from 'svelte-icons/io/IoIosHelpCircleOutline.svelte'
+
+	export let credentials;
+	export let existingCredentials;
+    export let gitIgnore;
+    existingCredentials.gitignoreCsv = gitIgnore ? gitIgnore.match(/\n.csv(?=\n|$)/) : false;
+    export let disableSave;
+
+	credentials = { ...existingCredentials };
+
+    credentials = {
+        filename: ":memory:",
+        gitignoreCsv: credentials.gitignoreCsv
+    }
+
+    let opts = [
+        {
+            id: "gitignoreCsv",
+            label: "Gitignore all CSV files",
+            type: "toggle",
+            additionalInstructions: 'If enabled, Evidence will gitignore .csv files',
+            optional: false,
+            override: false,
+            value: credentials.gitignoreCsv ?? true
+        }
+    ]
+
+    function handleCheck() {
+        disableSave = false;
+    }
+
+</script>
+
+<p style="margin-top: 15px;">Evidence uses DuckDB SQL syntax to query CSV files. <a class=docs-link href='https://duckdb.org/docs/sql/query_syntax/select' target='_blank' rel="noreferrer" >See the DuckDB docs for reference on query syntax</a></p>
+
+<div class=input-item>
+    <label for={opts[0].id}>
+        {opts[0].label}
+        {#if opts[0].additionalInstructions}
+        <span class="additional-info-icon">
+                <IoIosHelpCircleOutline/>
+                <span class=info-msg>{opts[0].additionalInstructions}</span>
+        </span>
+        {/if}
+    </label>
+
+    <label class="switch">
+        <input type="checkbox" bind:checked={credentials[opts[0].id]} on:change={handleCheck}/>
+        <span class="slider" />
+    </label>
+</div>
+
+<style>
+
+    span.additional-info-icon {
+        width: 18px;
+        color:var(--grey-600);
+        display:inline-block;
+        vertical-align: middle;
+        line-height: 1em;
+        cursor: help;
+        position:relative;
+        text-transform: none;
+    }
+
+    div.input-item{
+        font-family: var(--ui-font-family);
+        color: var(--grey-999);
+        font-size: 16px;
+        margin-top: 1.25em;
+        display:flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    label {
+        width: 30%;
+        text-transform: uppercase;
+        font-weight: normal;
+        font-size: 14px;
+        color: var(--grey-800);
+        white-space: nowrap;
+    }
+
+ 
+
+    .additional-info-icon .info-msg {
+        visibility: hidden;
+        position: absolute;
+        top: -5px;
+        left: 105%;
+        white-space: nowrap;
+        padding-left: 5px;
+        padding-right: 5px;     
+        padding-top: 2px;
+        padding-bottom: 1px;   
+        color: white;
+        font-family: sans-serif;
+        font-size: 0.8em;
+        background-color: var(--grey-900);
+        opacity: 0.85;
+        border-radius: 6px;
+        z-index: 1;
+    }
+
+    .additional-info-icon:hover .info-msg {
+        visibility: visible;
+    }
+
+       .switch {
+      position: relative;
+      display: inline-block;
+      width: 2.8rem;
+      height: 1.75rem;
+      margin-left: auto;
+      margin-right: 2px;
+    }
+  
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+  
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 25px;
+    }
+  
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 1.25rem;
+      width: 1.25rem;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 50%;
+      box-shadow: 0px 1px 2px var(--grey-500);
+
+    }
+  
+    input:checked + .slider {
+      background-color: var(--green-500);
+    }
+
+    input:checked + .slider:before {
+      -webkit-transform: translateX(1.1rem);
+      -ms-transform: translateX(1.1rem);
+      transform: translateX(1.1rem);
+    }
+
+
+    .docs-link {
+        color: var(--blue-600);
+        text-decoration: none;
+    }
+
+    .docs-link:hover {
+        color: var(--blue-800);
+    }
+
+</style>

--- a/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/sites/example-project/src/components/ui/Databases/DatabaseSettingsPanel.svelte
@@ -6,8 +6,10 @@
     import MysqlForm from '@evidence-dev/components/ui/Databases/MysqlForm.svelte'
     import SqliteForm from '@evidence-dev/components/ui/Databases/SqliteForm.svelte'
     import DuckdbForm from '@evidence-dev/components/ui/Databases/DuckdbForm.svelte'
+    import CSVForm from '@evidence-dev/components/ui/Databases/CSVForm.svelte'
 
     import { slide, blur } from 'svelte/transition'
+    import { select } from '@tidyjs/tidy';
 
     export let settings 
     export let gitIgnore
@@ -26,11 +28,11 @@
         {id: 'redshift', name: 'Redshift', formComponent: RedshiftForm}, // Redshift uses the postgres connector under the hood
 		{id: 'snowflake', name: 'Snowflake', formComponent: SnowflakeForm},
         {id: 'sqlite', name: 'SQLite', formComponent: SqliteForm},
-        {id: 'duckdb', name: 'DuckDB', formComponent: DuckdbForm}
+        {id: 'duckdb', name: 'DuckDB', formComponent: DuckdbForm},
+        {id: 'csv', name: 'CSV', formComponent: CSVForm}
 	];
 
     let selectedDatabase = databaseOptions.filter(d => d.id === settings.database)[0] ?? databaseOptions[0];
-
     let disableSave = false;
 
     async function runTest() {
@@ -72,7 +74,11 @@
 
     function databaseChange() {
         testResult = null;
-        disableSave = true;
+        if(selectedDatabase.id === "csv"){
+            disableSave = false;
+        } else {
+            disableSave = true;
+        }
     }
 </script>
 

--- a/sites/example-project/src/pages/api/settings.json.js
+++ b/sites/example-project/src/pages/api/settings.json.js
@@ -82,6 +82,52 @@ export function post(request) {
             })
             fs.writeFileSync('../../.gitignore', gitIgnore)
         }
+    } else if(settings.database === "duckdb"){
+        let gitIgnore;
+        let hasGitIgnore = fs.existsSync('../../.gitignore');
+        gitIgnore = hasGitIgnore ? fs.readFileSync('../../.gitignore', 'utf8') : "";
+        let extensions = [".duckdb", ".db"]
+        if(settings.credentials.gitignoreDuckdb === false){
+            let regex
+            if(hasGitIgnore){
+                extensions.forEach(ext => {
+                    regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
+                    gitIgnore = gitIgnore.replace(regex, "")
+                })
+                fs.writeFileSync('../../.gitignore', gitIgnore)
+            }
+        } else if(settings.credentials.gitignoreDuckdb === true){
+            extensions.forEach(ext => {
+                regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
+                if(!gitIgnore.match(regex)){
+                    gitIgnore = gitIgnore + ("\n" + ext)
+                }
+            })
+            fs.writeFileSync('../../.gitignore', gitIgnore)
+        }
+    } else if(settings.database === "csv"){
+            let gitIgnore;
+            let hasGitIgnore = fs.existsSync('../../.gitignore');
+            gitIgnore = hasGitIgnore ? fs.readFileSync('../../.gitignore', 'utf8') : "";
+            let extensions = [".csv"]
+            if(settings.credentials.gitignoreCsv === false){
+                let regex
+                if(hasGitIgnore){
+                    extensions.forEach(ext => {
+                        regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
+                        gitIgnore = gitIgnore.replace(regex, "")
+                    })
+                    fs.writeFileSync('../../.gitignore', gitIgnore)
+                }
+            } else if(settings.credentials.gitignoreCsv === true){
+                extensions.forEach(ext => {
+                    regex = new RegExp(`\n${ext}(?=\n|$)`, "g")
+                    if(!gitIgnore.match(regex)){
+                        gitIgnore = gitIgnore + ("\n" + ext)
+                    }
+                })
+                fs.writeFileSync('../../.gitignore', gitIgnore)
+            }
     }
     return {
         body: settings

--- a/sites/example-project/src/pages/test.md
+++ b/sites/example-project/src/pages/test.md
@@ -1,0 +1,5 @@
+# Test CSV Connector
+
+```csv
+select * from '../../sources/csv_test.csv'
+```

--- a/sites/example-project/src/pages/test.md
+++ b/sites/example-project/src/pages/test.md
@@ -1,5 +1,0 @@
-# Test CSV Connector
-
-```csv
-select * from '../../sources/csv_test.csv'
-```

--- a/sources/csv_test.csv
+++ b/sources/csv_test.csv
@@ -1,6 +1,0 @@
-﻿a,b,c
-1,564,htyht
-2,5645,fefdew
-3,5614,greg
-4,45645,htr
-5,15,erer

--- a/sources/csv_test.csv
+++ b/sources/csv_test.csv
@@ -1,0 +1,6 @@
+﻿a,b,c
+1,564,htyht
+2,5645,fefdew
+3,5614,greg
+4,45645,htr
+5,15,erer


### PR DESCRIPTION
### Description
- We already support CSV file querying through our DuckDB connector, but there are a few drawbacks for someone who wants to use only CSVs:
   - They need to include an empty DuckDB file along with their CSVs
   - The path to the file is not intuitive + it's not clear where to store the CSV files 
- This PR adds a new connector for CSVs, which uses DuckDB under the hood
- When the CSV connector is selected, it spins up an in-memory DuckDB instance and uses that to query the CSV files in the project
- This PR also includes a new `sources` directory, which will be the recommended place to store CSV files. E.g., 
```sql
select * from 'sources/myfile.csv'
```

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
