### PR TITLE
Fix query viewer still visible on windows (OS)

### DIFF
--- a/.changeset/tasty-dodos-speak.md
+++ b/.changeset/tasty-dodos-speak.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Fix query viewer still visible on windows (OS)

--- a/sites/example-project/src/components/ui/QueryViewer.svelte
+++ b/sites/example-project/src/components/ui/QueryViewer.svelte
@@ -156,7 +156,7 @@
 
 	.over-container {
 		overflow-y: hidden;
-		overflow-x: scroll;
+		overflow-x: auto;
 	}
 
 	.code-container::-webkit-scrollbar-thumb {


### PR DESCRIPTION
### Description
- Remove `QueryViewer` UI regression on windows machine

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)


### Previous


![](https://user-images.githubusercontent.com/16811433/226492450-ed7664ee-9774-43ff-9a04-ad9c612a9c8f.png)

### After

![CleanShot 2023-04-21 at 10 17 17](https://user-images.githubusercontent.com/10125507/233659495-c4b5dcdc-f2ae-4e73-b971-33a168c16aa8.gif)

