### PR TITLE
Add instructions for adapting UI components

### DIFF
--- a/sites/docs/docs/components/custom-components.md
+++ b/sites/docs/docs/components/custom-components.md
@@ -101,7 +101,7 @@ After opening the `components/MySidebar.svelte` file, modify the h2 with a class
 
 To use our new sidebar, you must import it in place of the existing sidebar. The general approach we will follow here is described in [themes and layouts.](/themes-and-layouts).
 
-We start by copying the file `+layout.svelte` from `.evidence/template/src/pages/` into `/pages`, the same directory where we put new report [pages](/components/pages) as we create them. After opening this newly copied file, modify the import statement for the `Sidebar` component (inside the script tag) as follows:
+We start by copying the file `+layout.svelte` from `.evidence/template/src/pages/` into `/pages`, the same directory where we put new report [pages](/core-concepts/pages) as we create them. After opening this newly copied file, modify the import statement for the `Sidebar` component (inside the script tag) as follows:
 
 ```svelte title="+layout.svelte"
 import Sidebar from "$lib/MySidebar.svelte";

--- a/sites/docs/docs/components/custom-components.md
+++ b/sites/docs/docs/components/custom-components.md
@@ -6,7 +6,7 @@ title: Custom Components
 
 Custom components allow you to extend the functionality of Evidence, as well as to make your code more reusable.
 
-In Evidence, you can build your own components and use them anywhere in your project. This is made possible through Svelte, the JavaScript framework Evidence is built on.
+In Evidence, you can build your own components and use them anywhere in your project. This is made possible through Svelte, the JavaScript framework Evidence is built on. These components can include the charts used for visualization, custom components created completely from scratch, or adaptations of existing UI components such as the sidebar, menu, etc.
 
 Below is a **short guide** on building a simple component in Evidence.
 
@@ -67,6 +67,49 @@ Add a folder called `components/` in the root of your project. This is where Evi
 
 <BarChart data="{query}" />
 ```
+
+## Modifying an existing component
+Adapting any existing components to your needs is straightforward as well. You can achieve this by duplicating an existing component into your `/components` directory, modifying that new component file, and importing the new component as needed in your project.
+
+In this example, we will modify the title at the upper-left of our reports to have a label of "Invoices", rather than "Evidence".
+
+### Folder structure
+
+```
+.
+|-- pages/
+|   `-- index.md
+`-- components/
+    `-- MySidebar.svelte
+```
+
+First, create the `components/` directory if this is your first custom component. Then copy the file `Sidebar.svelte` from `.evidence/template/src/components/ui` into the directory, renaming it to `MySidebar.svelte` (or any other name of your choosing).
+
+### Modifying the Component
+
+With this new version of the component now created as a copy of the original, we are going to make our modifications.
+
+After opening the `components/MySidebar.svelte` file, modify the h2 with a class of `project-title` to have inner text of "Invoicing", similar to the following:
+```html title="MySidebar.svelte"
+<div class="nav-header">
+    <a href="/" on:click={() => (open = !open)}><h2 class="project-title">Invoicing</h2></a>
+    <button class="close" on:click={() => (open = !open)}><CloseIcon height="36" width="36" /></button>
+</div>
+```
+
+### Using our new component
+
+To use our new sidebar, you must import it in place of the existing sidebar. The general approach we will follow here is described in [themes and layouts.](/themes-and-layouts).
+
+We start by copying the file `+layout.svelte` from `.evidence/template/src/pages/` into `/pages`, the same directory where we put new report [pages](/components/pages) as we create them. After opening this newly copied file, modify the import statement for the `Sidebar` component (inside the script tag) as follows:
+
+```javascript title="+layout.svelte"
+import Sidebar from "$lib/MySidebar.svelte";
+```
+
+As noted in the comments on one of the snippets above, `$lib` refers to the `component/` directory in the root of our project. Since we didn't change the export name of our component, we only need to change the reference to the file and can leave everything else the same.
+
+With these modifications, our project should now read "Invoices" as the title. This same approach can be used to modify any other UI elements as well.
 
 ## Building your own component: Checklist
 

--- a/sites/docs/docs/components/custom-components.md
+++ b/sites/docs/docs/components/custom-components.md
@@ -68,8 +68,8 @@ Add a folder called `components/` in the root of your project. This is where Evi
 <BarChart data="{query}" />
 ```
 
-## Modifying an existing component
-Adapting any existing components to your needs is straightforward as well. You can achieve this by duplicating an existing component into your `/components` directory, modifying that new component file, and importing the new component as needed in your project.
+## Modifying an existing component: Changing the project name
+Modify an existing component by copying the component's source code into the /components directory, modifying it, and importing the new component as needed in your project.
 
 In this example, we will modify the title at the upper-left of our reports to have a label of "Invoices", rather than "Evidence".
 
@@ -90,7 +90,7 @@ First, create the `components/` directory if this is your first custom component
 With this new version of the component now created as a copy of the original, we are going to make our modifications.
 
 After opening the `components/MySidebar.svelte` file, modify the h2 with a class of `project-title` to have inner text of "Invoicing", similar to the following:
-```html title="MySidebar.svelte"
+```svelte title="MySidebar.svelte"
 <div class="nav-header">
     <a href="/" on:click={() => (open = !open)}><h2 class="project-title">Invoicing</h2></a>
     <button class="close" on:click={() => (open = !open)}><CloseIcon height="36" width="36" /></button>
@@ -103,11 +103,11 @@ To use our new sidebar, you must import it in place of the existing sidebar. The
 
 We start by copying the file `+layout.svelte` from `.evidence/template/src/pages/` into `/pages`, the same directory where we put new report [pages](/components/pages) as we create them. After opening this newly copied file, modify the import statement for the `Sidebar` component (inside the script tag) as follows:
 
-```javascript title="+layout.svelte"
+```svelte title="+layout.svelte"
 import Sidebar from "$lib/MySidebar.svelte";
 ```
 
-As noted in the comments on one of the snippets above, `$lib` refers to the `component/` directory in the root of our project. Since we didn't change the export name of our component, we only need to change the reference to the file and can leave everything else the same.
+As noted in the comments on one of the snippets above, `$lib` refers to the `/components` directory in the root of our project. Since we didn't change the export name of our component, we only need to change the reference to the file and can leave everything else the same.
 
 With these modifications, our project should now read "Invoices" as the title. This same approach can be used to modify any other UI elements as well.
 


### PR DESCRIPTION
### Description

This PR extends the custom components documentation by adding a simple example for how to "override" an existing component to better suit ones needs. It wasn't immediately clear to me how I might adapt the sidebar to use a different project title, since the documentation seems focussed on adding new components and it wasn't obvious to me that adapting existing components is functionally identical.

A big thank you to the Evidence team for getting me pointed in the right direction on doing what I wanted, and I hope that this addition to the docs will help others as well.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

(I don't believe these checklist items apply since I am updating documentation only - I'll be happy to adapt if needed).