### PR TITLE
Move Show/Hide SQL to own button

### DIFF
--- a/.changeset/silly-comics-prove.md
+++ b/.changeset/silly-comics-prove.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+move Show/Hide queries button out of page menu into own button

--- a/sites/example-project/src/components/icons/SQLHideIcon.svelte
+++ b/sites/example-project/src/components/icons/SQLHideIcon.svelte
@@ -1,0 +1,44 @@
+<script>
+	export let height = 24;
+	export let width = 24;
+	export let verticalOffset = 0;
+</script>
+
+<span class="icon-container" style="padding-bottom: {verticalOffset}px">
+	<span class="icon" style="height: {height}px; width:{width}px">
+		<svg fill="currentColor" viewBox="0 0 32 32" id="icon" xmlns="http://www.w3.org/2000/svg">
+			<mask id="mask">
+				<rect width="32" height="32" fill="white" />
+				<polygon points="-0.5,29 21.5,7 28.5,8.5 6.5,30.5" fill="black" />
+			</mask>
+			<polygon mask="url(#mask)" points="24 21 24 9 22 9 22 23 30 23 30 21 24 21" />
+			<path
+				mask="url(#mask)"
+				d="M18,9H14a2,2,0,0,0-2,2V21a2,2,0,0,0,2,2h1v2a2,2,0,0,0,2,2h2V25H17V23h1a2,2,0,0,0,2-2V11A2,2,0,0,0,18,9ZM14,21V11h4V21Z"
+			/>
+			<path
+				mask="url(#mask)"
+				d="M8,23H2V21H8V17H4a2,2,0,0,1-2-2V11A2,2,0,0,1,4,9h6v2H4v4H8a2,2,0,0,1,2,2v4A2,2,0,0,1,8,23Z"
+			/>
+			<polygon points="4,27 26,5 27.5,6.5 5.5,28.5" />
+		</svg>
+	</span>
+</span>
+
+<style>
+	.icon {
+		align-items: center;
+		vertical-align: middle;
+	}
+
+	.icon-container {
+		display: inline-flex;
+		align-items: center;
+		vertical-align: middle;
+	}
+
+	svg {
+		margin: auto;
+		display: block;
+	}
+</style>

