### PR TITLE
switch to async while loop vs. setInterval

### DIFF
--- a/.changeset/ten-melons-complain.md
+++ b/.changeset/ten-melons-complain.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+switch to async + while loop to prevent requests building up

--- a/packages/core-components/src/lib/unsorted/QueryStatus.svelte
+++ b/packages/core-components/src/lib/unsorted/QueryStatus.svelte
@@ -56,13 +56,18 @@
 
 	onMount(() => {
 		endpoint = $routeHash;
-		const interval = setInterval(() => {
-			checkStatusAndInvalidate();
-		}, 100);
+		let keep_running = true;
 
-		return () => {
-			clearInterval(interval);
+		const loop = async () => {
+			while (keep_running) {
+				await checkStatusAndInvalidate();
+				await delay(100);
+			}
 		};
+
+		loop();
+
+		return () => (keep_running = false);
 	});
 </script>
 


### PR DESCRIPTION
### Description

Fixes #905 

Switches to async while loop to prevent requests building up and dumping when dev server is turned off/on

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
