### PR TITLE
removed redundant tailwind config lines that broke HMR

### DIFF
--- a/.changeset/old-shoes-marry.md
+++ b/.changeset/old-shoes-marry.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+removed redundant lines from tailwind.config.js

--- a/sites/example-project/tailwind.config.cjs
+++ b/sites/example-project/tailwind.config.cjs
@@ -6,8 +6,6 @@ module.exports = {
 		relative: true,
 		files: [
 			'./src/**/*.{html,js,svelte,ts,md}', // This is used for everything in base evidence template
-			'../../pages/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
-			'../../src/**/*.{html,js,svelte,ts,md}', // This is used in end user projects to let them access tailwind classes
 			'./node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}',
 			'../../node_modules/@evidence-dev/core-components/dist/**/*.{html,js,svelte,ts,md}'
 		]


### PR DESCRIPTION
### Description

Fixes #944 

Tailwind was breaking HMR because it was looking outside of vite's project directory(?), so removing these two lines makes it stay in it's place. The lines are redundant because all the contents of `/pages` and `/components` are copied to `.evidence/template/src` anyways, so Tailwind can parse them regardless.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