--- a/sites/example-project/src/components/icons/SQLIcon.svelte
+++ b/sites/example-project/src/components/icons/SQLIcon.svelte
@@ -6,22 +6,22 @@
 
 <span class="icon-container" style="padding-bottom: {verticalOffset}px">
 	<span class="icon" style="height: {height}px; width:{width}px">
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-			<g transform="rotate(90 12 12)">
-				<path
-					fill="currentColor"
-					d="M20 14a2 2 0 1 1-.001-3.999A2 2 0 0 1 20 14ZM6 12a2 2 0 1 1-3.999.001A2 2 0 0 1 6 12Zm8 0a2 2 0 1 1-3.999.001A2 2 0 0 1 14 12Z"
-				/>
-			</g>
+		<svg fill="currentColor" viewBox="0 0 32 32" id="icon" xmlns="http://www.w3.org/2000/svg">
+			<polygon points="24 21 24 9 22 9 22 23 30 23 30 21 24 21" />
+			<path
+				d="M18,9H14a2,2,0,0,0-2,2V21a2,2,0,0,0,2,2h1v2a2,2,0,0,0,2,2h2V25H17V23h1a2,2,0,0,0,2-2V11A2,2,0,0,0,18,9ZM14,21V11h4V21Z"
+			/>
+			<path
+				d="M8,23H2V21H8V17H4a2,2,0,0,1-2-2V11A2,2,0,0,1,4,9h6v2H4v4H8a2,2,0,0,1,2,2v4A2,2,0,0,1,8,23Z"
+			/>
 		</svg>
 	</span>
 </span>
 
 <style>
 	.icon {
-		width: 24px;
-		height: 24px;
 		align-items: center;
+		vertical-align: middle;
 	}
 
 	.icon-container {

--- a/sites/example-project/src/components/ui/Header.svelte
+++ b/sites/example-project/src/components/ui/Header.svelte
@@ -2,6 +2,7 @@
 	import BreadCrumbs from './BreadCrumbs.svelte';
 	import Hamburger from './Hamburger.svelte';
 	import PageMenu from './PageMenu.svelte';
+	import QueryToggleButton from './QueryToggleButton.svelte';
 	export let fileTree;
 	import { page } from '$app/stores';
 	export let open = false;
@@ -12,7 +13,10 @@
 		<Hamburger bind:open />
 		<BreadCrumbs {fileTree} />
 		{#if !$page.url.pathname.includes('/settings')}
-			<PageMenu />
+			<div class="option-tray">
+				<QueryToggleButton />
+				<PageMenu />
+			</div>
 		{/if}
 	</div>
 </header>
@@ -22,6 +26,12 @@
 		grid-area: header;
 		height: var(--header-height);
 		width: 100%;
+	}
+
+	.option-tray {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
 	}
 
 	div.header-container {

--- a/sites/example-project/src/components/ui/PageMenu.svelte
+++ b/sites/example-project/src/components/ui/PageMenu.svelte
@@ -3,10 +3,7 @@
 	import KebabIcon from '$lib/icons/KebabIcon.svelte';
 	import ExternalLinkIcon from '$lib/icons/ExternalLinkIcon.svelte';
 	import clickOutside from '$lib/modules/clickOutside';
-	import { showQueries } from './stores';
-	import { pageHasQueries } from './stores';
 	let options = [
-		{ label: 'Show / Hide Queries', prod: true },
 		{ label: 'Export PDF', prod: true },
 		{ label: 'Connect Data Source', url: '/settings/#connect-database', prod: false },
 		{ label: 'Deploy Project', url: '/settings/#deploy', prod: false },
@@ -24,10 +21,6 @@
 		window.print();
 	}
 
-	function toggleQueries() {
-		showQueries.update((value) => !value);
-	}
-
 	let showDropdown = false;
 
 	function toggleDropdown() {
@@ -37,30 +30,18 @@
 
 <div use:clickOutside={{ enabled: showDropdown, callback: () => (showDropdown = false) }}>
 	<button type="button" class="menu" aria-label="page menu button" on:click={toggleDropdown}
-		><KebabIcon color="--grey-600" /></button
+		><KebabIcon /></button
 	>
 	{#if showDropdown}
 		<ul class="dropdown-items" id="dropdown-items">
 			{#each options as option}
 				{#if dev || option.prod}
 					<li>
-						{#if option.label === 'Show / Hide Queries'}
-							{#if $pageHasQueries}
-								{#if $showQueries}
-									<button class="dropdown" aria-label="hide-queries" on:click={toggleQueries}
-										>Hide Queries</button
-									>
-								{:else}
-									<button class="dropdown" aria-label="show-queries" on:click={toggleQueries}
-										>Show Queries</button
-									>
-								{/if}
-							{/if}
-						{:else if option.label === 'Export PDF'}
+						{#if option.label === 'Export PDF'}
 							<button class="dropdown first" on:click={print}>{option.label}</button>
 						{:else if option.url.includes('http')}
 							<a href={option.url} target="_blank" rel="noreferrer"
-								>{option.label}<ExternalLinkIcon height="12" width="12" color="--red-700" /></a
+								>{option.label}<ExternalLinkIcon height="12" width="12" color="--grey-700" /></a
 							>
 						{:else}
 							<a href={option.url} target="_self">{option.label}</a>
@@ -89,6 +70,12 @@
 	button.menu {
 		margin: 16px;
 		font-size: unset;
+		color: var(--grey-600);
+	}
+
+	button.menu:hover {
+		color: var(--grey-900);
+		transition: all 0.2s;
 	}
 
 	ul {

--- a/sites/example-project/src/components/ui/QueryToggleButton.svelte
+++ b/sites/example-project/src/components/ui/QueryToggleButton.svelte
@@ -1,0 +1,32 @@
+<script>
+	import { showQueries } from './stores';
+	import { pageHasQueries } from './stores';
+	import SQLIcon from '$lib/icons/SqlIcon.svelte';
+	import SQLHideIcon from '$lib/icons/SQLHideIcon.svelte';
+	function toggleQueries() {
+		showQueries.update((value) => !value);
+	}
+</script>
+
+{#if $pageHasQueries}
+	{#if $showQueries}
+		<button aria-label="hide-queries" title="Hide Queries" on:click={toggleQueries}>
+			<SQLHideIcon height="28" width="28" />
+		</button>
+	{:else}
+		<button aria-label="show-queries" title="Show Queries" on:click={toggleQueries}>
+			<SQLIcon height="28" width="28" />
+		</button>
+	{/if}
+{/if}
+
+<style>
+	button {
+		color: var(--grey-600);
+	}
+
+	button:hover {
+		color: var(--grey-900);
+		transition: all 0.2s;
+	}
+</style>

--- a/sites/example-project/src/components/ui/QueryToggleButton.svelte
+++ b/sites/example-project/src/components/ui/QueryToggleButton.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { showQueries } from './stores';
 	import { pageHasQueries } from './stores';
-	import SQLIcon from '$lib/icons/SqlIcon.svelte';
+	import SQLIcon from '$lib/icons/SQLIcon.svelte';
 	import SQLHideIcon from '$lib/icons/SQLHideIcon.svelte';
 	function toggleQueries() {
 		showQueries.update((value) => !value);


### PR DESCRIPTION
### Description

Move back out of menu - users have reported it's hard to find inside the page menu.

![CleanShot 2023-04-13 at 22 06 26](https://user-images.githubusercontent.com/58074498/231923623-dde008ff-a646-4fb1-aa19-256d78a969b2.gif)



### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
