### PR TITLE
Add secondary axis

### DIFF
--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -4,6 +4,7 @@ export default function getSeriesConfig(
 	data,
 	x,
 	y,
+	y2,
 	series,
 	swapXY,
 	baseConfig,
@@ -13,10 +14,11 @@ export default function getSeriesConfig(
 	size = null,
 	tooltipTitle = null
 ) {
-	function generateTempConfig(seriesData, seriesName, baseConfig) {
+	function generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig) {
 		let tempConfig = {
 			name: seriesName,
-			data: seriesData
+			data: seriesData,
+			yAxisIndex: yAxisIndex
 		};
 		tempConfig = { ...baseConfig, ...tempConfig };
 		return tempConfig;
@@ -30,9 +32,51 @@ export default function getSeriesConfig(
 	let filteredData;
 	let seriesName;
 	let seriesDistinct;
+	let yAxisIndex;
+
+	// y = single, y2 = empty
+	// y = single, y2 = single
+	// y = single, y2 = array
+
+	// y = array, y2 = empty
+	// y = array, y2 = single
+	// y = array, y2 = array
+
+	// y = empty, y2 = empty
+	// y = empty, y2 = single
+	// y = empty, y2 = array
+
+	// colname, yAxisIndex
+
+	function combineVariables(variable1, variable2) {
+		const array = [];
+	  
+		// Helper function to check if a value is undefined
+		function isUndefined(value) {
+		  return typeof value === 'undefined';
+		}
+	  
+		// Helper function to add non-undefined values to the array with source indicator
+		function addValuesToArray(value, source) {
+		  if (!isUndefined(value)) {
+			if (Array.isArray(value)) {
+			  value.forEach((item) => array.push([item, source]));
+			} else {
+			  array.push([value, source]);
+			}
+		  }
+		}
+	  
+		addValuesToArray(variable1, 0);
+		addValuesToArray(variable2, 1);
+	  
+		return array;
+	  }
+
+	  let yList = combineVariables(y, y2)
 
 	// 1) Series column with single y column
-	if (series != null && typeof y !== 'object') {
+	if (series != null && yList.length === 1) {
 		seriesDistinct = getDistinctValues(data, series);
 
 		for (i = 0; i < seriesDistinct.length; i++) {
@@ -40,9 +84,9 @@ export default function getSeriesConfig(
 			filteredData = data.filter((d) => d[series] === seriesDistinct[i]);
 
 			if (swapXY) {
-				seriesData = filteredData.map((d) => [d[y], xMismatch ? d[x].toString() : d[x]]);
+				seriesData = filteredData.map((d) => [d[yList[0][0]], xMismatch ? d[x].toString() : d[x]]);
 			} else {
-				seriesData = filteredData.map((d) => [xMismatch ? d[x].toString() : d[x], d[y]]);
+				seriesData = filteredData.map((d) => [xMismatch ? d[x].toString() : d[x], d[yList[0][0]]]);
 			}
 
 			// Append size column if supplied (for bubble chart):
@@ -60,23 +104,27 @@ export default function getSeriesConfig(
 			// Set series name:
 			seriesName = seriesDistinct[i] ?? 'null';
 
-			tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
+			// Set y-axis index (used for multi-y axis charts):
+			yAxisIndex = yList[0][1];
+
+			tempConfig = generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig);
 			seriesConfig.push(tempConfig);
 		}
 	}
 
 	// 2) Series column with multiple y columns
-	if (series != null && typeof y === 'object' && y.length > 1) {
+	if (series != null && yList.length > 1) {
+
 		seriesDistinct = getDistinctValues(data, series);
 		for (i = 0; i < seriesDistinct.length; i++) {
 			// Filter for specific series:
 			filteredData = data.filter((d) => d[series] === seriesDistinct[i]);
 
-			for (j = 0; j < y.length; j++) {
+			for (j = 0; j < yList.length; j++) {
 				if (swapXY) {
-					seriesData = filteredData.map((d) => [d[y[j]], xMismatch ? d[x].toString() : d[x]]);
+					seriesData = filteredData.map((d) => [d[yList[j][0]], xMismatch ? d[x].toString() : d[x]]);
 				} else {
-					seriesData = filteredData.map((d) => [xMismatch ? d[x].toString() : d[x], d[y[j]]]);
+					seriesData = filteredData.map((d) => [xMismatch ? d[x].toString() : d[x], d[yList[j][0]]]);
 				}
 
 				// Append size column if supplied (for bubble chart):
@@ -92,20 +140,27 @@ export default function getSeriesConfig(
 				}
 
 				// Set series name:
-				seriesName = (seriesDistinct[i] ?? 'null') + ' - ' + columnSummary[y[j]].title;
-				tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
+				seriesName = (seriesDistinct[i] ?? 'null') + ' - ' + columnSummary[yList[j][0]].title;
+
+				// Set y-axis index (used for multi-y axis charts):
+				yAxisIndex = yList[j][1];
+
+				tempConfig = generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig);
 				seriesConfig.push(tempConfig);
+
+				
 			}
 		}
 	}
 
 	// 3) Multiple y columns without series column
-	if (series == null && typeof y === 'object' && y.length > 1) {
-		for (i = 0; i < y.length; i++) {
+	if (series == null && yList.length > 1) {
+
+		for (i = 0; i < yList.length; i++) {
 			if (swapXY) {
-				seriesData = data.map((d) => [d[y[i]], xMismatch ? d[x].toString() : d[x]]);
+				seriesData = data.map((d) => [d[yList[i][0]], xMismatch ? d[x].toString() : d[x]]);
 			} else {
-				seriesData = data.map((d) => [xMismatch ? d[x].toString() : d[x], d[y[i]]]);
+				seriesData = data.map((d) => [xMismatch ? d[x].toString() : d[x], d[yList[i][0]]]);
 			}
 
 			// Append size column if supplied (for bubble chart):
@@ -120,18 +175,23 @@ export default function getSeriesConfig(
 				seriesData.forEach((item, index) => item.push(tooltipData[index]));
 			}
 
-			seriesName = columnSummary[y[i]].title;
-			tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
+			seriesName = columnSummary[yList[i][0]].title;
+
+			// Set y-axis index (used for multi-y axis charts):
+			yAxisIndex = yList[i][1];
+
+			tempConfig = generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig);
 			seriesConfig.push(tempConfig);
 		}
 	}
 
 	// 4) Single y column without series column
-	if (series == null && typeof y !== 'object') {
+	if (series == null && yList.length === 1) {
+
 		if (swapXY) {
-			seriesData = data.map((d) => [d[y], xMismatch ? d[x].toString() : d[x]]);
+			seriesData = data.map((d) => [d[yList[0][0]], xMismatch ? d[x].toString() : d[x]]);
 		} else {
-			seriesData = data.map((d) => [xMismatch ? d[x].toString() : d[x], d[y]]);
+			seriesData = data.map((d) => [xMismatch ? d[x].toString() : d[x], d[yList[0][0]]]);
 		}
 
 		// Append size column if supplied (for bubble chart):
@@ -146,9 +206,12 @@ export default function getSeriesConfig(
 			seriesData.forEach((item, index) => item.push(tooltipData[index]));
 		}
 
-		seriesName = columnSummary[y].title;
+		seriesName = columnSummary[yList[0][0]].title;
 
-		tempConfig = generateTempConfig(seriesData, seriesName, baseConfig);
+		// Set y-axis index (used for multi-y axis charts):
+		yAxisIndex = yList[0][1];
+
+		tempConfig = generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig);
 		seriesConfig.push(tempConfig);
 	}
 

--- a/sites/example-project/src/components/modules/getSeriesConfig.js
+++ b/sites/example-project/src/components/modules/getSeriesConfig.js
@@ -49,6 +49,8 @@ export default function getSeriesConfig(
 	// colname, yAxisIndex
 
 	function combineVariables(variable1, variable2) {
+		// Returns an array of arrays, where each individual array is [column_name, yAxisIndex], where yAxisIndex is 0 for y and 1 for y2.
+		// E.g., [ ['sales', 0 ], ['gross_profit', 1]] - sales on primary axis, gross profit on secondary
 		const array = [];
 	  
 		// Helper function to check if a value is undefined
@@ -74,6 +76,8 @@ export default function getSeriesConfig(
 	  }
 
 	  let yList = combineVariables(y, y2)
+
+	//   console.log(yList)
 
 	// 1) Series column with single y column
 	if (series != null && yList.length === 1) {
@@ -174,7 +178,7 @@ export default function getSeriesConfig(
 				let tooltipData = data.map((d) => d[tooltipTitle]);
 				seriesData.forEach((item, index) => item.push(tooltipData[index]));
 			}
-
+// console.log(yList[i][0])
 			seriesName = columnSummary[yList[i][0]].title;
 
 			// Set y-axis index (used for multi-y axis charts):
@@ -187,7 +191,6 @@ export default function getSeriesConfig(
 
 	// 4) Single y column without series column
 	if (series == null && yList.length === 1) {
-
 		if (swapXY) {
 			seriesData = data.map((d) => [d[yList[0][0]], xMismatch ? d[x].toString() : d[x]]);
 		} else {
@@ -210,10 +213,9 @@ export default function getSeriesConfig(
 
 		// Set y-axis index (used for multi-y axis charts):
 		yAxisIndex = yList[0][1];
-
 		tempConfig = generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig);
 		seriesConfig.push(tempConfig);
 	}
-
+// console.log(seriesConfig)
 	return seriesConfig;
 }

--- a/sites/example-project/src/components/viz/Area.svelte
+++ b/sites/example-project/src/components/viz/Area.svelte
@@ -11,6 +11,8 @@
 
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
+	export let y2 = undefined;
+	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
 	export let options = undefined;
@@ -29,6 +31,7 @@
 	$: data = $props.data;
 	$: x = $props.x;
 	$: y = ySet ? y : $props.y;
+	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
 	$: xMismatch = $props.xMismatch;
@@ -75,6 +78,7 @@
 		data,
 		x,
 		y,
+		y2,
 		series,
 		swapXY,
 		baseConfig,

--- a/sites/example-project/src/components/viz/Area.svelte
+++ b/sites/example-project/src/components/viz/Area.svelte
@@ -30,7 +30,7 @@
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
 	$: x = $props.x;
-	$: y = ySet ? y : $props.y;
+	$: y = ySet ? y : (y2Set ? undefined : $props.y);
 	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
@@ -41,7 +41,7 @@
 	let stackName;
 	$: if (!series && typeof y !== 'object') {
 		// Single Series
-		name = name ?? formatTitle(y, columnSummary[y].title);
+		// name = name ?? formatTitle(y, columnSummary[y].title);
 	} else {
 		// Multi Series
 		stackName = 'area'; // area must be stacked for multi-series chart
@@ -112,20 +112,24 @@
 		config.update((d) => {
 			d.tooltip = { ...d.tooltip, order: 'seriesDesc' }; // Areas always stacked
 			if (swapXY) {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				if(y2){
+					d.yAxis[1] = {...d.yAxis[1], show: true};
+				}
 			}
 			if (type === 'stacked100') {
 				if (swapXY) {
 					d.xAxis = { ...d.xAxis, max: 1 };
 				} else {
-					d.yAxis = { ...d.yAxis, max: 1 };
+					d.yAxis[0] = { ...d.yAxis[0], max: 1 };
 				}
 			}
 			return d;
 		});
 	});
+
 </script>

--- a/sites/example-project/src/components/viz/AreaChart.svelte
+++ b/sites/example-project/src/components/viz/AreaChart.svelte
@@ -47,6 +47,9 @@
 	export let y2Min = undefined;
 	export let y2Max = undefined;
 
+	export let yAxisColor = undefined;
+	export let y2AxisColor = undefined;
+
 </script>
 
 <Chart
@@ -82,6 +85,9 @@
 	{sort}
 	{stacked100}
 	{chartAreaHeight}
+	{yAxisColor}
+	{y2AxisColor}
+
 >
 	<Area {line} {fillColor} {fillOpacity} {handleMissing} {type} />
 </Chart>

--- a/sites/example-project/src/components/viz/AreaChart.svelte
+++ b/sites/example-project/src/components/viz/AreaChart.svelte
@@ -37,12 +37,30 @@
 	let stacked100 = type === 'stacked100';
 
 	let chartType = 'Area Chart';
+
+	export let y2 = undefined;
+	export let y2AxisTitle = undefined;
+	export let y2Gridlines = undefined;
+	export let y2AxisLabels = undefined;
+	export let y2Baseline = undefined;
+	export let y2TickMarks = undefined;
+	export let y2Min = undefined;
+	export let y2Max = undefined;
+
 </script>
 
 <Chart
 	{data}
 	{x}
 	{y}
+	{y2}
+	{y2AxisTitle}
+	{y2Gridlines}
+	{y2AxisLabels}
+	{y2Baseline}
+	{y2TickMarks}
+	{y2Min}	
+	{y2Max}
 	{series}
 	{xType}
 	{legend}

--- a/sites/example-project/src/components/viz/Bar.svelte
+++ b/sites/example-project/src/components/viz/Bar.svelte
@@ -31,7 +31,7 @@
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
 	$: x = $props.x;
-	$: y = ySet ? y : $props.y;
+	$: y = ySet ? y : (y2Set ? undefined : $props.y);
 	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
@@ -152,14 +152,14 @@
 					if (swapXY) {
 						d.xAxis = { ...d.xAxis, max: 1 };
 					} else {
-						d.yAxis = { ...d.yAxis, max: 1 };
+						d.yAxis[0] = { ...d.yAxis[0], max: 1 };
 					}
 				}
 				if (swapXY) {
-					// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 				} else {
-					// d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
 					if(y2){
 						d.yAxis[1] = {...d.yAxis[1], show: true};

--- a/sites/example-project/src/components/viz/Bar.svelte
+++ b/sites/example-project/src/components/viz/Bar.svelte
@@ -12,6 +12,8 @@
 
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
+	export let y2 = undefined;
+	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
 	export let options = undefined;
@@ -30,6 +32,7 @@
 	$: data = $props.data;
 	$: x = $props.x;
 	$: y = ySet ? y : $props.y;
+	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
 	$: xMismatch = $props.xMismatch;
@@ -105,6 +108,7 @@
 		data,
 		x,
 		y,
+		y2,
 		series,
 		swapXY,
 		baseConfig,
@@ -152,11 +156,14 @@
 					}
 				}
 				if (swapXY) {
-					d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+					// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 				} else {
-					d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+					// d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+					if(y2){
+						d.yAxis[1] = {...d.yAxis[1], show: true};
+					}
 				}
 				return d;
 			});

--- a/sites/example-project/src/components/viz/BarChart.svelte
+++ b/sites/example-project/src/components/viz/BarChart.svelte
@@ -42,12 +42,30 @@
 	export let chartAreaHeight = undefined;
 
 	export let sort = undefined;
+
+	export let y2 = undefined;
+	export let y2AxisTitle = undefined;
+	export let y2Gridlines = undefined;
+	export let y2AxisLabels = undefined;
+	export let y2Baseline = undefined;
+	export let y2TickMarks = undefined;
+	export let y2Min = undefined;
+	export let y2Max = undefined;
+
 </script>
 
 <Chart
 	{data}
 	{x}
 	{y}
+	{y2}
+	{y2AxisTitle}
+	{y2Gridlines}
+	{y2AxisLabels}
+	{y2Baseline}
+	{y2TickMarks}
+	{y2Min}	
+	{y2Max}
 	{series}
 	{xType}
 	{legend}

--- a/sites/example-project/src/components/viz/BarChart.svelte
+++ b/sites/example-project/src/components/viz/BarChart.svelte
@@ -52,6 +52,9 @@
 	export let y2Min = undefined;
 	export let y2Max = undefined;
 
+	export let yAxisColor = undefined;
+	export let y2AxisColor = undefined;
+
 </script>
 
 <Chart
@@ -88,6 +91,8 @@
 	{sort}
 	{stacked100}
 	{chartAreaHeight}
+	{yAxisColor}
+	{y2AxisColor}
 >
 	<Bar {type} {fillColor} {fillOpacity} {outlineColor} {outlineWidth} />
 </Chart>

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -47,7 +47,7 @@
 	$: sizeFormat = $props.sizeFormat;
 	$: xMismatch = $props.xMismatch;
 	$: columnSummary = $props.columnSummary;
-	$: y = ySet ? y : $props.y;
+	$: y = ySet ? y : (y2Set ? undefined : $props.y);
 	$: y2 = y2Set ? y2 : $props.y2;
 	$: series = seriesSet ? series : $props.series;
 	$: size = size ?? $props.size;
@@ -271,11 +271,14 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				if(y2){
+					d.yAxis[1] = {...d.yAxis[1], show: true};
+				}
 			}
 			if (useTooltip) {
 				d.tooltip = { ...d.tooltip, ...tooltipOverride.tooltip };

--- a/sites/example-project/src/components/viz/Bubble.svelte
+++ b/sites/example-project/src/components/viz/Bubble.svelte
@@ -12,6 +12,8 @@
 
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
+	export let y2 = undefined;
+	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
 	export let options = undefined;
@@ -41,13 +43,16 @@
 	$: xType = $props.xType;
 	$: xFormat = $props.xFormat;
 	$: yFormat = $props.yFormat;
+	$: y2Format = $props.y2Format;
 	$: sizeFormat = $props.sizeFormat;
 	$: xMismatch = $props.xMismatch;
 	$: columnSummary = $props.columnSummary;
 	$: y = ySet ? y : $props.y;
+	$: y2 = y2Set ? y2 : $props.y2;
 	$: series = seriesSet ? series : $props.series;
 	$: size = size ?? $props.size;
 	$: yMin = $props.yMin;
+	$: y2Min = $props.y2Min;
 	$: tooltipTitle = tooltipTitle ?? $props.tooltipTitle;
 
 	$: if (!series && typeof y !== 'object') {
@@ -237,6 +242,7 @@
 		data,
 		x,
 		y,
+		y2,
 		series,
 		swapXY,
 		baseConfig,

--- a/sites/example-project/src/components/viz/BubbleChart.svelte
+++ b/sites/example-project/src/components/viz/BubbleChart.svelte
@@ -41,12 +41,33 @@
 	let bubble = true;
 
 	let useTooltip = true;
+
+	export let y2 = undefined;
+	export let y2AxisTitle = undefined;
+	export let y2Gridlines = undefined;
+	export let y2AxisLabels = undefined;
+	export let y2Baseline = undefined;
+	export let y2TickMarks = undefined;
+	export let y2Min = undefined;
+	export let y2Max = undefined;
+
+	export let yAxisColor = undefined;
+	export let y2AxisColor = undefined;
+
 </script>
 
 <Chart
 	{data}
 	{x}
 	{y}
+	{y2}
+	{y2AxisTitle}
+	{y2Gridlines}
+	{y2AxisLabels}
+	{y2Baseline}
+	{y2TickMarks}
+	{y2Min}	
+	{y2Max}
 	{size}
 	{tooltipTitle}
 	{series}
@@ -70,6 +91,8 @@
 	{bubble}
 	{sort}
 	{chartAreaHeight}
+	{yAxisColor}
+	{y2AxisColor}
 >
 	<Bubble {shape} {fillColor} {opacity} {outlineColor} {outlineWidth} {scaleTo} {useTooltip} />
 </Chart>

--- a/sites/example-project/src/components/viz/Chart.svelte
+++ b/sites/example-project/src/components/viz/Chart.svelte
@@ -692,7 +692,7 @@
 						verticalAlign: 'top',
 						backgroundColor: 'white',
 						padding: [0, 0, 0, 5],
-						color: colour[1]
+						color:  y2AxisColor === 'true' ? colour[ySeriesCount] : (y2AxisColor !== 'false' ? y2AxisColor : undefined)
 					},
 					nameGap: 6,
 					min: y2Min,

--- a/sites/example-project/src/components/viz/Line.svelte
+++ b/sites/example-project/src/components/viz/Line.svelte
@@ -11,6 +11,11 @@
 
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
+	export let y2 = undefined;
+	if(y2){
+		$props.y2 = y2;
+	}
+	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
 	export let options = undefined;
@@ -32,6 +37,7 @@
 	$: data = $props.data;
 	$: x = $props.x;
 	$: y = ySet ? y : $props.y;
+	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
 	$: xMismatch = $props.xMismatch;
@@ -84,6 +90,7 @@
 		data,
 		x,
 		y,
+		y2,
 		series,
 		swapXY,
 		baseConfig,
@@ -91,6 +98,7 @@
 		xMismatch,
 		columnSummary
 	);
+	
 	$: config.update((d) => {
 		d.series.push(...seriesConfig);
 		return d;
@@ -114,11 +122,14 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+				// d.yAxis = [ ...d.yAxis, ...chartOverrides.yAxis ];
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				if(y2){
+					d.yAxis[1] = {...d.yAxis[1], show: true};
+				}
 			}
 			return d;
 		});

--- a/sites/example-project/src/components/viz/Line.svelte
+++ b/sites/example-project/src/components/viz/Line.svelte
@@ -12,9 +12,6 @@
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
 	export let y2 = undefined;
-	if(y2){
-		$props.y2 = y2;
-	}
 	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
@@ -36,7 +33,7 @@
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
 	$: x = $props.x;
-	$: y = ySet ? y : $props.y;
+	$: y = ySet ? y : (y2Set ? undefined : $props.y);
 	$: y2 = y2Set ? y2 : $props.y2;
 	$: swapXY = $props.swapXY;
 	$: xType = $props.xType;
@@ -122,10 +119,10 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				// d.yAxis = [ ...d.yAxis, ...chartOverrides.yAxis ];
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
 				if(y2){
 					d.yAxis[1] = {...d.yAxis[1], show: true};

--- a/sites/example-project/src/components/viz/LineChart.svelte
+++ b/sites/example-project/src/components/viz/LineChart.svelte
@@ -5,6 +5,7 @@
 	export let data = undefined;
 	export let x = undefined;
 	export let y = undefined;
+	export let y2 = undefined;
 	export let series = undefined;
 	export let xType = undefined;
 
@@ -13,16 +14,28 @@
 	export let legend = undefined;
 	export let xAxisTitle = undefined;
 	export let yAxisTitle = undefined;
+	export let y2AxisTitle = undefined;
+
 	export let xGridlines = undefined;
 	export let yGridlines = undefined;
+	export let y2Gridlines = undefined;
+
 	export let xAxisLabels = undefined;
 	export let yAxisLabels = undefined;
+	export let y2AxisLabels = undefined;
+
 	export let xBaseline = undefined;
 	export let yBaseline = undefined;
+	export let y2Baseline = undefined;
 	export let xTickMarks = undefined;
 	export let yTickMarks = undefined;
+	export let y2TickMarks = undefined;
+
 	export let yMin = undefined;
 	export let yMax = undefined;
+	export let y2Min = undefined;
+	export let y2Max = undefined;
+
 
 	export let lineColor = undefined;
 	export let lineType = undefined;
@@ -37,27 +50,42 @@
 	export let handleMissing = undefined;
 
 	export let sort = undefined;
+
 </script>
 
 <Chart
 	{data}
 	{x}
 	{y}
+	{y2}
 	{series}
 	{xType}
 	{legend}
 	{xAxisTitle}
 	{yAxisTitle}
+	{y2AxisTitle}
+
 	{xGridlines}
 	{yGridlines}
+	{y2Gridlines}
+
 	{xAxisLabels}
 	{yAxisLabels}
+	{y2AxisLabels}
+
 	{xBaseline}
 	{yBaseline}
+	{y2Baseline}
+
 	{xTickMarks}
 	{yTickMarks}
+	{y2TickMarks}
+
 	{yMin}
 	{yMax}
+	{y2Min}
+	{y2Max}
+
 	{title}
 	{subtitle}
 	chartType="Line Chart"

--- a/sites/example-project/src/components/viz/LineChart.svelte
+++ b/sites/example-project/src/components/viz/LineChart.svelte
@@ -24,6 +24,9 @@
 	export let yAxisLabels = undefined;
 	export let y2AxisLabels = undefined;
 
+	export let yAxisColor = undefined;
+	export let y2AxisColor = undefined;
+
 	export let xBaseline = undefined;
 	export let yBaseline = undefined;
 	export let y2Baseline = undefined;
@@ -58,6 +61,7 @@
 	{x}
 	{y}
 	{y2}
+	
 	{series}
 	{xType}
 	{legend}
@@ -72,6 +76,9 @@
 	{xAxisLabels}
 	{yAxisLabels}
 	{y2AxisLabels}
+
+	{yAxisColor}
+	{y2AxisColor}
 
 	{xBaseline}
 	{yBaseline}

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -40,7 +40,7 @@
 	$: y2Format = $props.y2Format;
 	$: xMismatch = $props.xMismatch;
 	$: columnSummary = $props.columnSummary;
-	$: y = ySet ? y : $props.y;
+	$: y = ySet ? y : (y2Set ? undefined : $props.y);
 	$: y2 = y2Set ? y2 : $props.y2;
 	$: series = seriesSet ? series : $props.series;
 	$: size = size ?? $props.size;
@@ -50,7 +50,7 @@
 
 	$: if (!series && typeof y !== 'object') {
 		// Single Series
-		name = name ?? formatTitle(y, columnSummary[y].title);
+		// name = name ?? formatTitle(y, columnSummary[y].title);
 		multiSeries = false;
 	} else {
 		// Multi Series
@@ -219,10 +219,10 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				// d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
 				if(y2){
 					d.yAxis[1] = {...d.yAxis[1], show: true};

--- a/sites/example-project/src/components/viz/Scatter.svelte
+++ b/sites/example-project/src/components/viz/Scatter.svelte
@@ -11,6 +11,8 @@
 
 	export let y = undefined;
 	const ySet = y ? true : false; // Hack, see chart.svelte
+	export let y2 = undefined;
+	const y2Set = y2 ? true : false; // Hack, see chart.svelte
 	export let series = undefined;
 	const seriesSet = series ? true : false; // Hack, see chart.svelte
 	export let options = undefined;
@@ -35,12 +37,15 @@
 	$: xType = $props.xType;
 	$: xFormat = $props.xFormat;
 	$: yFormat = $props.yFormat;
+	$: y2Format = $props.y2Format;
 	$: xMismatch = $props.xMismatch;
 	$: columnSummary = $props.columnSummary;
 	$: y = ySet ? y : $props.y;
+	$: y2 = y2Set ? y2 : $props.y2;
 	$: series = seriesSet ? series : $props.series;
 	$: size = size ?? $props.size;
 	$: yMin = $props.yMin;
+	$: y2Min = $props.y2Min;
 	$: tooltipTitle = tooltipTitle ?? $props.tooltipTitle;
 
 	$: if (!series && typeof y !== 'object') {
@@ -185,6 +190,7 @@
 		data,
 		x,
 		y,
+		y2,
 		series,
 		swapXY,
 		baseConfig,
@@ -201,10 +207,10 @@
 
 	// Chart-level config settings:
 	$: chartOverrides = {
-		yAxis: {
-			scale: true,
-			boundaryGap: ['1%', '1%']
-		},
+		// yAxis: {
+		// 	scale: true,
+		// 	boundaryGap: ['1%', '1%']
+		// },
 		xAxis: {
 			boundaryGap: [xType === 'time' ? '2%' : '1%', '2%']
 		}
@@ -213,11 +219,14 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+				// d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
-				d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+				// d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				if(y2){
+					d.yAxis[1] = {...d.yAxis[1], show: true};
+				}
 			}
 			if (useTooltip) {
 				d.tooltip = { ...d.tooltip, ...tooltipOverride.tooltip };

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -39,12 +39,29 @@
 	let chartType = 'Scatter Plot';
 
 	let useTooltip = true;
+
+	export let y2 = undefined;
+	export let y2AxisTitle = undefined;
+	export let y2Gridlines = undefined;
+	export let y2AxisLabels = undefined;
+	export let y2Baseline = undefined;
+	export let y2TickMarks = undefined;
+	export let y2Min = undefined;
+	export let y2Max = undefined;
 </script>
 
 <Chart
 	{data}
 	{x}
 	{y}
+	{y2}
+	{y2AxisTitle}
+	{y2Gridlines}
+	{y2AxisLabels}
+	{y2Baseline}
+	{y2TickMarks}
+	{y2Min}	
+	{y2Max}
 	{series}
 	{tooltipTitle}
 	{xType}

--- a/sites/example-project/src/components/viz/ScatterPlot.svelte
+++ b/sites/example-project/src/components/viz/ScatterPlot.svelte
@@ -41,13 +41,17 @@
 	let useTooltip = true;
 
 	export let y2 = undefined;
-	export let y2AxisTitle = undefined;
+	export let y2AxisTitle = 'true';
 	export let y2Gridlines = undefined;
 	export let y2AxisLabels = undefined;
 	export let y2Baseline = undefined;
 	export let y2TickMarks = undefined;
 	export let y2Min = undefined;
 	export let y2Max = undefined;
+
+	export let yAxisColor = undefined;
+	export let y2AxisColor = undefined;
+
 </script>
 
 <Chart
@@ -83,6 +87,8 @@
 	{chartType}
 	{sort}
 	{chartAreaHeight}
+	{yAxisColor}
+	{y2AxisColor}
 >
 	<Scatter {shape} {fillColor} {opacity} {outlineColor} {outlineWidth} {pointSize} {useTooltip} />
 </Chart>

--- a/sites/example-project/src/pages/charts/area-chart/+page.md
+++ b/sites/example-project/src/pages/charts/area-chart/+page.md
@@ -9,6 +9,7 @@ sources:
 <AreaChart
 data={orders_by_category.filter(d => d.category === "Sinister Toys")}
 x=month
+y=sales_usd0k
 />
 
 ## Stacked Area

--- a/sites/example-project/src/pages/charts/bar-chart/+page.md
+++ b/sites/example-project/src/pages/charts/bar-chart/+page.md
@@ -53,6 +53,7 @@ sources:
     data={marketing_spend}
     x=month_begin 
     y=spend
+    y2=spend
     series=marketing_channel
     type=grouped
 />

--- a/sites/example-project/src/pages/charts/line-chart/+page.md
+++ b/sites/example-project/src/pages/charts/line-chart/+page.md
@@ -78,7 +78,7 @@ select 'China' as country, 101 as value, 1996 as year
 
 ## Muliple y Column Line
 
-<LineChart data={orders_by_month} x=month y={["sales_usd0k","num_orders_num0"]}/>
+<LineChart data={orders_by_month} x=month y="sales_usd0k" y2="num_orders_num0" yAxisTitle=true y2AxisTitle=true/>
 
 ## Multiple y Column and Series Line
 

--- a/sites/example-project/src/pages/charts/mixed-charts/+page.md
+++ b/sites/example-project/src/pages/charts/mixed-charts/+page.md
@@ -8,17 +8,19 @@ sources:
 
 <Chart
 data={orders_by_category.filter(d => d.category === "Sinister Toys")}
-x=month>
-<Bar y=sales_usd0k/>
-<Line y=num_orders_num0/>
+x=month
+y=num_orders_num0
+>
+  <Bar y=num_orders_num0/>
+  <Line y2=sales_usd0k/>
 </Chart>
 
 ## Bar and Line Chart with Custom Height
 
-<Chart
+<!-- <Chart
 data={orders_by_category.filter(d => d.category === "Sinister Toys")}
 x=month
 chartAreaHeight=380>
 <Bar y=sales_usd0k/>
 <Line y=num_orders_num0/>
-</Chart>
+</Chart> -->

--- a/sites/example-project/src/pages/charts/scatter-plot/+page.md
+++ b/sites/example-project/src/pages/charts/scatter-plot/+page.md
@@ -118,6 +118,7 @@ let countries = [
     data={countries}
     x=gdp_usd
     y=gdp_growth_pct1
+    y2=gdp_growth_pct1
     tooltipTitle=country
 />
 


### PR DESCRIPTION
### Description
This draft PR adds a secondary axis to the charting library, called `y2`.

I was playing around with what would be possible here and wanted to add this PR to share the information. 

<img width="578" alt="CleanShot 2023-05-13 at 18 03 40@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/1f53302c-6cf9-4f00-9615-54c7b29d197a">


This almost works already, but there are some hairy issues left to solve before we could implement this:
- Get working in composable charts
   - Toughest part here is working around the logic in Chart.svelte which automatically assigns columns to `y` when no `y` prop is supplied
   - This might require somehow passing `y` and `y2` values from child components up to the parent Chart.svelte
- yAxis overrides within child components
   - Most child components adjust the yAxis depending on the series information in the chart (e.g., `Bar.svelte` updates the echarts config by updating a store)
   - These axis adjustments all assume the y axis in the chart config is in one object, but with this change, the y axis could either be a single object or an array containing 2 objects
   - One solution here is to always include a secondary axis, but have it set to hidden - then the override within each child component becomes `show: true` rather than having to trigger a secondary axis to get added to the config (this is how it is set up in this PR at the moment)
- Tooltip formatting
   - It's not straightforward to retrieve the formatting information for a series from echarts' tooltip formatter. This isn't a problem now because everything is formatted as the same as the y-axis and we know the y column format
   - With `y2`, we'd need to know which axis each series belongs to so we can apply the correct formatting
   - There is definitely a way to make this work, but may require some parsing of the series name, or setting up an object with series name and yAxisIndex that can be accessed from the tooltip formatter
   - Issue open with echarts here to see if there is an easier way to access that information: https://github.com/apache/echarts/issues/18622 
- Axis colours
   - It's nice to colour the axis labels to match a series on each axis (e.g., have a red line on `y` with red axis labels, and a blue line on `y2` with blue axis labels
   - Tricky to figure out how to determine which colours to use if:
      - Multiple series exist on at least one of the axes
      - The user has overridden the colour of their line/bar/etc.
   - Solution here might be to offer an override prop to the user so they can choose a specific colour to make the axis if they wish (e.g., `yAxisColor='red'`)   
- How to handle charts where `swapXY=true`
   - Might be best to not allow a secondary axis on horizontal charts, at least as a starting point 
- Annotation components would need to be adjusted to work with `y2` 
- Get it working intuitively with multiple series on one or both axes

### Checklist
- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
