### PR TITLE
integrate components folder as a plugin

### DIFF
--- a/.changeset/silly-waves-own.md
+++ b/.changeset/silly-waves-own.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': minor
+---
+
+allow for components folder to be used as a component plugin

--- a/packages/plugin-connector/src/build-plugins/preprocess.js
+++ b/packages/plugin-connector/src/build-plugins/preprocess.js
@@ -21,7 +21,8 @@ export const evidencePlugins = () => {
 	const autoImporter = packages.then((packages) =>
 		autoImport({
 			include: ['**/*.(svelte|md)'],
-			module: packages
+			module: packages,
+			components: [{ directory: '../../components', flat: true }]
 		})
 	);
 

--- a/packages/plugin-connector/src/component-resolution/get-plugin-components.js
+++ b/packages/plugin-connector/src/component-resolution/get-plugin-components.js
@@ -3,6 +3,9 @@ import { getComponentsForPackage } from './get-components-for-package';
 import { loadConfig } from '../plugin-discovery/resolve-evidence-config';
 import { getRootModules } from '../plugin-discovery/get-root-modules';
 import chalk from 'chalk';
+import { findSvelteComponents } from './loaders/file-loader';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * @param {EvidenceConfig} [cfg]
@@ -106,6 +109,21 @@ export async function getPluginComponents(cfg, discoveries) {
 		},
 		{}
 	);
+
+	if (fs.existsSync(`${rootDir}/components`)) {
+		const user_components = await findSvelteComponents(`${rootDir}/components`);
+		for (const component_file of user_components) {
+			const component = path.basename(component_file, '.svelte');
+			if (componentMap[component]) {
+				console.warn(
+					chalk.yellow(
+						`[!] The components folder and ${componentMap[component].package} both provide ${component}. The component from the components folder will be used. To use the component from ${componentMap[component].package}, specify an alias (https://docs.evidence.dev/plugins/using-plugins/#component-aliases) or explicitly import the component.`
+					)
+				);
+				delete componentMap[component];
+			}
+		}
+	}
 
 	return componentMap;
 }

--- a/packages/plugin-connector/types/sveltekit-autoimport/index.d.ts
+++ b/packages/plugin-connector/types/sveltekit-autoimport/index.d.ts
@@ -6,7 +6,7 @@ declare module 'sveltekit-autoimport' {
 		exclude?: string[];
 		module?: Record<string, string[]>;
 		mapping?: unknown;
-		components?: unknown;
+		components?: (string | { directory: string; flat?: boolean; prefix?: string })[];
 	};
 
 	export default function (args: AutoImportArgs): { markup: MarkupPreprocessor };


### PR DESCRIPTION
### Description

Fixes #829

Enables components in the components folder to be automatically imported

Message when conflict is detected:
> [!] The components folder and {package} both provide {component}. The component from the components folder will be used. To use the component from {package}, specify an alias (https://docs.evidence.dev/plugins/using-plugins/#component-aliases) or explicitly import the component.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
