### PR TITLE
Line colour for area chart. Addresses issue #923

### DIFF
--- a/.changeset/mean-swans-impress.md
+++ b/.changeset/mean-swans-impress.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'evidence-docs': patch
+---
+
+Added lineColor prop to AreaChart

--- a/packages/core-components/src/lib/unsorted/viz/Area.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Area.svelte
@@ -23,6 +23,7 @@
 	export let type = 'stacked'; // stacked or stacked100
 
 	export let fillColor = undefined;
+	export let lineColor = undefined;
 	export let fillOpacity = undefined;
 	export let line = true;
 	$: line = line === 'true' || line === true;
@@ -64,7 +65,8 @@
 		},
 		connectNulls: handleMissing === 'connect',
 		lineStyle: {
-			width: line ? 1 : 0
+			width: line ? 1 : 0,
+			color: lineColor
 		},
 		label: {
 			show: false

--- a/packages/core-components/src/lib/unsorted/viz/AreaChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/AreaChart.svelte
@@ -30,6 +30,7 @@
 
 	export let line = undefined;
 	export let fillColor = undefined;
+	export let lineColor = undefined;
 	export let fillOpacity = undefined;
 	export let chartAreaHeight = undefined;
 
@@ -69,6 +70,6 @@
 	{stacked100}
 	{chartAreaHeight}
 >
-	<Area {line} {fillColor} {fillOpacity} {handleMissing} {type} />
+	<Area {line} {fillColor} {lineColor} {fillOpacity} {handleMissing} {type} />
 	<slot />
 </Chart>

--- a/sites/docs/docs/components/area-chart.md
+++ b/sites/docs/docs/components/area-chart.md
@@ -75,6 +75,7 @@ hide_table_of_contents: false
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
 <tr>	<td>type</td>	<td>Grouping method to use for multi-series charts</td>	<td class='tcenter'>-</td>	<td class='tcenter'>stacked | stacked100</td>	<td class='tcenter'>stacked</td>	</tr>
 <tr>	<td>fillColor</td>	<td>Color to override default series color. Only accepts a single color.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>CSS name | hexademical | RGB | HSL</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>lineColor</td>	<td>Color to override default line color. Only accepts a single color.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>CSS name | hexademical | RGB | HSL</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>fillOpacity</td>	<td>% of the full color that should be rendered, with remainder being transparent</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number (0 to 1)</td>	<td class='tcenter'>0.7</td>	</tr>
 <tr>	<td>line</td>	<td>Show line on top of the area</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
 </table>

--- a/sites/example-project/src/pages/charts/area-chart/+page.md
+++ b/sites/example-project/src/pages/charts/area-chart/+page.md
@@ -11,6 +11,14 @@ data={orders_by_category.filter(d => d.category === "Sinister Toys")}
 x=month
 />
 
+## Area with Custom Line Color
+
+<AreaChart
+data={orders_by_category.filter(d => d.category === "Sinister Toys")}
+x=month
+lineColor=red
+/>
+
 ## Stacked Area
 
 <AreaChart 


### PR DESCRIPTION
### Description

Added `lineColor` prop to `AreaChart.svelte` file. Also doc for AreaChart has been updated

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

![image](https://github.com/evidence-dev/evidence/assets/8280216/f1a960c8-b566-4607-a414-2d24248354c3)

