### PR TITLE
issue-700 Workaround for handing values from numeric columns that are not returned as JS 64 bit number

### DIFF
--- a/.changeset/dull-lemons-notice.md
+++ b/.changeset/dull-lemons-notice.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/bigquery': patch
+---
+
+"Fixed an issue with wide numeric type columns values not showing up on Evidence"

--- a/packages/bigquery/index.cjs
+++ b/packages/bigquery/index.cjs
@@ -8,7 +8,16 @@ const standardizeResult = async (result) => {
 		for (const [key, value] of Object.entries(row)) {
 			if (typeof value === 'object') {
 				if (value) {
-					standardized[key] = value.value;
+					if (value.value) {
+						standardized[key] = value.value;
+					} else {
+						//This is a bigQuery specific workaround for https://github.com/evidence-dev/evidence/issues/792
+						try {
+							standardized[key] = Number(value);
+						} catch (err) {
+							standardized[key] = value;
+						}
+					}
 				} else {
 					standardized[key] = null;
 				}

--- a/packages/bigquery/test/test.js
+++ b/packages/bigquery/test/test.js
@@ -40,16 +40,15 @@ test('query runs', async () => {
 	);
 });
 
-792
+792;
 test('numeric types are retrieved correctly', async () => {
 	results = await runQuery(
-		"select CAST(1.23456789 AS NUMERIC) as numeric_number, CAST(1.23456789 AS FLOAT64) as float64_number, CAST(1.23456789 AS DECIMAL) as decimal_number, CAST(1.23456789 AS STRING) as string_number"
+		'select CAST(1.23456789 AS NUMERIC) as numeric_number, CAST(1.23456789 AS FLOAT64) as float64_number, CAST(1.23456789 AS DECIMAL) as decimal_number, CAST(1.23456789 AS STRING) as string_number'
 	);
 	let actualColumnTypes = results.columnTypes.map((columnType) => columnType.evidenceType);
 	let actualColumnNames = results.columnTypes.map((columnType) => columnType.name);
 	let actualTypePrecisions = results.columnTypes.map((columnType) => columnType.typeFidelity);
 	let actualValues = Object.keys(results.rows[0]).map((key) => results.rows[0][key]);
-
 
 	let expectedColumnTypes = ['number', 'number', 'number', 'string'];
 	let expectedColumnNames = ['numeric_number', 'float64_number', 'decimal_number', 'string_number'];
@@ -71,7 +70,7 @@ test('numeric types are retrieved correctly', async () => {
 		expectedTypePrecision.length === actualTypePrecisions.length &&
 			expectedTypePrecision.every((value, index) => value === actualTypePrecisions[index])
 	);
-	assert.equal(expectedValues, actualValues)
+	assert.equal(expectedValues, actualValues);
 });
 
 test.run();

--- a/packages/bigquery/test/test.js
+++ b/packages/bigquery/test/test.js
@@ -40,4 +40,38 @@ test('query runs', async () => {
 	);
 });
 
+792
+test('numeric types are retrieved correctly', async () => {
+	results = await runQuery(
+		"select CAST(1.23456789 AS NUMERIC) as numeric_number, CAST(1.23456789 AS FLOAT64) as float64_number, CAST(1.23456789 AS DECIMAL) as decimal_number, CAST(1.23456789 AS STRING) as string_number"
+	);
+	let actualColumnTypes = results.columnTypes.map((columnType) => columnType.evidenceType);
+	let actualColumnNames = results.columnTypes.map((columnType) => columnType.name);
+	let actualTypePrecisions = results.columnTypes.map((columnType) => columnType.typeFidelity);
+	let actualValues = Object.keys(results.rows[0]).map((key) => results.rows[0][key]);
+
+
+	let expectedColumnTypes = ['number', 'number', 'number', 'string'];
+	let expectedColumnNames = ['numeric_number', 'float64_number', 'decimal_number', 'string_number'];
+	let expectedTypePrecision = Array(4).fill(TypeFidelity.PRECISE);
+	let expectedValues = [1.23456789, 1.23456789, 1.23456789, '1.23456789'];
+
+	assert.equal(
+		true,
+		expectedColumnTypes.length === actualColumnTypes.length &&
+			expectedColumnTypes.every((value, index) => value === actualColumnTypes[index])
+	);
+	assert.equal(
+		true,
+		expectedColumnNames.length === actualColumnNames.length &&
+			expectedColumnNames.every((value, index) => value === actualColumnNames[index])
+	);
+	assert.equal(
+		true,
+		expectedTypePrecision.length === actualTypePrecisions.length &&
+			expectedTypePrecision.every((value, index) => value === actualTypePrecisions[index])
+	);
+	assert.equal(expectedValues, actualValues)
+});
+
 test.run();


### PR DESCRIPTION
It seems that the BigQuery driver is returning special objects when the values corresponding to it's type is *potentially* too wide to fit in a JS number. 

This is a more general issue on Evidence and we should find a generalized approach for all DB drivers (e.g BIGINT types in Postgres)  More details here:  https://github.com/evidence-dev/evidence/issues/792

The fix here is a work around for how it specifically fails in BigQuery.  I suspect this was a regression introduced by the BigQuery driver updated from a month ago 1124bb52c8879bfcf8a052f02002ea190db5c35b

In BigQueries case, this blew up when we were standardizing row results

## Before fix
```
{
   "rows":[
      {
         "numeric_number":"1.23456789",
         "float64_number":1.23456789,
         "decimal_number":"1.23456789",
         "string_number":"1.23456789"
      },
      {
         "numeric_number":"9.999",
         "float64_number":9.999,
         "decimal_number":"9.999",
         "string_number":"9.999"
      }
   ],
   "standardizedRows":[
      {
         "float64_number":1.23456789,
         "string_number":"1.23456789"
      },
      {
         "float64_number":9.999,
         "string_number":"9.999"
      }
   ]
}
```
## After fix
```
{
   "rows":[
      {
         "numeric_number":"1.23456789",
         "float64_number":1.23456789,
         "decimal_number":"1.23456789",
         "string_number":"1.23456789"
      },
      {
         "numeric_number":"9.999",
         "float64_number":9.999,
         "decimal_number":"9.999",
         "string_number":"9.999"
      }
   ],
   "standardizedRows":[
      {
         "numeric_number":1.23456789,   
         "float64_number":1.23456789,
         "decimal_number":1.23456789,
         "string_number":"1.23456789"
      },
      {
        "numeric_number":9.999,
         "float64_number":9.999,
         "decimal_number":9.999,
         "string_number":"9.999"
      }
   ]
}
```