### PR TITLE
moved plugin-connector dependency, deleted .npmrc

### DIFF
--- a/.changeset/eleven-drinks-share.md
+++ b/.changeset/eleven-drinks-share.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/evidence': patch
+'evidence-test-environment': patch
+---
+
+switched plugin-connector to evidence dep

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@evidence-dev:registry=https://registry.itsbrian.dev/repository/npm

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"@evidence-dev/db-orchestrator": "link:packages/db-orchestrator",
 		"@evidence-dev/evidence": "link:packages/evidence",
 		"@evidence-dev/preprocess": "link:packages/preprocess",
+        "@evidence-dev/plugin-connector": "link:packages/plugin-connector",
 		"@evidence-dev/telemetry": "link:packages/telemetry",
 		"@sveltejs/adapter-static": "1.0.0",
 		"@sveltejs/kit": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"@evidence-dev/db-orchestrator": "link:packages/db-orchestrator",
 		"@evidence-dev/evidence": "link:packages/evidence",
 		"@evidence-dev/preprocess": "link:packages/preprocess",
-        "@evidence-dev/plugin-connector": "link:packages/plugin-connector",
+		"@evidence-dev/plugin-connector": "link:packages/plugin-connector",
 		"@evidence-dev/telemetry": "link:packages/telemetry",
 		"@sveltejs/adapter-static": "1.0.0",
 		"@sveltejs/kit": "1.13.0",

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -39,6 +39,7 @@
 	},
 	"dependencies": {
 		"@evidence-dev/preprocess": "workspace:^",
+        "@evidence-dev/plugin-connector": "workspace:^",
 		"@evidence-dev/telemetry": "workspace:^",
 		"@sveltejs/adapter-static": "1.0.0",
 		"chokidar": "3.5.3",

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -39,7 +39,7 @@
 	},
 	"dependencies": {
 		"@evidence-dev/preprocess": "workspace:^",
-        "@evidence-dev/plugin-connector": "workspace:^",
+		"@evidence-dev/plugin-connector": "workspace:^",
 		"@evidence-dev/telemetry": "workspace:^",
 		"@sveltejs/adapter-static": "1.0.0",
 		"chokidar": "3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ importers:
       '@evidence-dev/core-components': link:packages/core-components
       '@evidence-dev/db-orchestrator': link:packages/db-orchestrator
       '@evidence-dev/evidence': link:packages/evidence
+      '@evidence-dev/plugin-connector': link:packages/plugin-connector
       '@evidence-dev/preprocess': link:packages/preprocess
       '@evidence-dev/tailwind': link:packages/tailwind
       '@evidence-dev/telemetry': link:packages/telemetry
@@ -61,6 +62,7 @@ importers:
       '@evidence-dev/core-components': link:packages/core-components
       '@evidence-dev/db-orchestrator': link:packages/db-orchestrator
       '@evidence-dev/evidence': link:packages/evidence
+      '@evidence-dev/plugin-connector': link:packages/plugin-connector
       '@evidence-dev/preprocess': link:packages/preprocess
       '@evidence-dev/telemetry': link:packages/telemetry
       '@sveltejs/adapter-static': 1.0.0_@sveltejs+kit@1.13.0
@@ -276,6 +278,7 @@ importers:
       '@evidence-dev/components': workspace:^
       '@evidence-dev/core-components': workspace:^
       '@evidence-dev/db-orchestrator': workspace:^
+      '@evidence-dev/plugin-connector': workspace:^
       '@evidence-dev/preprocess': workspace:^
       '@evidence-dev/telemetry': workspace:^
       '@sveltejs/adapter-static': 1.0.0
@@ -286,6 +289,7 @@ importers:
       svelte: 3.55.0
       vite: ^4.0.4
     dependencies:
+      '@evidence-dev/plugin-connector': link:../plugin-connector
       '@evidence-dev/preprocess': link:../preprocess
       '@evidence-dev/telemetry': link:../telemetry
       '@sveltejs/adapter-static': 1.0.0_@sveltejs+kit@1.13.0
@@ -618,12 +622,10 @@ importers:
       '@evidence-dev/component-utilities': workspace:^
       '@evidence-dev/core-components': workspace:^
       '@evidence-dev/evidence': workspace:^
-      '@evidence-dev/plugin-connector': workspace:^
     dependencies:
       '@evidence-dev/component-utilities': link:../../packages/component-utilities
       '@evidence-dev/core-components': link:../../packages/core-components
       '@evidence-dev/evidence': link:../../packages/evidence
-      '@evidence-dev/plugin-connector': link:../../packages/plugin-connector
 
   tests:
     specifiers:

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -15,7 +15,6 @@
 	"dependencies": {
 		"@evidence-dev/component-utilities": "workspace:^",
 		"@evidence-dev/core-components": "workspace:^",
-		"@evidence-dev/evidence": "workspace:^",
-		"@evidence-dev/plugin-connector": "workspace:^"
+		"@evidence-dev/evidence": "workspace:^"
 	}
 }


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->
Removes accidental `.npmrc` commit, adds `@evidence-dev/plugin-connector` in with `@evidence-dev/preprocess`