### PR TITLE
fixed tailwind exploration path

### DIFF
--- a/sites/example-project/tailwind.config.cjs
+++ b/sites/example-project/tailwind.config.cjs
@@ -8,7 +8,8 @@ module.exports = {
 			'./src/**/*.{html,js,svelte,ts,md}', // This is used for everything in base evidence template
 			'../../pages/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
 			'../../src/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
-			'./node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}'
+			'./node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}',
+            '../../node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}'
 		]
 	},
 	theme: {

--- a/sites/example-project/tailwind.config.cjs
+++ b/sites/example-project/tailwind.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
 			'../../pages/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
 			'../../src/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
 			'./node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}',
-            '../../node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}'
+			'../../node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}'
 		]
 	},
 	theme: {


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->
Instead of looking in `<project>/node_modules/@evidence-dev/...`, example-project was looking in `<project>/.evidence/template/node_modules/@evidence-dev/...` for components