### PR TITLE
Better error handling + doc update

### DIFF
--- a/packages/plugin-connector/src/plugin-discovery/is-valid-package.js
+++ b/packages/plugin-connector/src/plugin-discovery/is-valid-package.js
@@ -9,8 +9,29 @@ import fs from 'fs/promises';
  * @returns {Promise<false | ValidPackage>}
  */
 export const isValidPackage = async (path) => {
-	const s = await fs.stat(path);
-	if (!s.isDirectory()) return false;
+    try {
+        const s = await fs.stat(path);
+        if (!s.isDirectory()) return false;
+    } catch (e) {
+        if (e instanceof Error && (/** @type{NodeJS.ErrnoException} */(e)).code !== 'ENOENT') {
+            console.warn(
+                chalk.yellow(
+                    `[!] An error occured while loading ${chalk.bold(
+                        `"${path.split('node_modules/')[1]}"`
+                    )}: ${e}.`
+                )
+            )
+        } else {
+            console.warn(
+                chalk.yellow(
+                    `[!] ${chalk.bold(
+                        `"${path.split('node_modules/')[1]}"`
+                    )} could not be found in your node_modules. Check for spelling errors or try running npm install.`
+                )
+            );
+        }
+        return false;
+    }
 
 	const c = await fs.readdir(path);
 	if (!c.includes('package.json')) return false;

--- a/sites/docs/docs/plugins/using-plugins/index.md
+++ b/sites/docs/docs/plugins/using-plugins/index.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 1
+hide_table_of_contents: false
+title: 'Using Plugins'
+---
+
 # Plugins
 
 Evidence uses a plugin system to load components (charts, buttons, and other visual parts of your project), and they are configured using the `evidence.plugins.yaml` file in your project.
@@ -10,8 +16,7 @@ If you want to create new plugins, see [Creating a Plugin](./creating-a-plugin).
 
 ## Installing Plugins
 
-To install a plugin, use the `npm install` command. Make sure you include the `--save` flag or the plugin
-will not be saved with your project.
+To install a plugin, use the `npm install` command. Make sure you include the `--save` flag or the plugin will not be saved with your project.
 
 For example:
 
@@ -19,7 +24,9 @@ For example:
 npm install --save @acme/charting 
 ```
 
-Once the plugin is installed, you can add it to your plugin file and begin using it in your project
+Once the plugin is installed, you can add it to your plugin file and begin using it in your project.
+
+> **Note:** Adding new packages to your plugin file will not immediately take effect in your project. You will need to restart the Evidence server for the changes to take effect. This can be done by pressing the 'r' key in the terminal window where you have Evidence running.
 
 ## Plugin file syntax
 
@@ -32,8 +39,7 @@ In each configuration, the `components` object has a key for each plugin that ma
 the package name.
 
 In this example, the `@evidence-dev/core-components` and `@acme/charting` plugins are used.
-Because [aliases](#component-aliases) or [overrides](#component-overrides) aren't being used,
-they have a value of `{}` (empty object).
+Because [aliases](#component-aliases) or [overrides](#component-overrides) aren't being used, they have a value of `{}` (empty object).
 
 ```yaml
 components:
@@ -53,7 +59,7 @@ made available in the Evidence project as `AcmeChart`
 components:
     @acme/charting:
         aliases:
-            LongNameForAChart: AcmeChart
+            AcmeChart: LongNameForAChart
 ```
 
 ### Component Overrides
@@ -76,7 +82,7 @@ components:
     @evidence-dev/core-components: {}
     @acme/charting:
         aliases:
-            CustomQueryViewer: QueryViewer # Rename CustomQueryViewer
+            QueryViewer: CustomQueryViewer # Rename CustomQueryViewer
         overrides:
             - QueryViewer # Override QueryViewer with the now renamed CustomQueryViewer
 ```
@@ -85,6 +91,15 @@ components:
 
 If you want to use a component library that is _not_ an Evidence component plugin, you can use the `provides` field to 
 manually document the components that the library provides.
+
+```yaml
+components:
+  @evidence-dev/core-components: {}
+  carbon-components-svelte:
+    provides:
+      - Button
+      - CodeSnippet
+```
 
 :::info
 The components provided _must_ be named exports, e.g. `import {ComponentName} from 'package';`, _not_ `import ComponentName from 'package/ComponentName.svelte;`.


### PR DESCRIPTION
### Description

Gives a warning when a dependency isn't found instead of a big warning:
<img width="796" alt="image" src="https://github.com/evidence-dev/evidence/assets/61282104/80161838-340d-4ad9-b6ae-51604685a798">

And adds some tidbits to the docs