### PR TITLE
Add Tabs Component

### DIFF
--- a/.changeset/lazy-bulldogs-dream.md
+++ b/.changeset/lazy-bulldogs-dream.md
@@ -1,0 +1,6 @@
+---
+"@evidence-dev/preprocess": patch
+"@evidence-dev/components": patch
+---
+
+Added Tabs component

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -53,6 +53,9 @@ const createDefaultProps = function(filename, componentDevelopmentMode, fileQuer
         import { pageHasQueries, routeHash } from '$lib/ui/stores';
         import { setContext, getContext, beforeUpdate } from 'svelte';
         import BigLink from '$lib/ui/BigLink.svelte';
+        import Tab from "$lib/ui/Tabs/Tab.svelte";
+        import Tabs from "$lib/ui/Tabs/Tabs.svelte";
+        
         import VennDiagram from '$lib/diagrams/VennDiagram.svelte';
         import SankeyDiagram from "$lib/diagrams/SankeyDiagram.svelte";
         import Value from '$lib/viz/Value.svelte';

--- a/sites/example-project/src/components/ui/Tabs/Tab.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tab.svelte
@@ -1,0 +1,43 @@
+<script>
+	import {getContext, onDestroy, onMount} from "svelte";
+	
+	/**
+	 * @type {string}
+	 */
+	export let label
+	/**
+	 * @type {string}
+	 */
+	export let id = label
+
+	/**
+	 * @type {boolean}
+	 */
+	export let selected
+		
+	const tabs = getContext("TAB_REGISTRATION")
+	onMount(() => {
+        $tabs.tabs = [...$tabs.tabs, { label, id }]
+		if (selected) $tabs.active = id
+        // We are creating our subscription (instead of using $tabs) after handling the selected prop to make sure that
+        // it is effective. Otherwise it would get set to false by our subscription and not work.
+        // Returning a function from onMount is basically onDestroy; so we are also cleaning this up easily
+		return tabs.subscribe(({active}) => {
+			selected = active === id
+		})
+	})
+
+    // Ensure that tabs remove themselves correctly when they are unmounted.
+    // Otherwise they will still exist but will never render content.
+    onDestroy(() => {
+        $tabs.tabs = $tabs.tabs.filter(t => t.id !== id)
+        if ($tabs.active === id) {
+            $tabs.active = $tabs.tabs[0].id
+        }
+    })
+	
+</script>
+
+{#if selected}
+	<slot/>
+{/if}

--- a/sites/example-project/src/components/ui/Tabs/Tab.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tab.svelte
@@ -15,7 +15,11 @@
 	 */
 	export let selected
 		
+	/**
+	 * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string, tabsId: string}>}
+	 */
 	const tabs = getContext("TAB_REGISTRATION")
+
 	onMount(() => {
         $tabs.tabs = [...$tabs.tabs, { label, id }]
 		if (selected) $tabs.active = id
@@ -32,7 +36,7 @@
     onDestroy(() => {
         $tabs.tabs = $tabs.tabs.filter(t => t.id !== id)
         if ($tabs.active === id) {
-            $tabs.active = $tabs.tabs[0].id
+            $tabs.active = $tabs.tabs[0]?.id
         }
     })
 	

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -58,10 +58,10 @@
          hover:bg-gray-200
          active:bg-gray-100
         transition-colors rounded-t;
-  }
-  nav button.active {
-    @apply border-green-500
+    &.active {
+      @apply border-green-500
             hover:border-green-600 hover:bg-gray-200
             active:border-green-700 active:bg-gray-100;
+    }
   }
 </style>

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -1,23 +1,44 @@
 <script>
-	import {setContext} from "svelte";
+	import {onMount, setContext} from "svelte";
 	import {writable} from "svelte/store";
+
+	/**
+	 * id can be provided to enable tab selection to persist across reloads (e.g. with query params)
+	 * @type {string}
+	 */
+	export let id
 	
 	/**
-	 * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string}>}
+	 * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string, tabsId: string}>}
 	 */
 	const tabItems = writable({tabs: [], active: null})
 	
-    // Select the first tab by default
+	onMount(() => {
+		const url = new URL(window.location.href)
+		const urlActive = url.searchParams.get(id)
+		if (urlActive) {
+			$tabItems.active = urlActive
+		}
+	})
+
     $: if(!$tabItems.active && $tabItems.tabs.length) 
-        $tabItems.active = $tabItems.tabs[0].id
+    	// Select the first tab by default
+		$tabItems.active = $tabItems.tabs[0].id
+
+	$: if ($tabItems.active && id) {
+		// Keep the Query in sync
+		const url = new URL(window.location.href)
+		url.searchParams.set(id, $tabItems.active)
+		history.replaceState({}, '', url)
+	}
 
 	setContext("TAB_REGISTRATION", tabItems)
 </script>
 <section>
-	<nav class="flex gap-4">
+	<nav class="flex gap-x-4 gap-y-1 flex-wrap">
 		{#each $tabItems.tabs as tab}
-			<button on:click={() => $tabItems.active = tab.id} 
-                class="px-4 pt-2 border-b-2 border-blue-300"
+			<button on:click={() => $tabItems.active = tab.id}
+                class="px-4 pt-2 border-b-2 border-blue-300 text-sm whitespace-nowrap"
                 class:active={$tabItems.active === tab.id}>
 				{tab.label}
 			</button>
@@ -30,7 +51,7 @@
 
 <style lang="postcss">
     nav button {
-        @apply px-4 py-2 border-b-2 border-transparent
+        @apply px-4 py-2 border-b-2 border-b-gray-100 hover:border-b-gray-200
          hover:bg-gray-200
          active:bg-gray-100
         transition-colors rounded-t;

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -1,0 +1,44 @@
+<script>
+	import {setContext} from "svelte";
+	import {writable} from "svelte/store";
+	
+	/**
+	 * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string}>}
+	 */
+	const tabItems = writable({tabs: [], active: null})
+	
+    // Select the first tab by default
+    $: if(!$tabItems.active && $tabItems.tabs.length) 
+        $tabItems.active = $tabItems.tabs[0].id
+
+	setContext("TAB_REGISTRATION", tabItems)
+</script>
+<section>
+	<nav class="flex gap-4">
+		{#each $tabItems.tabs as tab}
+			<button on:click={() => $tabItems.active = tab.id} 
+                class="px-4 pt-2 border-b-2 border-blue-300"
+                class:active={$tabItems.active === tab.id}>
+				{tab.label}
+			</button>
+		{/each}
+	</nav>
+	<div>
+		<slot/>
+	</div>
+</section>
+
+<style lang="postcss">
+    nav button {
+        @apply px-4 py-2 border-b-2 border-transparent
+         hover:bg-gray-200
+         active:bg-gray-100
+        transition-colors rounded-t;
+
+        &.active {
+            @apply border-green-500
+            hover:border-green-600 hover:bg-gray-200
+            active:border-green-700 active:bg-gray-100
+        }
+    }
+</style>

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -35,7 +35,7 @@
 	setContext("TAB_REGISTRATION", tabItems)
 </script>
 <section>
-	<nav class="flex gap-x-4 gap-y-1 flex-wrap">
+	<nav class="flex gap-x-4 gap-y-1 flex-wrap mb-2">
 		{#each $tabItems.tabs as tab}
 			<button on:click={() => $tabItems.active = tab.id}
                 class="px-4 pt-2 border-b-2 border-blue-300 text-sm whitespace-nowrap"

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -1,66 +1,67 @@
 <script>
-	import {onMount, setContext} from "svelte";
-	import {writable} from "svelte/store";
+  import { onMount, setContext } from "svelte";
+  import { writable } from "svelte/store";
 
-	/**
-	 * id can be provided to enable tab selection to persist across reloads (e.g. with query params)
-	 * @type {string}
-	 */
-	export let id
-	
-	/**
-	 * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string, tabsId: string}>}
-	 */
-	const tabItems = writable({tabs: [], active: null})
-	
-	onMount(() => {
-		const url = new URL(window.location.href)
-		const urlActive = url.searchParams.get(id)
-		if (urlActive) {
-			$tabItems.active = urlActive
-		}
-	})
+  /**
+   * id can be provided to enable tab selection to persist across reloads (e.g. with query params)
+   * @type {string}
+   */
+  export let id;
 
-    $: if(!$tabItems.active && $tabItems.tabs.length) 
-    	// Select the first tab by default
-		$tabItems.active = $tabItems.tabs[0].id
+  /**
+   * @type {import("svelte/store").Writable<{ tabs: {label: string, id: string}[], active: string, tabsId: string}>}
+   */
+  const tabItems = writable({ tabs: [], active: null });
 
-	$: if ($tabItems.active && id) {
-		// Keep the Query in sync
-		const url = new URL(window.location.href)
-		url.searchParams.set(id, $tabItems.active)
-		history.replaceState({}, '', url)
-	}
+  onMount(() => {
+    const url = new URL(window.location.href);
+    const urlActive = url.searchParams.get(id);
+    if (urlActive) {
+      $tabItems.active = urlActive;
+    }
+  });
 
-	setContext("TAB_REGISTRATION", tabItems)
+  $: if (!$tabItems.active && $tabItems.tabs.length)
+    // Select the first tab by default
+    $tabItems.active = $tabItems.tabs[0].id;
+
+  $: if ($tabItems.active && id) {
+    // Keep the Query in sync
+    const url = new URL(window.location.href);
+    url.searchParams.set(id, $tabItems.active);
+    history.replaceState({}, "", url);
+  }
+
+  setContext("TAB_REGISTRATION", tabItems);
 </script>
+
 <section>
-	<nav class="flex gap-x-4 gap-y-1 flex-wrap mb-2">
-		{#each $tabItems.tabs as tab}
-			<button on:click={() => $tabItems.active = tab.id}
-                class="px-4 pt-2 border-b-2 border-blue-300 text-sm whitespace-nowrap"
-                class:active={$tabItems.active === tab.id}>
-				{tab.label}
-			</button>
-		{/each}
-	</nav>
-	<div>
-		<slot/>
-	</div>
+  <nav class="flex gap-x-4 gap-y-1 flex-wrap mb-2">
+    {#each $tabItems.tabs as tab}
+      <button
+        on:click={() => ($tabItems.active = tab.id)}
+        class="px-4 pt-2 border-b-2 border-blue-300 text-sm whitespace-nowrap"
+        class:active={$tabItems.active === tab.id}
+      >
+        {tab.label}
+      </button>
+    {/each}
+  </nav>
+  <div>
+    <slot />
+  </div>
 </section>
 
 <style lang="postcss">
-    nav button {
-        @apply px-4 py-2 border-b-2 border-b-gray-100 hover:border-b-gray-200
+  nav button {
+    @apply px-4 py-2 border-b-2 border-b-gray-100 hover:border-b-gray-200
          hover:bg-gray-200
          active:bg-gray-100
         transition-colors rounded-t;
-
-        
-    }
-	nav button.active {
-            @apply border-green-500
+  }
+  nav button.active {
+    @apply border-green-500
             hover:border-green-600 hover:bg-gray-200
-            active:border-green-700 active:bg-gray-100
-        }
+            active:border-green-700 active:bg-gray-100;
+  }
 </style>

--- a/sites/example-project/src/components/ui/Tabs/Tabs.svelte
+++ b/sites/example-project/src/components/ui/Tabs/Tabs.svelte
@@ -56,10 +56,11 @@
          active:bg-gray-100
         transition-colors rounded-t;
 
-        &.active {
+        
+    }
+	nav button.active {
             @apply border-green-500
             hover:border-green-600 hover:bg-gray-200
             active:border-green-700 active:bg-gray-100
         }
-    }
 </style>

--- a/sites/example-project/src/pages/ui-components/tabs/+page.md
+++ b/sites/example-project/src/pages/ui-components/tabs/+page.md
@@ -1,0 +1,9 @@
+## Tabs
+
+<!-- TODO: Add Content here -->
+<Tabs>
+    <Tab label="A Chart">
+    </Tab>
+    <Tab label="Another Chart">
+    </Tab>
+</Tabs>

--- a/sites/example-project/src/pages/ui-components/tabs/+page.md
+++ b/sites/example-project/src/pages/ui-components/tabs/+page.md
@@ -1,9 +1,14 @@
 ## Tabs
 
-<!-- TODO: Add Content here -->
-<Tabs>
+<Tabs id="first-tab">
     <Tab label="A Chart">
     </Tab>
     <Tab label="Another Chart">
+    </Tab>
+    <Tab label="Yet Another Chart">
+    </Tab>
+    <Tab label="Even Still More Chart">
+    </Tab>
+    <Tab label="Okay I give up, it is just a  Chart">
     </Tab>
 </Tabs>

--- a/sites/example-project/src/pages/ui-components/tabs/+page.md
+++ b/sites/example-project/src/pages/ui-components/tabs/+page.md
@@ -1,14 +1,10 @@
 ## Tabs
 
-<Tabs id="first-tab">
-    <Tab label="A Chart">
+<Tabs id="my-tabs">
+    <Tab label="Tab 1">
+        This is the content of Tab 1
     </Tab>
-    <Tab label="Another Chart">
-    </Tab>
-    <Tab label="Yet Another Chart">
-    </Tab>
-    <Tab label="Even Still More Chart">
-    </Tab>
-    <Tab label="Okay I give up, it is just a  Chart">
+    <Tab label="Tab 2">
+        This is the content of Tab 2
     </Tab>
 </Tabs>


### PR DESCRIPTION
### Description
<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes. 
-->

This adds a tabs component; with an interface that looks like this:
```html
<Tabs id="my-tabs">
    <Tab label="Tab 1">
        This is the content of Tab 1
    </Tab>
    <Tab label="Tab 2">
        This is the content of Tab 2
    </Tab>
</Tabs>
```

This is the result of that example:

https://user-images.githubusercontent.com/10779616/226673033-25137495-8fa3-4c22-92bc-1c3a8d2780c3.mp4

The `id` prop on the `Tabs` component is optional; but when provided, the tab state is persisted in the URL via Query Parameters, which means links can be sent that indicate which tab should be upon load.

This probably needs a design pass; I loosely based this off the tabs shown [in the documentation](https://docs.evidence.dev/getting-started/install-evidence)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

**This is not yet ready for merge**; just posting to get design feedback and see if the tests throw a fit about nested styles on this branch.
