### PR TITLE
Empty sources folder after copying to template

### DIFF
--- a/.changeset/seven-paws-switch.md
+++ b/.changeset/seven-paws-switch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+emptied sources folder in template

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -24,6 +24,8 @@ templatePaths.forEach((p) => {
 	fs.copySync(path.join('../../sites/example-project', p), path.join('./template', p));
 });
 
+fs.emptyDirSync('./template/sources');
+
 // Create a clean SK config (workspace's is modified)
 fs.outputFileSync(
 	'./template/svelte.config.js',


### PR DESCRIPTION
### Description

Removes the contents of `sources` during template build

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
