### PR TITLE
Make download buttons non-copyable

### DIFF
--- a/.changeset/mean-baboons-punch.md
+++ b/.changeset/mean-baboons-punch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Make download buttons non-copyable

--- a/sites/example-project/src/components/ui/DownloadData.svelte
+++ b/sites/example-project/src/components/ui/DownloadData.svelte
@@ -68,6 +68,11 @@
 		margin: 0 5px;
 		gap: 3px;
 		transition: color 200ms;
+		-moz-user-select: none;
+		-webkit-user-select: none;
+		-ms-user-select: none;
+		-o-user-select: none;
+		user-select: none;
 	}
 
 	button:hover {


### PR DESCRIPTION
### Description
Fixes #819 

### Before
![CleanShot 2023-04-27 at 13 41 43](https://user-images.githubusercontent.com/12602440/234949576-5993b255-fa27-4c05-ae78-209201438bed.gif)

### After
![CleanShot 2023-04-27 at 13 42 48](https://user-images.githubusercontent.com/12602440/234949561-40c9e6f6-aef1-4e37-9a4a-a56d5e025d81.gif)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
