### PR TITLE
docs/data-sources: fix link to local-data-files

### DIFF
--- a/sites/docs/docs/core-concepts/data-sources/index.md
+++ b/sites/docs/docs/core-concepts/data-sources/index.md
@@ -30,7 +30,7 @@ Evidence supports:
 - [MySQL](#mysql)
 - [SQLite](#sqlite)
 - [DuckDB](#duckdb)
-- [CSV and Parquet files](#local-data-files)
+- [CSV and Parquet files](#csv-and-parquet-files)
 - & More
 
 We're adding new connectors regularly. [Create a GitHub issue](https://github.com/evidence-dev/evidence/issues) or [send us a message in Slack](https://join.slack.com/t/evidencedev/shared_invite/zt-uda6wp6a-hP6Qyz0LUOddwpXW5qG03Q) if you'd like to use Evidence with a database that isn't currently supported.


### PR DESCRIPTION
### Description

Change anchor reference from #local-data-files to #csv-and-parquet-files as needed to make the link work on the published website.

i.e. https://docs.evidence.dev/core-concepts/data-sources/#csv-and-parquet-files

### Checklist

- [ X ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [  ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
