### PR TITLE
Waterfall chart

### DIFF
--- a/packages/preprocess/src/process-queries.cjs
+++ b/packages/preprocess/src/process-queries.cjs
@@ -45,6 +45,7 @@ const createDefaultProps = function (filename, componentDevelopmentMode, fileQue
         import FunnelChart from "$lib/viz/FunnelChart.svelte";
         import SankeyChart from "$lib/viz/SankeyChart.svelte";
         import ScatterPlot from '$lib/viz/ScatterPlot.svelte';
+        import WaterfallChart from '$lib/viz/WaterfallChart.svelte';
         import Histogram from '$lib/viz/Histogram.svelte';
         import ECharts from '$lib/viz/ECharts.svelte';
         import USMap from '$lib/viz/USMap.svelte';

--- a/sites/example-project/src/components/viz/Waterfall.svelte
+++ b/sites/example-project/src/components/viz/Waterfall.svelte
@@ -94,6 +94,12 @@
       itemStyle: {
           color: 'grey'
       },
+	  label: {
+		normal: {
+			show: true,
+			position: swapXY ? 'right' : 'top'
+		}
+        },
 		tooltip: {
 			show: false
 		}
@@ -106,6 +112,12 @@
       itemStyle: {
           color: 'green'
       },
+	  label: {
+		normal: {
+			show: true,
+			position: swapXY ? 'right' : 'top'
+		}
+        },
 		tooltip: {
 			show: false
 		}
@@ -118,6 +130,12 @@
       itemStyle: {
         color: 'darkred'
       },
+	  label: {
+		normal: {
+			show: true,
+			position: swapXY ? 'left' : 'bottom'
+		}
+        },
 		tooltip: {
 			show: false
 		}

--- a/sites/example-project/src/components/viz/Waterfall.svelte
+++ b/sites/example-project/src/components/viz/Waterfall.svelte
@@ -6,66 +6,148 @@
 
 	export let options = undefined;
 
-	export let category = undefined;
-	export let value = undefined;
+	// export let category = undefined;
+	// export let value = undefined;
 	export let total = undefined;
 	export let data = undefined;
 
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
 	$: x = $props.x;
+	$: y = $props.y;
 	$: swapXY = $props.swapXY;
 
 	let xLabels = [];
-	for (let i = 0; i < 6; i++){
-		xLabels.push(data[i][category])
+	$: for (let i = 0; i < $props.data.length; i++){
+		if(i === 0){
+			xLabels = [];
+		}
+		
+		xLabels.push(data[i][x])
 	}
 
 	let helper = [];
-	let totals = [];
+	let totals =[];
 	let positive = [];
+	let positive2 = [];
 	let negative = [];
+	let negative2 = [];
 	let connector = [];
-	let sum = 0;
+	let sum = 0
 
 	// set up separate series to construct the waterfall
-	for (let i = 0; i < 6; i++) {
-		if(data[i][total] === true){
-			totals.push(data[i][value]);
-			positive.push('-');
-			negative.push('-');
-		} else if (data[i][value] >= 0) {
-			positive.push(data[i][value]);
-			negative.push('-');
-			totals.push('-');
-		} else {
-			positive.push('-');
-			negative.push(-data[i][value]);
-			totals.push('-');
-		}
-
-		// create helper series
+	$: for (let i = 0; i < $props.data.length; i++) {
 		if(i === 0){
-			helper.push(0);
-		} else {
-			sum += data[i - 1][value];
-			if(data[i][total] === true){
-			helper.push(0);
-			} else if (data[i][value] < 0) {
-			helper.push(sum + data[i][value]);
+			helper = [];
+			totals = [];
+			positive = [];
+			positive2 = [];
+			negative = [];
+			negative2 = [];
+			connector = [];
+			sum = 0;
+		}
+		
+		if(data[i][total] === true){
+			totals.push(data[i][y]);
+			positive.push('-');
+			positive2.push('-');
+			negative.push('-');
+			negative2.push('-');
+		} else if (sum >= 0) {
+			// Starting in Positive Space
+			if((sum + data[i][y]) >= 0){
+				// Ending in Positive Space
+				if (data[i][y] >= 0) {
+					positive.push(data[i][y]);
+					negative.push('-');
+					negative2.push('-');
+					totals.push('-');
+					positive2.push('-');
+				} else {
+					positive.push('-');
+					positive2.push('-');
+					negative.push(-data[i][y]);
+					negative2.push('-');
+					totals.push('-');
+				}
 			} else {
-			helper.push(sum);
+				// Ending in Negative Space (Crossover)
+				// Value must be negatve
+				positive2.push('-');
+				positive.push('-');
+				negative.push(sum);
+				negative2.push(data[i][y] + sum);
+				totals.push('-');
+			}
+		} else {
+			// Starting in Negative Space
+			if((sum + data[i][y]) < 0){
+				// Ending in Negative Space
+				if (data[i][y] >= 0) {
+					positive.push(-data[i][y]);
+					negative.push('-');
+					negative2.push('-');
+					totals.push('-');
+					positive2.push('-');
+				} else {
+					positive.push('-');
+					positive2.push('-');
+					negative.push(data[i][y]);
+					negative2.push('-');
+					totals.push('-');
+				}
+			} else {
+				// Ending in Positive Space (Crossover)
+				positive2.push(sum);
+				positive.push(data[i][y] + sum);
+				negative.push('-');
+				negative2.push('-');
+				totals.push('-');
 			}
 		}
-	
+
 		// create connector series
 		if(i === 0){
 			connector.push(0)
 		} else {
 			connector.push(sum)
 		}
-	}
 
+		// create helper series
+		if(i === 0){
+			helper.push(0);
+			sum += data[i][y];
+		} else {
+			if(data[i][total] === true){
+				helper.push(0);
+			} else if ((sum >= 0) === (sum + data[i][y]) >= 0){
+				if(sum >= 0) {
+					// Positive Space
+					if(data[i][y] < 0){
+						helper.push(sum + data[i][y]);
+						sum += data[i][y];
+					} else {
+						helper.push(sum);
+						sum += data[i][y];					
+					}
+				} else {
+					// Negative Space
+					if(data[i][y] >= 0){
+						helper.push(sum + data[i][y]);
+						sum += data[i][y];
+					} else {
+						helper.push(sum);
+						sum += data[i][y];					
+					}
+				}
+			} else {
+				helper.push(0);
+				sum += data[i][y];					
+			}
+		}
+	
+	}
 
 	$: seriesConfig = [
     {
@@ -74,7 +156,7 @@
       itemStyle: {
         normal: {
           barBorderColor: 'rgba(0,0,0,0)',
-          color: 'rgba(0,0,0,0)'
+          color:'rgba(0,0,0,0)'
         },
         emphasis: {
           barBorderColor: 'rgba(0,0,0,0)',
@@ -92,7 +174,7 @@
       stack: 'all',
       data: totals,
       itemStyle: {
-          color: 'grey'
+          color: '#888b8c'
       },
 	  label: {
 		normal: {
@@ -110,7 +192,25 @@
       stack: 'all',
       data: positive,
       itemStyle: {
-          color: 'green'
+          color: '#0a7f10'
+      },
+	  label: {
+		normal: {
+			show: true,
+			position: swapXY ? 'right' : 'top'
+		}
+        },
+		tooltip: {
+			show: false
+		}
+    },
+	{
+      name: 'positive2',
+      type: 'bar',
+      stack: 'all',
+      data: positive2,
+      itemStyle: {
+          color: '#0a7f10'
       },
 	  label: {
 		normal: {
@@ -128,7 +228,25 @@
       stack: 'all',
       data: negative,
       itemStyle: {
-        color: 'darkred'
+        color: '#a60303'
+      },
+	  label: {
+		normal: {
+			show: true,
+			position: swapXY ? 'left' : 'bottom'
+		}
+        },
+		tooltip: {
+			show: false
+		}
+    },
+	{
+      name: 'negative2',
+      type: 'bar',
+      stack: 'all',
+      data: negative2,
+      itemStyle: {
+        color: '#a60303'
       },
 	  label: {
 		normal: {
@@ -148,7 +266,7 @@
             step:'start',
             data: connector,
             lineStyle: {
-              color: 'lightgrey',
+              color: '#a2a5a6',
               width: 1,
               type: 'dashed'
             },
@@ -178,7 +296,7 @@
 			xAxis: {
 				data: xLabels,
 				axisLabel: {
-					width: 60,
+					width: 500 / xLabels.length,
 					interval: 0,
 					overflow: 'break'
 				}
@@ -186,7 +304,7 @@
 		};
 	}
 
-	beforeUpdate(() => {
+	$: beforeUpdate(() => {
 		// beforeUpdate ensures that these overrides always run before we render the chart.
 		// otherwise, this block won't re-execute after a change to the data object, and
 		// the chart will re-render using the base config from Chart.svelte

--- a/sites/example-project/src/components/viz/Waterfall.svelte
+++ b/sites/example-project/src/components/viz/Waterfall.svelte
@@ -1,0 +1,195 @@
+<script>
+	import { getContext, beforeUpdate } from 'svelte';
+	import { propKey, configKey } from './context';
+	$: props = getContext(propKey);
+	$: config = getContext(configKey);
+
+	export let options = undefined;
+
+	export let category = undefined;
+	export let value = undefined;
+	export let total = undefined;
+	export let data = undefined;
+
+	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
+	$: data = $props.data;
+	$: x = $props.x;
+	$: swapXY = $props.swapXY;
+
+	let xLabels = [];
+	for (let i = 0; i < 6; i++){
+		xLabels.push(data[i][category])
+	}
+
+	let helper = [];
+	let totals = [];
+	let positive = [];
+	let negative = [];
+	let connector = [];
+	let sum = 0;
+
+	// set up separate series to construct the waterfall
+	for (let i = 0; i < 6; i++) {
+		if(data[i][total] === true){
+			totals.push(data[i][value]);
+			positive.push('-');
+			negative.push('-');
+		} else if (data[i][value] >= 0) {
+			positive.push(data[i][value]);
+			negative.push('-');
+			totals.push('-');
+		} else {
+			positive.push('-');
+			negative.push(-data[i][value]);
+			totals.push('-');
+		}
+
+		// create helper series
+		if(i === 0){
+			helper.push(0);
+		} else {
+			sum += data[i - 1][value];
+			if(data[i][total] === true){
+			helper.push(0);
+			} else if (data[i][value] < 0) {
+			helper.push(sum + data[i][value]);
+			} else {
+			helper.push(sum);
+			}
+		}
+	
+		// create connector series
+		if(i === 0){
+			connector.push(0)
+		} else {
+			connector.push(sum)
+		}
+	}
+
+
+	$: seriesConfig = [
+    {
+      type: 'bar',
+      stack: 'all',
+      itemStyle: {
+        normal: {
+          barBorderColor: 'rgba(0,0,0,0)',
+          color: 'rgba(0,0,0,0)'
+        },
+        emphasis: {
+          barBorderColor: 'rgba(0,0,0,0)',
+          color: 'rgba(0,0,0,0)'
+        }
+      },
+      data: helper,
+		tooltip: {
+			show: false
+		}
+    },
+     {
+      name: 'total',
+      type: 'bar',
+      stack: 'all',
+      data: totals,
+      itemStyle: {
+          color: 'grey'
+      },
+		tooltip: {
+			show: false
+		}
+    },
+    {
+      name: 'positive',
+      type: 'bar',
+      stack: 'all',
+      data: positive,
+      itemStyle: {
+          color: 'green'
+      },
+		tooltip: {
+			show: false
+		}
+    },
+    {
+      name: 'negative',
+      type: 'bar',
+      stack: 'all',
+      data: negative,
+      itemStyle: {
+        color: 'darkred'
+      },
+		tooltip: {
+			show: false
+		}
+    },
+            {
+            name:'connector',
+            type:'line',
+            symbol:'none',
+            z:1,
+            step:'start',
+            data: connector,
+            lineStyle: {
+              color: 'lightgrey',
+              width: 1,
+              type: 'dashed'
+            },
+			animationDelay: 400,
+			tooltip: {
+				show: false
+			}
+        }
+  ]
+
+	$: config.update((d) => {
+		d.series.push(...seriesConfig);
+		return d;
+	});
+
+	let chartOverrides;
+	$: if(swapXY){
+		chartOverrides = {
+			// Evidence definition of axes (yAxis = dependent, xAxis = independent)
+			xAxis: {
+				data: xLabels
+			}
+		};
+	} else {
+		chartOverrides = {
+			// Evidence definition of axes (yAxis = dependent, xAxis = independent)
+			xAxis: {
+				data: xLabels,
+				axisLabel: {
+					width: 60,
+					interval: 0,
+					overflow: 'break'
+				}
+			}
+		};
+	}
+
+	beforeUpdate(() => {
+		// beforeUpdate ensures that these overrides always run before we render the chart.
+		// otherwise, this block won't re-execute after a change to the data object, and
+		// the chart will re-render using the base config from Chart.svelte
+
+		if (options) {
+			config.update((d) => {
+				return { ...d, ...options };
+			});
+		}
+
+		if (chartOverrides) {
+			config.update((d) => {
+				if (swapXY) {
+					d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
+				} else {
+					d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+					d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				}
+				return d;
+			});
+		}
+	});
+</script>

--- a/sites/example-project/src/components/viz/WaterfallChart.svelte
+++ b/sites/example-project/src/components/viz/WaterfallChart.svelte
@@ -3,14 +3,15 @@
 	import Waterfall from './Waterfall.svelte';
 
 	export let data = undefined;
+
 	export let y = undefined;
 	export let series = undefined;
 	export let xType = undefined;
 
-	export let category = undefined;
-	export let x = category;
+	// export let category = undefined;
+	export let x = undefined;
 
-	export let value = undefined;
+	// export let value = undefined;
 	export let total = undefined;
 
 	export let title = undefined;
@@ -65,5 +66,5 @@
 	chartType="Waterfall Chart"
 	{sort}
 >
-	<Waterfall {data} {category} {value} {total} />
+	<Waterfall {data} {total} />
 </Chart>

--- a/sites/example-project/src/components/viz/WaterfallChart.svelte
+++ b/sites/example-project/src/components/viz/WaterfallChart.svelte
@@ -1,0 +1,69 @@
+<script>
+	import Chart from './Chart.svelte';
+	import Waterfall from './Waterfall.svelte';
+
+	export let data = undefined;
+	export let y = undefined;
+	export let series = undefined;
+	export let xType = undefined;
+
+	export let category = undefined;
+	export let x = category;
+
+	export let value = undefined;
+	export let total = undefined;
+
+	export let title = undefined;
+	export let subtitle = undefined;
+	export let legend = undefined;
+	export let xAxisTitle = undefined;
+	export let yAxisTitle = undefined;
+	export let xGridlines = undefined;
+	export let yGridlines = undefined;
+	export let xAxisLabels = undefined;
+	export let yAxisLabels = undefined;
+	export let xBaseline = undefined;
+	export let yBaseline = undefined;
+	export let xTickMarks = undefined;
+	export let yTickMarks = undefined;
+	export let yMin = undefined;
+	export let yMax = undefined;
+	export let swapXY = false;
+	$: {
+		if (swapXY === 'true' || swapXY === true) {
+			swapXY = true;
+		} else {
+			swapXY = false;
+		}
+	}
+
+	export let sort = undefined;
+</script>
+
+<Chart
+	{data}
+	{x}
+	{y}
+	{series}
+	{xType}
+	{legend}
+	{xAxisTitle}
+	{yAxisTitle}
+	{xGridlines}
+	{yGridlines}
+	{xAxisLabels}
+	{yAxisLabels}
+	{xBaseline}
+	{yBaseline}
+	{xTickMarks}
+	{yTickMarks}
+	{yMin}
+	{yMax}
+	{swapXY}
+	{title}
+	{subtitle}
+	chartType="Waterfall Chart"
+	{sort}
+>
+	<Waterfall {data} {category} {value} {total} />
+</Chart>

--- a/sites/example-project/src/pages/charts/waterfall-chart/+page.md
+++ b/sites/example-project/src/pages/charts/waterfall-chart/+page.md
@@ -1,5 +1,30 @@
 <script>
-import WaterfallChart from '$lib/viz/WaterfallChart.svelte'
+    let wf = [
+        {"category": "PY Revenue", "revenue_usd": 100000, "total": true},
+        {"category": "New Customers", "revenue_usd": 20000, "total": false},
+        {"category": "Upsell", "revenue_usd": 10000, "total": false},
+        // {"category": "Subtotal", "revenue_usd": 130000, "total": true},
+        {"category": "Churn", "revenue_usd": -1000, "total": false},
+        {"category": "Price Changes", "revenue_usd": -5000, "total": false},
+        {"category": "CY Revenue", "revenue_usd": 124000, "total": true}
+    ]
+
+    let bal = [
+        {"category": "balance", "amount_usd": -1000, "total": true},
+        {"category": "deposits", "amount_usd": 500, "total": false},
+        {"category": "withdrawals", "amount_usd": -300, "total": false},
+        {"category": "new balance", "amount_usd": -800, "total": true}
+    ]
+
+    let diff = [
+    {'category': 'start', 'value': -10000, 'total': false},
+    {'category': 'one', 'value': 30000, 'total': false},
+    {'category': 'two', 'value': 20000, 'total': false},
+    {'category': 'subtotal', 'value': 40000, 'total': true},
+{'category': 'three', 'value': -80000, 'total': false},
+    {'category': 'four', 'value': 50000, 'total': false},
+    {'category': 'five', 'value': 10000, 'total': false}
+]
 </script>
 
 # Waterfall Chart
@@ -15,14 +40,29 @@ select 'Churn' as category, -45368 as revenue_usd, false as total
 union all 
 select 'Price Changes' as category, -551250 as revenue_usd, false as total
 union all 
-select 'CY Revenue' as category, 764115 as revenue_usd, true as total
+select 'CY Revenue' as category, 740115 as revenue_usd, true as total
 ```
 
 <WaterfallChart 
-    data={waterfall} 
-    category=category 
-    value=revenue_usd 
+    data={wf} 
+    x=category
+    y=revenue_usd 
     total=total 
+    yMin=80000
+/>
+
+<WaterfallChart
+    data={bal}
+    x=category
+    y=amount_usd
+    total=total
+/>
+
+<WaterfallChart
+    data={diff}
+    x=category
+    y=value
+    total=total
 />
 
 <WaterfallChart 
@@ -33,3 +73,10 @@ select 'CY Revenue' as category, 764115 as revenue_usd, true as total
     swapXY=true
 />
 
+<WaterfallChart
+    data={diff}
+    x=category
+    y=value
+    total=total
+    swapXY=true
+/>

--- a/sites/example-project/src/pages/charts/waterfall-chart/+page.md
+++ b/sites/example-project/src/pages/charts/waterfall-chart/+page.md
@@ -1,0 +1,35 @@
+<script>
+import WaterfallChart from '$lib/viz/WaterfallChart.svelte'
+</script>
+
+# Waterfall Chart
+
+```waterfall
+select 'PY Revenue' as category, 1200000 as revenue_usd, true as total
+union all 
+select 'New Customers' as category, 135423 as revenue_usd, false as total
+union all 
+select 'Upsell' as category, 25310 as revenue_usd, false as total
+union all 
+select 'Churn' as category, -45368 as revenue_usd, false as total
+union all 
+select 'Price Changes' as category, -551250 as revenue_usd, false as total
+union all 
+select 'CY Revenue' as category, 764115 as revenue_usd, true as total
+```
+
+<WaterfallChart 
+    data={waterfall} 
+    category=category 
+    value=revenue_usd 
+    total=total 
+/>
+
+<WaterfallChart 
+    data={waterfall} 
+    category=category 
+    value=revenue_usd 
+    total=total 
+    swapXY=true
+/>
+


### PR DESCRIPTION
### Description
Draft of waterfall chart approach. Feel free to play around with this and discuss here or in the issue #815 
<img width="699" alt="CleanShot 2023-04-26 at 10 42 45@2x" src="https://user-images.githubusercontent.com/12602440/234639909-4c9ca10e-0001-40de-b919-f48b628a3aeb.png">

<img width="597" alt="CleanShot 2023-04-26 at 10 57 15@2x" src="https://user-images.githubusercontent.com/12602440/234639923-3a33d8cb-ac3e-421f-92a4-41fa9443d790.png">

### To Do
- Axis label overflow behaviour + behaviour on mobile
- Ensure chart area is right size when multi-line axis labels are included
- Consider alternative data structures that the component can accept
- Data labels with reasonable positioning and overflow behaviour
- Tooltip support
- ~~Subtotals - the logic for generating the chart series will need to be updated to accomodate subtotals - currently, having a total in the middle of the data throws off the cumulative sum~~
- Sort feature, by magnitude of delta?
- In a lot of cases, people need to start the y-axis at a higher number than 0 to make the changes visible enough on a waterfall chart
   - We could offer a `yMin` prop to allow someone to set it manually
   - I could also imagine some dynamic logic to check the change range (max of cumulative sum - min of cumulative sum) as a % of axis range and adjust the `yMin` so that the change range takes up something like 50% of the vertical chart area

### Checklist
- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
