### PR TITLE
Expose format function

### DIFF
--- a/.changeset/fresh-coats-lick.md
+++ b/.changeset/fresh-coats-lick.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/preprocess': minor
+'@evidence-dev/components': minor
+---
+
+Expose format function to end users

--- a/packages/preprocess/src/process-queries.cjs
+++ b/packages/preprocess/src/process-queries.cjs
@@ -24,6 +24,8 @@ const createDefaultProps = function (filename, componentDevelopmentMode, fileQue
         import { page } from '$app/stores';
         import { pageHasQueries, routeHash } from '$lib/ui/stores';
         import { setContext, getContext, beforeUpdate } from 'svelte';
+        
+        // Components
         import BigLink from '$lib/ui/BigLink.svelte';
         import VennDiagram from '$lib/diagrams/VennDiagram.svelte';
         import SankeyDiagram from "$lib/diagrams/SankeyDiagram.svelte";
@@ -50,11 +52,12 @@ const createDefaultProps = function (filename, componentDevelopmentMode, fileQue
         import USMap from '$lib/viz/USMap.svelte';
         import QueryViewer from '$lib/ui/QueryViewer.svelte';
         import CodeBlock from '$lib/ui/CodeBlock.svelte';
-
         import Alert from '$lib/ui/Alert.svelte';
-
         import Tabs from '$lib/ui/Tabs/Tabs.svelte';
         import Tab from '$lib/ui/Tabs/Tab.svelte';
+
+        // Functions
+        import { formatValue as fmt } from '$lib/modules/formatting';
 
         import { CUSTOM_FORMATTING_SETTINGS_CONTEXT_KEY } from '$lib/modules/globalContexts';
         

--- a/sites/docs/docs/core-concepts/formatting/index.md
+++ b/sites/docs/docs/core-concepts/formatting/index.md
@@ -5,6 +5,12 @@ title: 'Number Formatting'
 description: 'Formats are defined using the column names in your SQL query'
 ---
 
+[Format tags](#format-tags) are the primary way to format numbers and dates in Evidence. Format tags are appended to column names in your SQL query to format how they are displayed in components.
+
+[The format function](#format-function) can be used directly, when using numbers outside components. For example, when using [expressions](../syntax/#expressions) it is not possible to use format tags.
+
+## Format Tags
+
 Formats for numbers and dates are defined using the column names in your SQL query.
 
 A **format tag** can be appended to your column name to ensure the right format (see table below for accepted tags).
@@ -15,15 +21,15 @@ Formatting can be configured in the Value Formatting Section of the Evidence Set
 
 Format tags are case-insensitive, so `growth_pct` and `GROWTH_PCT` are equivalent.
 
-## Built-in Value Format Tags
+### Built-in Value Format Tags
 
 Evidence supports a variety of date/time, number, percentage, and currency formats. You can find the full list of format tags [below](#format-reference)
 
-## Custom Value Format Tags
+### Custom Value Format Tags
 
 Custom formats can be added in the Value Formatting Section of the Evidence Settings. Formats can be coded using [Excel style custom format codes](https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68).
 
-## Title Formatting
+### Title Formatting
 
 When creating a table, Evidence formats column titles based on the name of the column and its format tag. Format tags that do not add to the meaning of the column name are not printed as part of the title.
 
@@ -52,17 +58,17 @@ When creating a table, Evidence formats column titles based on the name of the c
 </tr>
 </table>
 
-## Large Numbers
+### Large Numbers
 
 Evidence automatically formats large numbers into shortened versions based on the size of the median number in a column (e.g., 4,000,000 &rarr; 4M).
 
 You can choose to handle these numbers differently by choosing a specific format code. For example, if Evidence is formatting a column as millions, but you want to see all numbers in thousands, you could use the `num0k` format tag, which will show all numbers in the column in thousands with 0 decimal places.
 
-## Format Reference
+### Format Reference
 
 <!-- These are pasted in from the settings menu HTML, with edits -->
 
-### Dates
+#### Dates
 
 <table class="wide">
 <thead >
@@ -140,7 +146,7 @@ You can choose to handle these numbers differently by choosing a specific format
 </tr>
 </table >
 
-### Currencies
+#### Currencies
 
 Supported currencies:
 
@@ -257,7 +263,7 @@ For example, the available tags for USD are:
 
 </table>
 
-### Numbers
+#### Numbers
 
 <table>
 <thead>
@@ -396,7 +402,7 @@ For example, the available tags for USD are:
 
 </table>
 
-### Percentages
+#### Percentages
 
 <table>
 <thead>
@@ -438,3 +444,38 @@ For example, the available tags for USD are:
 </tr>
 
 </table>
+
+
+## Format Function
+
+The format function is used to format expressions which return _numbers_. The format function _cannot_ be used to format dates or times. The syntax is:
+
+```javascript
+fmt(expression, formatCode)
+```
+
+This is useful when you cannot use a component.
+
+
+
+:::info Format Codes
+The format function, `fmt()` accepts Excel style format codes, not format tags
+:::
+
+### Example
+
+In the below example, we return a value from a calculation. In this situtation we cannot use the `Value` component, which only accepts a single row. Instead we use the `Format` function to format the result.
+
+
+````markdown
+```sql sales_per_year
+select
+    date_part('year', order_datetime) AS year,
+    sum(sales) AS total_sales
+from orders
+group by year
+order by year desc
+```
+
+Sales are {fmt(sales_per_year[0].total_sales - sales_per_year[1].total_sales, '+#,##0;-#,##0')} vs last year.
+````

--- a/sites/example-project/src/components/modules/formatting.js
+++ b/sites/example-project/src/components/modules/formatting.js
@@ -175,10 +175,8 @@ function applyFormatting(
 }
 function getEffectiveFormattingCode(columnFormat, formattingContext = VALUE_FORMATTING_CONTEXT) {
 	if (typeof columnFormat === 'string') {
-		console.warn(
-			`The first arg to getEffectiveFormattingCode(${columnFormat}, ${formattingContext}) should be an object, not a string`
-		);
-		return columnFormat; //TODO issue-333 consolidate legacy support
+		// This should only be used by end users, not by components.
+		return columnFormat;
 	} else {
 		if (formattingContext === AXIS_FORMATTING_CONTEXT && columnFormat?.axisFormatCode) {
 			return columnFormat.axisFormatCode;

--- a/sites/example-project/src/pages/expressions/+page.md
+++ b/sites/example-project/src/pages/expressions/+page.md
@@ -3,13 +3,31 @@ title: Expressions
 ---
 
 ```sql orders
-SELECT
-    date_trunc('month', order_datetime) AS month,
-    count(*) AS num_orders,
-    sum(sales) as total_sales
-FROM orders
-GROUP BY 1
-order by 1 desc
+SELECT '2022-12-01' AS month, 645 AS num_orders, 987 AS sales
+UNION ALL 
+SELECT '2022-11-01' AS month, 752 AS num_orders, 960 AS sales
+UNION ALL
+SELECT '2022-10-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-09-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-08-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-07-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-06-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-05-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-04-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-03-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-02-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2022-01-01' AS month, 1000 AS num_orders, 1000 AS sales
+UNION ALL
+SELECT '2021-12-01' AS month, 600 AS num_orders, 600 AS sales
 ```
 
 ## Number formatting

--- a/sites/example-project/src/pages/expressions/+page.md
+++ b/sites/example-project/src/pages/expressions/+page.md
@@ -2,10 +2,6 @@
 title: Expressions
 ---
 
-<script>
-    import {format as ssfFmt} from 'ssf'
-</script>
-
 ```sql orders
 SELECT
     date_trunc('month', order_datetime) AS month,

--- a/sites/example-project/src/pages/expressions/+page.md
+++ b/sites/example-project/src/pages/expressions/+page.md
@@ -1,0 +1,38 @@
+---
+title: Expressions
+---
+
+<script>
+    import {format as ssfFmt} from 'ssf'
+</script>
+
+```sql orders
+SELECT
+    date_trunc('month', order_datetime) AS month,
+    count(*) AS num_orders,
+    sum(sales) as total_sales
+FROM orders
+GROUP BY 1
+order by 1 desc
+```
+
+## Number formatting
+
+You can use the `fmt()` function to format expressions using Excel-style format strings.
+
+```javascript
+fmt(number, excelFormatString);
+```
+
+Last month, there were {fmt(orders[0].num_orders,'#,##0')} orders, a change of:
+
+- **{fmt(orders[0].num_orders-orders[1].num_orders,'+#,##0;-#,##0;0')}** ({fmt(orders[0].num_orders/orders[1].num_orders-1,'+0.0%;-0.0%')}) vs the previous month.
+- **{fmt(orders[0].num_orders-orders[12].num_orders,'+#,##0;-#,##0;0')}** ({fmt(orders[0].num_orders/orders[12].num_orders-1,'+0.0%;-0.0%')}) vs last year.
+
+## Date formatting does not work reliably
+
+This is because dates are stored as strings.
+
+Last month was {fmt(orders[0].month, 'MMMM')}.
+
+Last month was {fmt(new Date(orders[0].month), 'MMMM')}. (wrong)

--- a/sites/example-project/src/pages/expressions/+page.md
+++ b/sites/example-project/src/pages/expressions/+page.md
@@ -4,7 +4,7 @@ title: Expressions
 
 ```sql orders
 SELECT '2022-12-01' AS month, 645 AS num_orders, 987 AS sales
-UNION ALL 
+UNION ALL
 SELECT '2022-11-01' AS month, 752 AS num_orders, 960 AS sales
 UNION ALL
 SELECT '2022-10-01' AS month, 1000 AS num_orders, 1000 AS sales


### PR DESCRIPTION
# Why?
- Sometimes it’s not possible to use our components
   - For example, if you want to do a subtraction in js, it will display raw js floating point
   - `Sales are up {orders[0].sales_usd - orders[1].sales_usd} from last month.`
 - It stops you doing difficult stuff in SQL just to get the format right
   - Common occurrence is lag functions and annoying division

    ```orders_by_month
    select
      date,
      count(*) as num_orders,
      lag(count(*),1) as num_orders_last_month,
      count(*) / lag(count(*),1) -1 as num_orders_change_pct
    from orders
    ```
- It means making a custom component is much easier
  - You call the format function

## Implementation
- Allows users to call the function like this`{fmt(value, excelFormatCode)}`, eg `{fmt(orders[0].sales, '$##0')}`
- It works for numbers, percentages, currencies
- It _does not_ work for dates
   - Suspect because dates are converted to strings

## Questions 
- What should we call the function? `fmt()`, `fmtVal()`,`format()` all seem quite good options
- Does it matter that it doesn't work for dates?

### Checklist

- [ ] ~~For UI or styling changes, I have added a screenshot or gif showing before & after~~
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
