### PR TITLE
Fix breadcrumb capitalization

### DIFF
--- a/.changeset/eighty-buckets-jam.md
+++ b/.changeset/eighty-buckets-jam.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": patch
+---
+
+Fix for breadcrumb capitalization

--- a/sites/example-project/src/components/ui/BreadCrumbs.svelte
+++ b/sites/example-project/src/components/ui/BreadCrumbs.svelte
@@ -93,6 +93,7 @@
     }
 
     a {
+        display: inline-block;
         text-transform: capitalize;
         text-decoration: none;
         color: var(--grey-700);


### PR DESCRIPTION
### Description
Fixes #509 

### Before
<img width="495" alt="CleanShot 2023-02-14 at 16 25 23@2x" src="https://user-images.githubusercontent.com/12602440/218866930-3a478645-048f-405d-8abe-cf620ed8bdc8.png">

### After
<img width="505" alt="CleanShot 2023-02-14 at 16 25 49@2x" src="https://user-images.githubusercontent.com/12602440/218866947-362c824e-9aab-4960-9c87-733c73a43baa.png">

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
