### PR TITLE
Make build:strict windows compatible

### DIFF
--- a/.changeset/moody-toys-sit.md
+++ b/.changeset/moody-toys-sit.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Make build:strict compatible with Windows OS

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Steps we can take to reproduce the issue you're seeing. Sample data is helpful.
 
 ### Environment
 
-- Node version (`node -v`): 
+- Node version (`node -v`):
 - npm version (`npm -v`):
 - OS:
 - Browser:

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -121,6 +121,9 @@ const watchPatterns = [
 	{ sourceRelative: '.', targetRelative: './.evidence/template/src/', filePattern: 'app.css' } // custom theme file
 ];
 
+const strictMode = function () {
+	process.env['VITE_BUILD_STRICT'] = true;
+};
 const buildHelper = function (command, args) {
 	const watchers = runFileWatcher(watchPatterns);
 	const flatArgs = flattenArguments(args);
@@ -185,7 +188,8 @@ prog
 	.action((args) => {
 		populateTemplate();
 		clearQueryCache();
-		buildHelper('VITE_BUILD_STRICT=true npx vite build', args);
+		strictMode();
+		buildHelper('npx vite build', args);
 	});
 
 prog.parse(process.argv);


### PR DESCRIPTION
### Description

See #898 

Add the `env` setup in the new `sade` CLI setup.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
