### PR TITLE
Revert "tests: only run on code changes"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@
 ### Checklist
 
 - [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
-- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset) (not required for docs changes)
+- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,7 @@
 name: Tests
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'sites/docs/**'
-      - 'readme/**'
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
-      - 'sites/example-project/src/pages/**'
+  pull_request_target:
 
 jobs:
   Tests-sources:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,14 +2,6 @@ name: UI-Tests
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'sites/docs/**'
-      - 'readme/**'
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
 
 jobs:
   wait_for_preview:


### PR DESCRIPTION
This reverts commit facd101a919317daf88792ac83a7b9f97fd21253.

This doesn't work: branch protection rules prevent the ignore syntax working

See #860 for detail.

Additionally, pull_request_target is needed for access to secrets