### PR TITLE
Clarify Snowflake account number formats

### DIFF
--- a/.changeset/early-cooks-greet.md
+++ b/.changeset/early-cooks-greet.md
@@ -1,0 +1,5 @@
+---
+"@evidence-dev/components": major
+---
+
+Updated the account number format on SnowflakeForm

--- a/.changeset/six-steaks-attack.md
+++ b/.changeset/six-steaks-attack.md
@@ -1,5 +1,5 @@
 ---
-"@evidence-dev/components": major
+"@evidence-dev/components": patch
 ---
 
 Updated the account number format on SnowflakeForm

--- a/sites/example-project/src/components/ui/Databases/GenericForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/GenericForm.svelte
@@ -1,5 +1,5 @@
 <script>
-    import IoIosHelpCircleOutline from 'svelte-icons/io/IoIosHelpCircleOutline.svelte'
+    import InfoIcon from './InfoIcon.svelte';
 
     export let opts
     export let credentials
@@ -43,10 +43,7 @@
         {opt.label}
 
         {#if opt.additionalInstructions}
-        <span class="additional-info-icon">
-                <IoIosHelpCircleOutline/>
-                <span class=info-msg>{opt.additionalInstructions}</span>
-        </span>
+        <InfoIcon>{opt.additionalInstructions}</InfoIcon>
         {/if}
     </label>
 
@@ -86,10 +83,7 @@
         {opt.label}
 
         {#if opt.additionalInstructions}
-        <span class="additional-info-icon">
-                <IoIosHelpCircleOutline/>
-                <span class=info-msg>{opt.additionalInstructions}</span>
-        </span>
+        <InfoIcon>{opt.additionalInstructions}</InfoIcon>
         {/if}
     </label>
 
@@ -118,18 +112,6 @@
 {/each}
 
 <style>
-
-    span.additional-info-icon {
-        width: 18px;
-        color:var(--grey-600);
-        display:inline-block;
-        vertical-align: middle;
-        line-height: 1em;
-        cursor: help;
-        position:relative;
-        text-transform: none;
-    }
-
     div.input-item{
         font-family: var(--ui-font-family);
         color: var(--grey-999);
@@ -168,32 +150,6 @@
         font-weight: normal;
         font-size: 14px;
         color: var(--grey-800)
-    }
-
-    .additional-info-icon .info-msg {
-        visibility: hidden;
-        display: none;
-        position: absolute;
-        top: -5px;
-        left: 105%;
-        padding-left: 5px;
-        padding-right: 5px;     
-        padding-top: 2px;
-        padding-bottom: 1px;   
-        color: white;
-        font-family: sans-serif;
-        font-size: 0.8em;
-        background-color: var(--grey-900);
-        opacity: 0.85;
-        border-radius: 6px;
-        z-index: 1;
-        max-width: 200px;
-        min-width: 150px;
-    }
-
-    .additional-info-icon:hover .info-msg {
-        visibility: visible;
-        display: inline;
     }
 
     .separator {

--- a/sites/example-project/src/components/ui/Databases/InfoIcon.svelte
+++ b/sites/example-project/src/components/ui/Databases/InfoIcon.svelte
@@ -1,0 +1,54 @@
+<script>
+    import IoIosHelpCircleOutline from 'svelte-icons/io/IoIosHelpCircleOutline.svelte'
+    import { fade } from 'svelte/transition';
+
+    let visible = false
+
+    const showMessage = () => visible = true
+    const hideMessage = () => visible = false
+</script>
+
+<span 
+    on:focus={showMessage} on:blur={hideMessage}
+    on:mouseenter={showMessage} on:mouseleave={hideMessage}
+    class="additional-info-icon"
+>
+    <IoIosHelpCircleOutline/>
+    {#if visible}
+    <span transition:fade class=info-msg>
+        <slot></slot>
+    </span>
+    {/if}
+</span>
+
+<style scoped>
+    span.additional-info-icon {
+        width: 18px;
+        color:var(--grey-600);
+        display:inline-block;
+        vertical-align: middle;
+        line-height: 1em;
+        cursor: help;
+        position:relative;
+        text-transform: none;
+    }
+
+    .additional-info-icon .info-msg {
+        position: absolute;
+        top: -5px;
+        left: 105%;
+        padding-left: 5px;
+        padding-right: 5px;     
+        padding-top: 2px;
+        padding-bottom: 1px;   
+        color: white;
+        font-family: sans-serif;
+        font-size: 0.8em;
+        background-color: var(--grey-900);
+        opacity: 0.85;
+        border-radius: 6px;
+        z-index: 1;
+        max-width: 200px;
+        min-width: 150px;
+    }
+</style>

--- a/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
@@ -12,7 +12,7 @@
             type: "text", 
             optional: false,
             override: false,
-            placeholder: "xx16244.us-central1.gcp",
+            placeholder: "xy12345.us-central1.gcp or xy12345.ap-southeast-1 or xy12345",
             value: credentials.account,
             dataTestId: "snowflakeAccount"
         },

--- a/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
@@ -14,7 +14,8 @@
             override: false,
             placeholder: "xy12345.us-central1.gcp or xy12345.ap-southeast-1 or xy12345",
             value: credentials.account,
-            dataTestId: "snowflakeAccount"
+            dataTestId: "snowflakeAccount",
+            additionalInstructions: "The account number must be of any of these format options (xy12345.us-central1.gcp or xy12345.ap-southeast-1 or xy12345)"
         },
         {
             id: "username", 

--- a/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
+++ b/sites/example-project/src/components/ui/Databases/SnowflakeForm.svelte
@@ -12,10 +12,10 @@
             type: "text", 
             optional: false,
             override: false,
-            placeholder: "xy12345.us-central1.gcp or xy12345.ap-southeast-1 or xy12345",
+            placeholder: "xy12345.us-east4.gcp | xy12345.eu-west-1 | xy12345",
             value: credentials.account,
             dataTestId: "snowflakeAccount",
-            additionalInstructions: "The account number must be of any of these format options (xy12345.us-central1.gcp or xy12345.ap-southeast-1 or xy12345)"
+            additionalInstructions: "The account number typically uses one of these formats: xy12345.us-east4.gcp, xy12345.eu-west-1 or xy12345. For more info see https://docs.snowflake.com/en/user-guide/admin-account-identifier"
         },
         {
             id: "username", 


### PR DESCRIPTION
### Description
Resolves #655 
Gives users clear understanding of the format of snowflake account number to be entered.

![image](https://user-images.githubusercontent.com/62562483/221372293-e1b9d3e6-c269-427b-92e7-63134009ae46.png)


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
