### PR TITLE
Fix funnel chart spacing

### DIFF
--- a/.changeset/flat-impalas-rule.md
+++ b/.changeset/flat-impalas-rule.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Fix legend and chart spacing for funnel chart

--- a/sites/example-project/src/components/viz/FunnelChart.svelte
+++ b/sites/example-project/src/components/viz/FunnelChart.svelte
@@ -13,6 +13,7 @@
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = true;
+	legend = legend === 'true' || legend === true;
 
 	export let outlineColor = undefined;
 	export let outlineWidth = undefined;
@@ -75,7 +76,7 @@
 		hasTitle * titleFontSize +
 		hasSubtitle * subtitleFontSize +
 		titleBoxPadding * Math.max(hasTitle, hasSubtitle);
-	chartAreaTopPosition = hasTitle * 60 + hasSubtitle * 20;
+	chartAreaTopPosition = (hasLegend ? 30 : 10) + hasTitle * 23 + (hasTitle ? hasSubtitle * 25 : hasSubtitle * 30);
 	chartAreaPaddingTop = 2;
 	chartAreaPaddingBottom = 8;
 

--- a/sites/example-project/src/components/viz/FunnelChart.svelte
+++ b/sites/example-project/src/components/viz/FunnelChart.svelte
@@ -76,7 +76,8 @@
 		hasTitle * titleFontSize +
 		hasSubtitle * subtitleFontSize +
 		titleBoxPadding * Math.max(hasTitle, hasSubtitle);
-	chartAreaTopPosition = (hasLegend ? 30 : 10) + hasTitle * 23 + (hasTitle ? hasSubtitle * 25 : hasSubtitle * 30);
+	chartAreaTopPosition =
+		(hasLegend ? 30 : 10) + hasTitle * 23 + (hasTitle ? hasSubtitle * 25 : hasSubtitle * 30);
 	chartAreaPaddingTop = 2;
 	chartAreaPaddingBottom = 8;
 

--- a/sites/example-project/src/pages/charts/funnel-chart/+page.md
+++ b/sites/example-project/src/pages/charts/funnel-chart/+page.md
@@ -10,14 +10,85 @@ union all
 select 14 as customers, 'Order' as stage,
 ```
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Simple Funnel Chart" outlineColor="white"/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Simple Funnel Chart" 
+/>
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Descending" outlineColor="white" funnelSort="Descending"/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="No subtitle" 
+/>
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Ascending" outlineColor="white" funnelSort="ascending"/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    subtitle="Only subtitle" 
+/>
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Right Aligned" outlineColor="white" funnelAlign="right"/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+/>
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Left Aligned" outlineColor="white" funnelAlign="left"/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers
+    legend=false
+/>
 
-<FunnelChart data={funnel_data} nameCol=stage valueCol=customers title="Funnel Chart" subtitle="Funnel with Percent" showPercent=true/>
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Descending" 
+    funnelSort="Descending"
+/>
+
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Ascending" 
+    outlineColor="white" 
+    funnelSort="ascending"
+/>
+
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Right Aligned" 
+    outlineColor="white" 
+    funnelAlign="right"
+/>
+
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Left Aligned" 
+    outlineColor="white" 
+    funnelAlign="left"
+/>
+
+<FunnelChart 
+    data={funnel_data} 
+    nameCol=stage 
+    valueCol=customers 
+    title="Funnel Chart" 
+    subtitle="Funnel with Percent" 
+    showPercent=true
+/>


### PR DESCRIPTION
### Description
Fixes #786 

Funnel chart spacing was working for charts with titles and subtitles, but didn't account for charts without those. This PR adds logic to handle the various combinations of title, subtitle, and legend to include appropriate spacing at the top of the chart.

### Before
<img width="474" alt="CleanShot 2023-04-21 at 14 32 16@2x" src="https://user-images.githubusercontent.com/12602440/233710129-a87de8a7-5f58-4a6a-9eb4-7e9ca65a2575.png">

### After
<img width="450" alt="CleanShot 2023-04-21 at 14 30 43@2x" src="https://user-images.githubusercontent.com/12602440/233710141-92ec56d4-014e-46b0-9626-1ee8fd746468.png">

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
