### PR TITLE
Value component error icon

### DIFF
--- a/.changeset/afraid-planets-sip.md
+++ b/.changeset/afraid-planets-sip.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+Error icon in value component is now vertically centered and color is white

--- a/sites/example-project/src/components/icons/HelpCircleIcon.svelte
+++ b/sites/example-project/src/components/icons/HelpCircleIcon.svelte
@@ -20,12 +20,12 @@
 
 <style>
 	.icon {
+		display: flex;
 		align-items: center;
 		vertical-align: middle;
 	}
 
 	.icon-container {
-		display: inline-flex;
 		align-items: center;
 		vertical-align: middle;
 	}

--- a/sites/example-project/src/components/icons/HelpCircleIcon.svelte
+++ b/sites/example-project/src/components/icons/HelpCircleIcon.svelte
@@ -20,12 +20,12 @@
 
 <style>
 	.icon {
-		display: flex;
 		align-items: center;
 		vertical-align: middle;
 	}
 
 	.icon-container {
+		display: inline-flex;
 		align-items: center;
 		vertical-align: middle;
 	}
@@ -33,5 +33,6 @@
 	svg {
 		margin: auto;
 		display: block;
+		height: 100%;
 	}
 </style>

--- a/sites/example-project/src/components/viz/Value.svelte
+++ b/sites/example-project/src/components/viz/Value.svelte
@@ -85,7 +85,7 @@
 	<span class="error">
 		<span class="error-label">Error</span>
 		<span class="additional-info-icon">
-			<HelpCircleIcon height="18" width="18" verticalOffset="2" color="--grey-000" />
+			<HelpCircleIcon height="18" width="18" verticalOffset="2" color="--grey-100" />
 		</span>
 		<span class="error-msg">{error}</span>
 	</span>

--- a/sites/example-project/src/components/viz/Value.svelte
+++ b/sites/example-project/src/components/viz/Value.svelte
@@ -85,7 +85,7 @@
 	<span class="error">
 		<span class="error-label">Error</span>
 		<span class="additional-info-icon">
-			<HelpCircleIcon height="18" width="18" verticalOffset="2" color="--grey-100" />
+			<HelpCircleIcon height="18" width="18" verticalOffset="1" color="--grey-100" />
 		</span>
 		<span class="error-msg">{error}</span>
 	</span>
@@ -117,7 +117,10 @@
 	}
 
 	.additional-info-icon {
-		display: inline;
+		display: flex;
+		align-items: center;
+		height: 100%;
+		width: 100%;
 		vertical-align: middle;
 		width: 14px;
 		color: white;


### PR DESCRIPTION
### Description

Addressing #788
Value component error icon is white and positioned in the center.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)


Before: 
![image](https://github.com/evidence-dev/evidence/assets/63001560/6daab5fe-6a71-4b36-be25-bbfe86fcf60b)


After:
<img width="495" alt="Screenshot 2023-05-14 at 20 59 59" src="https://github.com/evidence-dev/evidence/assets/63001560/f95bffdc-532a-4f4b-b314-4e366d23f6c4">
