### PR TITLE
Expose formatting to components

### DIFF
--- a/.changeset/pink-snakes-knock.md
+++ b/.changeset/pink-snakes-knock.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': minor
+'@evidence-dev/core-components': minor
+---
+
+Adds formatting control to components

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -59,7 +59,7 @@ export function getFormatObjectFromString(formatString) {
 			formatTag: 'custom',
 			formatCode: potentialFormatTag,
 			valueType: 'number'
-		}
+		};
 		return newFormat;
 	}
 }

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -45,6 +45,25 @@ export const lookupColumnFormat = (columnName, columnEvidenceType, columnUnitSum
 	return undefined;
 };
 
+export function getFormatObjectFromString(formatString) {
+	let potentialFormatTag = formatString;
+	let customFormats = getCustomFormats();
+	let matchingFormat = [...BUILT_IN_FORMATS, ...customFormats].find(
+		(format) => format.formatTag?.toLowerCase() === potentialFormatTag?.toLowerCase()
+	);
+	let newFormat = {};
+	if (matchingFormat) {
+		return matchingFormat;
+	} else {
+		newFormat = {
+			formatTag: 'custom',
+			formatCode: potentialFormatTag,
+			valueType: 'number'
+		}
+		return newFormat;
+	}
+}
+
 export const formatValue = (value, columnFormat = undefined, columnUnitSummary = undefined) => {
 	try {
 		return applyFormatting(value, columnFormat, columnUnitSummary, VALUE_FORMATTING_CONTEXT);

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -4,6 +4,7 @@ import { CUSTOM_FORMATTING_SETTINGS_CONTEXT_KEY } from './globalContexts';
 import { findImplicitAutoFormat, autoFormat, fallbackFormat, isAutoFormat } from './autoFormatting';
 import { BUILT_IN_FORMATS } from './builtInFormats';
 import { standardizeDateString } from './dateParsing';
+import { inferValueType } from './inferColumnTypes';
 
 const AXIS_FORMATTING_CONTEXT = 'axis';
 const VALUE_FORMATTING_CONTEXT = 'value';
@@ -45,7 +46,7 @@ export const lookupColumnFormat = (columnName, columnEvidenceType, columnUnitSum
 	return undefined;
 };
 
-export function getFormatObjectFromString(formatString) {
+export function getFormatObjectFromString(formatString, valueType = undefined) {
 	let potentialFormatTag = formatString;
 	let customFormats = getCustomFormats();
 	let matchingFormat = [...BUILT_IN_FORMATS, ...customFormats].find(
@@ -57,9 +58,11 @@ export function getFormatObjectFromString(formatString) {
 	} else {
 		newFormat = {
 			formatTag: 'custom',
-			formatCode: potentialFormatTag,
-			valueType: 'number'
+			formatCode: potentialFormatTag
 		};
+		if (valueType) {
+			newFormat.valueType = valueType;
+		}
 		return newFormat;
 	}
 }
@@ -154,6 +157,9 @@ function applyFormatting(
 	if (value === undefined || value === null) {
 		return '-';
 	}
+
+	// let valueType = columnFormat.valueType ?? inferValueType(value);
+
 	let result = undefined;
 	if (columnFormat) {
 		try {
@@ -221,5 +227,7 @@ function maybeExtractFormatTag(columnName) {
 
 export function fmt(value, format) {
 	let formatObj = getFormatObjectFromString(format);
+	let valueType = inferValueType(value);
+	formatObj.valueType = valueType;
 	return formatValue(value, formatObj);
 }

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -218,3 +218,8 @@ function maybeExtractFormatTag(columnName) {
 		return undefined;
 	}
 }
+
+export function fmt(value, format) {
+	let formatObj = getFormatObjectFromString(format);
+	return formatValue(value, formatObj);
+}

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -158,8 +158,6 @@ function applyFormatting(
 		return '-';
 	}
 
-	// let valueType = columnFormat.valueType ?? inferValueType(value);
-
 	let result = undefined;
 	if (columnFormat) {
 		try {

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -46,6 +46,12 @@ export const lookupColumnFormat = (columnName, columnEvidenceType, columnUnitSum
 	return undefined;
 };
 
+/**
+ * Returns an Evidence format object to be used in the applyFormatting function
+ * @param {string} formatString string containing an Excel-style format code, or a format name matching a built-in or custom format
+ * @param {string} valueType optional - a string representing the data type within the column that will be formatted ('number', 'date', 'boolean', or 'string)
+ * @returns a format object based on the formatString matching a built-in or custom format name, or a new custom format object containing an Excel-style format code
+ */
 export function getFormatObjectFromString(formatString, valueType = undefined) {
 	let potentialFormatTag = formatString;
 	let customFormats = getCustomFormats();
@@ -223,6 +229,12 @@ function maybeExtractFormatTag(columnName) {
 	}
 }
 
+/**
+ * Formats a value to whichever format is passed in
+ * @param {*} value the value to be formatted
+ * @param {string} format string containing an Excel-style format code, or a format name matching a built-in or custom format
+ * @returns a formatted value
+ */
 export function fmt(value, format) {
 	let formatObj = getFormatObjectFromString(format);
 	let valueType = inferValueType(value);

--- a/packages/component-utilities/src/inferColumnTypes.js
+++ b/packages/component-utilities/src/inferColumnTypes.js
@@ -14,7 +14,7 @@ var TypeFidelity;
 	TypeFidelity['PRECISE'] = 'precise';
 })(TypeFidelity || (TypeFidelity = {}));
 
-const inferValueType = function (columnValue) {
+export const inferValueType = function (columnValue) {
 	if (typeof columnValue === 'number') {
 		return EvidenceType.NUMBER;
 	} else if (typeof columnValue === 'boolean') {

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/BuiltInFormatGrid.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/BuiltInFormatGrid.svelte
@@ -9,7 +9,7 @@
 
 <table>
 	<thead>
-		<th class="align_left narrow_column">Format Tag</th>
+		<th class="align_left narrow_column">Format Name</th>
 		<th class="align_left wide_column">Format Code</th>
 		<th class="align_left wide_column">Example Input</th>
 		<th class="align_right wide_column">Example Output</th>

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/CurrencyFormatGrid.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/CurrencyFormatGrid.svelte
@@ -22,7 +22,7 @@
 	<div transition:slide>
 		<table>
 			<thead>
-				<th class="align_left narrow_column">Format Tag</th>
+				<th class="align_left narrow_column">Format Name</th>
 				<th class="align_left wide_column">Format Code</th>
 				<th class="align_left wide_column">Example Input</th>
 				<th class="align_right wide_column">Example Output</th>

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/CustomFormatGrid.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/CustomFormatGrid.svelte
@@ -11,7 +11,7 @@
 
 <table>
 	<thead>
-		<th class="align_left narrow_column">Format Tag</th>
+		<th class="align_left narrow_column">Format Name</th>
 		<th class="align_left wide_column">Format Code</th>
 		<th class="align_left wide_column">Example Input</th>
 		<th class="align_right wide_column">Example Output</th>

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/CustomFormatsSection.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/CustomFormatsSection.svelte
@@ -61,7 +61,7 @@
 		let errors = [];
 		if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(formatTag)) {
 			errors.push(
-				`"${formatTag}" is not a valid format tag. The format tag should always start with a letter and only contain letters and numbers.`
+				`"${formatTag}" is not a valid format name. The format name should always start with a letter and only contain letters and numbers.`
 			);
 		}
 		let testValue = 10;
@@ -85,7 +85,7 @@
 			builtInFormats.find((format) => format.formatTag === formatTag) ||
 			customFormattingSettings.customFormats?.find((format) => format.formatTag === formatTag)
 		) {
-			errors.push(`The format tag "${formatTag}"" is already assigned to an existing format.`);
+			errors.push(`The format name "${formatTag}"" is already assigned to an existing format.`);
 		}
 		return errors;
 	}
@@ -112,7 +112,7 @@
 		</select>
 	</div>
 	<div class="input-item">
-		<label for="formatTag">Format Tag</label>
+		<label for="formatTag">Format Name</label>
 		<input id="formatTag" type="text" placeholder="myformat" bind:value={formatTag} />
 	</div>
 	<div class="input-item">

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
@@ -21,9 +21,9 @@ from table`;
 	x=date
 	y=sales
 	yFmt=euro
-/>`
+/>`;
 
-	let valueExample = `<Value data={sales_data} column=sales fmt='$#,##0' />`
+	let valueExample = `<Value data={sales_data} column=sales fmt='$#,##0' />`;
 </script>
 
 <form id="formatting">
@@ -31,21 +31,24 @@ from table`;
 		<div class="panel">
 			<h2>Value Formatting</h2>
 			<p>
-				Evidence supports built-in formats (like <code>usd</code> and <code>pct</code>) and Excel-style formats (like <code>$#,##0.0</code>). The easiest way to apply these formats is using component props. 
-				
-				For example:
+				Evidence supports built-in formats (like <code>usd</code> and <code>pct</code>) and
+				Excel-style formats (like <code>$#,##0.0</code>). The easiest way to apply these formats is
+				using component props. For example:
 			</p>
 			<p>In the Value component, you can use the <code>fmt</code> prop</p>
 			<div class="code-container p-2">
 				<Prism language="html" code={valueExample} />
 			</div>
-			<br/>
+			<br />
 			<p>In charts, you can use the <code>xFmt</code> and <code>yFmt</code> props</p>
 			<div class="code-container p-2">
 				<Prism language="jsx" code={componentExample} />
 			</div>
-			<br/>
-			<p>You can also set formats within your SQL queries using SQL format tags. Use these by aliasing your column names and appending a format. For example:</p>
+			<br />
+			<p>
+				You can also set formats within your SQL queries using SQL format tags. Use these by
+				aliasing your column names and appending a format. For example:
+			</p>
 			<div class="code-container p-2">
 				<Prism language="sql" code={exampleQuery} />
 			</div>

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
@@ -15,6 +15,15 @@
   growth as growth_pct, -- formatted as a percentage
   sales as sales_usd    -- formatted as US dollars
 from table`;
+
+	let componentExample = `<LineChart
+	data={sales_data}
+	x=date
+	y=sales
+	yFmt=euro
+/>`
+
+	let valueExample = `<Value data={sales_data} column=sales fmt='$#,##0' />`
 </script>
 
 <form id="formatting">
@@ -22,18 +31,29 @@ from table`;
 		<div class="panel">
 			<h2>Value Formatting</h2>
 			<p>
-				Format tags like <code>_usd</code> and <code>_pct</code> let you control how data will be formatted
-				in Evidence.
+				Evidence supports built-in formats (like <code>usd</code> and <code>pct</code>) and Excel-style formats (like <code>$#,##0.0</code>). The easiest way to apply these formats is using component props. 
+				
+				For example:
 			</p>
-			<p>Apply format tags by including them at the end of column names. For example:</p>
+			<p>In the Value component, you can use the <code>fmt</code> prop</p>
+			<div class="code-container p-2">
+				<Prism language="html" code={valueExample} />
+			</div>
+			<br/>
+			<p>In charts, you can use the <code>xFmt</code> and <code>yFmt</code> props</p>
+			<div class="code-container p-2">
+				<Prism language="jsx" code={componentExample} />
+			</div>
+			<br/>
+			<p>You can also set formats within your SQL queries using SQL format tags. Use these by aliasing your column names and appending a format. For example:</p>
 			<div class="code-container p-2">
 				<Prism language="sql" code={exampleQuery} />
 			</div>
 			<p />
 		</div>
 		<div class="panel">
-			<h2>Built in Format Tags</h2>
-			<p>All of the built in format tags are listed below for reference.</p>
+			<h2>Built-in Formats</h2>
+			<p>All built-in formats are listed below for reference.</p>
 			<CollapsibleTableSection headerText={'Dates'} expanded={false}>
 				<BuiltInFormatGrid formats={BUILT_IN_FORMATS.filter((d) => d.formatCategory === 'date')} />
 			</CollapsibleTableSection>
@@ -54,9 +74,9 @@ from table`;
 			</CollapsibleTableSection>
 		</div>
 		<div class="panel">
-			<h2>Custom Format Tags</h2>
+			<h2>Custom Formats</h2>
 			<p>
-				Add new format tags to your project. Custom format tags use <a
+				Add new formats to your project. Custom formats use <a
 					class="docs-link"
 					target="none"
 					href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68"

--- a/packages/core-components/src/lib/unsorted/viz/AreaChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/AreaChart.svelte
@@ -12,6 +12,9 @@
 	export let series = undefined;
 	export let xType = undefined;
 
+	export let yFmt = undefined;
+	export let xFmt = undefined;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = undefined;
@@ -48,6 +51,8 @@
 	{data}
 	{x}
 	{y}
+	{xFmt}
+	{yFmt}
 	{series}
 	{xType}
 	{legend}

--- a/packages/core-components/src/lib/unsorted/viz/BarChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/BarChart.svelte
@@ -12,6 +12,9 @@
 	export let series = undefined;
 	export let xType = undefined;
 
+	export let yFmt = undefined;
+	export let xFmt = undefined;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = undefined;
@@ -52,6 +55,8 @@
 	{data}
 	{x}
 	{y}
+	{xFmt}
+	{yFmt}
 	{series}
 	{xType}
 	{legend}

--- a/packages/core-components/src/lib/unsorted/viz/BigValue.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/BigValue.svelte
@@ -10,10 +10,15 @@
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
 	import { strictBuild } from './context';
+	import { getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	export let data;
 	export let value = null;
 	export let comparison = null;
 	export let sparkline = null;
+
+	// Formatting:
+	export let fmt = undefined;
+	export let comparisonFmt = undefined;
 
 	export let title = null;
 	export let comparisonTitle = null;
@@ -106,7 +111,7 @@
 	{:else}
 		<p class="text-sm font-medium text-grey-700 text-shadow shadow-white m-0">{title}</p>
 		<div class="relative">
-			<Value {data} column={value} />
+			<Value {data} column={value} fmt={fmt}/>
 			{#if sparkline}
 				{#if isLinkedChartReady()}
 					<div class="inline-block">
@@ -131,7 +136,7 @@
 		{#if comparison}
 			<p class="m-0 text-xs font-medium font-ui" style={`color:${comparisonColor}`}>
 				{@html positive ? '&#9650;' : '&#9660;'}
-				<Value {data} column={comparison} />
+				<Value {data} column={comparison} fmt={comparisonFmt}/>
 				<span class="text-grey-700 font-normal">{comparisonTitle}</span>
 			</p>
 		{/if}

--- a/packages/core-components/src/lib/unsorted/viz/BigValue.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/BigValue.svelte
@@ -10,7 +10,6 @@
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
 	import { strictBuild } from './context';
-	import { getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	export let data;
 	export let value = null;
 	export let comparison = null;
@@ -111,7 +110,7 @@
 	{:else}
 		<p class="text-sm font-medium text-grey-700 text-shadow shadow-white m-0">{title}</p>
 		<div class="relative">
-			<Value {data} column={value} fmt={fmt}/>
+			<Value {data} column={value} {fmt} />
 			{#if sparkline}
 				{#if isLinkedChartReady()}
 					<div class="inline-block">
@@ -136,7 +135,7 @@
 		{#if comparison}
 			<p class="m-0 text-xs font-medium font-ui" style={`color:${comparisonColor}`}>
 				{@html positive ? '&#9650;' : '&#9660;'}
-				<Value {data} column={comparison} fmt={comparisonFmt}/>
+				<Value {data} column={comparison} fmt={comparisonFmt} />
 				<span class="text-grey-700 font-normal">{comparisonTitle}</span>
 			</p>
 		{/if}

--- a/packages/core-components/src/lib/unsorted/viz/BubbleChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/BubbleChart.svelte
@@ -15,6 +15,7 @@
 
 	export let yFmt = undefined;
 	export let xFmt = undefined;
+	export let sizeFmt = undefined;
 
 	export let title = undefined;
 	export let subtitle = undefined;
@@ -54,9 +55,10 @@
 	{data}
 	{x}
 	{y}
+	{size}
 	{xFmt}
 	{yFmt}
-	{size}
+	{sizeFmt}
 	{tooltipTitle}
 	{series}
 	{xType}

--- a/packages/core-components/src/lib/unsorted/viz/BubbleChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/BubbleChart.svelte
@@ -13,6 +13,9 @@
 	export let series = undefined;
 	export let xType = undefined;
 
+	export let yFmt = undefined;
+	export let xFmt = undefined;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = undefined;
@@ -51,6 +54,8 @@
 	{data}
 	{x}
 	{y}
+	{xFmt}
+	{yFmt}
 	{size}
 	{tooltipTitle}
 	{series}

--- a/packages/core-components/src/lib/unsorted/viz/Chart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Chart.svelte
@@ -83,9 +83,6 @@
 	export let sort = false; // sorts x values in case x is out of order in dataset (e.g., would create line chart that is out of order)
 	sort = sort === 'true' || sort === true;
 	export let xFmt = undefined;
-	if (xFmt) {
-		xFmt = getFormatObjectFromString(xFmt);
-	}
 
 	// Y axis:
 	export let yAxisTitle = 'false'; // Default false. If true, use formatTitle(x). Or you can supply a custom string
@@ -100,15 +97,9 @@
 	export let yMin = undefined;
 	export let yMax = undefined;
 	export let yFmt = undefined;
-	if (yFmt) {
-		yFmt = getFormatObjectFromString(yFmt);
-	}
 
 	// Other column formats:
 	export let sizeFmt = undefined;
-	if (sizeFmt) {
-		sizeFmt = getFormatObjectFromString(sizeFmt);
-	}
 
 	// Legend:
 	export let legend = undefined;
@@ -404,6 +395,8 @@
 			// Get format codes for axes
 			// ---------------------------------------------------------------------------------------
 			if (xFmt) {
+				xFmt = getFormatObjectFromString(xFmt, columnSummary[x].format.valueType);
+				// Override with provided format
 				xFormat = xFmt;
 			} else {
 				xFormat = columnSummary[x].format;
@@ -413,6 +406,12 @@
 				yFormat = 'str';
 			} else {
 				if (yFmt) {
+					if (typeof y === 'object') {
+						yFmt = getFormatObjectFromString(yFmt, columnSummary[y[0]].format.valueType);
+					} else {
+						yFmt = getFormatObjectFromString(yFmt, columnSummary[y].format.valueType);
+					}
+					// Override with provided format
 					yFormat = yFmt;
 				} else {
 					if (typeof y === 'object') {
@@ -425,6 +424,8 @@
 
 			if (size) {
 				if (sizeFmt) {
+					sizeFmt = getFormatObjectFromString(sizeFmt, columnSummary[size].format.valueType);
+					// Override with provided format
 					sizeFormat = sizeFmt;
 				} else {
 					sizeFormat = columnSummary[size].format;

--- a/packages/core-components/src/lib/unsorted/viz/Chart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Chart.svelte
@@ -20,7 +20,10 @@
 	import { standardizeDateColumn } from '@evidence-dev/component-utilities/dateParsing';
 	import { formatAxisValue } from '@evidence-dev/component-utilities/formatting';
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 	import ErrorChart from './ErrorChart.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import { colours } from '@evidence-dev/component-utilities/colours';
@@ -80,7 +83,7 @@
 	export let sort = false; // sorts x values in case x is out of order in dataset (e.g., would create line chart that is out of order)
 	sort = sort === 'true' || sort === true;
 	export let xFmt = undefined;
-	if(xFmt){
+	if (xFmt) {
 		xFmt = getFormatObjectFromString(xFmt);
 	}
 
@@ -97,13 +100,13 @@
 	export let yMin = undefined;
 	export let yMax = undefined;
 	export let yFmt = undefined;
-	if(yFmt){
+	if (yFmt) {
 		yFmt = getFormatObjectFromString(yFmt);
 	}
 
 	// Other column formats:
 	export let sizeFmt = undefined;
-	if(sizeFmt){
+	if (sizeFmt) {
 		sizeFmt = getFormatObjectFromString(sizeFmt);
 	}
 
@@ -400,8 +403,8 @@
 			// ---------------------------------------------------------------------------------------
 			// Get format codes for axes
 			// ---------------------------------------------------------------------------------------
-			if(xFmt){
-				xFormat = xFmt;				
+			if (xFmt) {
+				xFormat = xFmt;
 			} else {
 				xFormat = columnSummary[x].format;
 			}
@@ -409,7 +412,7 @@
 			if (!y) {
 				yFormat = 'str';
 			} else {
-				if (yFmt){
+				if (yFmt) {
 					yFormat = yFmt;
 				} else {
 					if (typeof y === 'object') {
@@ -421,7 +424,7 @@
 			}
 
 			if (size) {
-				if(sizeFmt){
+				if (sizeFmt) {
 					sizeFormat = sizeFmt;
 				} else {
 					sizeFormat = columnSummary[size].format;
@@ -816,7 +819,6 @@
 	}
 
 	$: data;
-
 </script>
 
 {#if !error}

--- a/packages/core-components/src/lib/unsorted/viz/Chart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Chart.svelte
@@ -20,7 +20,7 @@
 	import { standardizeDateColumn } from '@evidence-dev/component-utilities/dateParsing';
 	import { formatAxisValue } from '@evidence-dev/component-utilities/formatting';
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	import ErrorChart from './ErrorChart.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import { colours } from '@evidence-dev/component-utilities/colours';
@@ -79,6 +79,10 @@
 	xAxisLabels = xAxisLabels === 'true' || xAxisLabels === true;
 	export let sort = false; // sorts x values in case x is out of order in dataset (e.g., would create line chart that is out of order)
 	sort = sort === 'true' || sort === true;
+	export let xFmt = undefined;
+	if(xFmt){
+		xFmt = getFormatObjectFromString(xFmt);
+	}
 
 	// Y axis:
 	export let yAxisTitle = 'false'; // Default false. If true, use formatTitle(x). Or you can supply a custom string
@@ -92,6 +96,16 @@
 	yAxisLabels = yAxisLabels === 'true' || yAxisLabels === true;
 	export let yMin = undefined;
 	export let yMax = undefined;
+	export let yFmt = undefined;
+	if(yFmt){
+		yFmt = getFormatObjectFromString(yFmt);
+	}
+
+	// Other column formats:
+	export let sizeFmt = undefined;
+	if(sizeFmt){
+		sizeFmt = getFormatObjectFromString(sizeFmt);
+	}
 
 	// Legend:
 	export let legend = undefined;
@@ -386,19 +400,32 @@
 			// ---------------------------------------------------------------------------------------
 			// Get format codes for axes
 			// ---------------------------------------------------------------------------------------
-			xFormat = columnSummary[x].format;
+			if(xFmt){
+				xFormat = xFmt;				
+			} else {
+				xFormat = columnSummary[x].format;
+			}
+
 			if (!y) {
 				yFormat = 'str';
 			} else {
-				if (typeof y === 'object') {
-					yFormat = columnSummary[y[0]].format;
+				if (yFmt){
+					yFormat = yFmt;
 				} else {
-					yFormat = columnSummary[y].format;
+					if (typeof y === 'object') {
+						yFormat = columnSummary[y[0]].format;
+					} else {
+						yFormat = columnSummary[y].format;
+					}
 				}
 			}
 
 			if (size) {
-				sizeFormat = columnSummary[size].format;
+				if(sizeFmt){
+					sizeFormat = sizeFmt;
+				} else {
+					sizeFormat = columnSummary[size].format;
+				}
 			}
 
 			xUnitSummary = columnSummary[x].columnUnitSummary;
@@ -789,6 +816,7 @@
 	}
 
 	$: data;
+
 </script>
 
 {#if !error}

--- a/packages/core-components/src/lib/unsorted/viz/Column.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Column.svelte
@@ -5,7 +5,6 @@
 <script>
 	import { getContext } from 'svelte';
 	import { propKey, strictBuild } from './context';
-	import { getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 
 	let props = getContext(propKey);
 
@@ -56,9 +55,6 @@
 
 	// Formatting:
 	export let fmt = undefined;
-	if (fmt) {
-		fmt = getFormatObjectFromString(fmt);
-	}
 
 	let options = {
 		id: id,

--- a/packages/core-components/src/lib/unsorted/viz/Column.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Column.svelte
@@ -5,6 +5,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import { propKey, strictBuild } from './context';
+	import { getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 
 	let props = getContext(propKey);
 
@@ -53,6 +54,12 @@
 
 	export let linkLabel = undefined;
 
+	// Formatting:
+	export let fmt = undefined;
+	if(fmt){
+		fmt = getFormatObjectFromString(fmt);
+	}
+
 	let options = {
 		id: id,
 		title: title,
@@ -63,7 +70,8 @@
 		width: width,
 		alt: alt,
 		openInNewTab: openInNewTab,
-		linkLabel: linkLabel
+		linkLabel: linkLabel,
+		fmt: fmt
 	};
 
 	props.update((d) => {

--- a/packages/core-components/src/lib/unsorted/viz/Column.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Column.svelte
@@ -56,7 +56,7 @@
 
 	// Formatting:
 	export let fmt = undefined;
-	if(fmt){
+	if (fmt) {
 		fmt = getFormatObjectFromString(fmt);
 	}
 

--- a/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
@@ -401,7 +401,7 @@
 												{#if row[column.linkLabel] != undefined}
 													{formatValue(
 														row[column.linkLabel],
-														safeExtractColumn(column).format,
+														column.fmt ?? safeExtractColumn(column).format,
 														safeExtractColumn(column).columnUnitSummary
 													)}
 												{:else}
@@ -410,7 +410,7 @@
 											{:else}
 												{formatValue(
 													row[column.id],
-													safeExtractColumn(column).format,
+													column.fmt ?? safeExtractColumn(column).format,
 													safeExtractColumn(column).columnUnitSummary
 												)}
 											{/if}
@@ -418,7 +418,7 @@
 									{:else}
 										{formatValue(
 											row[column.id],
-											safeExtractColumn(column).format,
+											column.fmt ?? safeExtractColumn(column).format,
 											safeExtractColumn(column).columnUnitSummary
 										)}
 									{/if}

--- a/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
@@ -9,7 +9,10 @@
 	import { propKey, strictBuild } from './context';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { convertColumnToDate } from '@evidence-dev/component-utilities/dateParsing';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 	import ErrorChart from './ErrorChart.svelte';
 	import SearchBar from './SearchBar.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
@@ -401,7 +404,12 @@
 												{#if row[column.linkLabel] != undefined}
 													{formatValue(
 														row[column.linkLabel],
-														column.fmt ?? safeExtractColumn(column).format,
+														column.fmt
+															? getFormatObjectFromString(
+																	column.fmt,
+																	safeExtractColumn(column).format.valueType
+															  )
+															: safeExtractColumn(column).format,
 														safeExtractColumn(column).columnUnitSummary
 													)}
 												{:else}
@@ -410,7 +418,12 @@
 											{:else}
 												{formatValue(
 													row[column.id],
-													column.fmt ?? safeExtractColumn(column).format,
+													column.fmt
+														? getFormatObjectFromString(
+																column.fmt,
+																safeExtractColumn(column).format.valueType
+														  )
+														: safeExtractColumn(column).format,
 													safeExtractColumn(column).columnUnitSummary
 												)}
 											{/if}
@@ -418,7 +431,12 @@
 									{:else}
 										{formatValue(
 											row[column.id],
-											column.fmt ?? safeExtractColumn(column).format,
+											column.fmt
+												? getFormatObjectFromString(
+														column.fmt,
+														safeExtractColumn(column).format.valueType
+												  )
+												: safeExtractColumn(column).format,
 											safeExtractColumn(column).columnUnitSummary
 										)}
 									{/if}

--- a/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
@@ -18,9 +18,6 @@
 	export let valueCol = undefined;
 
 	export let valueFmt = undefined;
-	if (valueFmt) {
-		valueFmt = getFormatObjectFromString(valueFmt);
-	}
 
 	export let title = undefined;
 	export let subtitle = undefined;
@@ -72,6 +69,7 @@
 	$: nameColFormat = columnSummary[nameCol].format;
 	let valueColFormat;
 	$: if (valueFmt) {
+		valueFmt = getFormatObjectFromString(valueFmt, columnSummary[valueCol].format.valueType);
 		valueColFormat = valueFmt;
 	} else {
 		valueColFormat = columnSummary[valueCol].format;

--- a/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
@@ -6,13 +6,18 @@
 	import ECharts from './ECharts.svelte';
 
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { colours } from '@evidence-dev/component-utilities/colours';
 
 	export let data = undefined;
 	export let nameCol = undefined;
 	export let valueCol = undefined;
+
+	export let valueFmt = undefined;
+	if(valueFmt){
+		valueFmt = getFormatObjectFromString(valueFmt);
+	}
 
 	export let title = undefined;
 	export let subtitle = undefined;
@@ -62,7 +67,12 @@
 	$: columnSummary = getColumnSummary(data);
 	$: name = name ?? formatTitle(valueCol, columnSummary[nameCol].title);
 	$: nameColFormat = columnSummary[nameCol].format;
-	$: valueColFormat = columnSummary[valueCol].format;
+	let valueColFormat;
+	$: if(valueFmt){
+			valueColFormat = valueFmt;
+		} else {
+			valueColFormat = columnSummary[valueCol].format;
+		}
 
 	// ---------------------------------------------------------------------------------------
 	// Set up chart area

--- a/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/FunnelChart.svelte
@@ -6,7 +6,10 @@
 	import ECharts from './ECharts.svelte';
 
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { colours } from '@evidence-dev/component-utilities/colours';
 
@@ -15,7 +18,7 @@
 	export let valueCol = undefined;
 
 	export let valueFmt = undefined;
-	if(valueFmt){
+	if (valueFmt) {
 		valueFmt = getFormatObjectFromString(valueFmt);
 	}
 
@@ -68,11 +71,11 @@
 	$: name = name ?? formatTitle(valueCol, columnSummary[nameCol].title);
 	$: nameColFormat = columnSummary[nameCol].format;
 	let valueColFormat;
-	$: if(valueFmt){
-			valueColFormat = valueFmt;
-		} else {
-			valueColFormat = columnSummary[valueCol].format;
-		}
+	$: if (valueFmt) {
+		valueColFormat = valueFmt;
+	} else {
+		valueColFormat = columnSummary[valueCol].format;
+	}
 
 	// ---------------------------------------------------------------------------------------
 	// Set up chart area

--- a/packages/core-components/src/lib/unsorted/viz/Histogram.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Histogram.svelte
@@ -10,6 +10,8 @@
 	export let x = undefined;
 	export let legend = false;
 
+	export let xFmt;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let xAxisTitle = undefined;
@@ -33,6 +35,7 @@
 <Chart
 	{data}
 	{x}
+	{xFmt}
 	{legend}
 	{xAxisTitle}
 	{yAxisTitle}

--- a/packages/core-components/src/lib/unsorted/viz/LineChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/LineChart.svelte
@@ -12,6 +12,9 @@
 	export let series = undefined;
 	export let xType = undefined;
 
+	export let yFmt = undefined;
+	export let xFmt = undefined;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = undefined;
@@ -47,6 +50,8 @@
 	{data}
 	{x}
 	{y}
+	{xFmt}
+	{yFmt}
 	{series}
 	{xType}
 	{legend}

--- a/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
@@ -5,7 +5,10 @@
 <script>
 	import { getContext } from 'svelte';
 	import { propKey, configKey } from './context';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
 	import { colours } from '@evidence-dev/component-utilities/colours';
@@ -35,7 +38,7 @@
 	$: hideValue = hideValue === 'true' || hideValue === true;
 
 	export let valueFmt = undefined;
-	if(valueFmt){
+	if (valueFmt) {
 		valueFmt = getFormatObjectFromString(valueFmt);
 	}
 

--- a/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
@@ -5,7 +5,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import { propKey, configKey } from './context';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
 	import { colours } from '@evidence-dev/component-utilities/colours';
@@ -33,6 +33,11 @@
 
 	export let hideValue = false;
 	$: hideValue = hideValue === 'true' || hideValue === true;
+
+	export let valueFmt = undefined;
+	if(valueFmt){
+		valueFmt = getFormatObjectFromString(valueFmt);
+	}
 
 	let colorList = {
 		red: { lineColor: '#b04646', labelColor: '#b04646' },
@@ -163,13 +168,13 @@
 						if (params.name === '') {
 							// If no label supplied
 							result = !hideValue
-								? `${formatValue(params.value, y ? yFormat : x ? xFormat : 'string')}`
+								? `${formatValue(params.value, valueFmt ?? (y ? yFormat : x ? xFormat : 'string'))}`
 								: '';
 						} else {
 							result = !hideValue
 								? `${params.name} (${formatValue(
 										params.value,
-										y ? yFormat : x ? xFormat : 'string'
+										valueFmt ?? (y ? yFormat : x ? xFormat : 'string')
 								  )})`
 								: `${params.name}`;
 						}

--- a/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ReferenceLine.svelte
@@ -5,10 +5,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import { propKey, configKey } from './context';
-	import {
-		formatValue,
-		getFormatObjectFromString
-	} from '@evidence-dev/component-utilities/formatting';
+	import { formatValue } from '@evidence-dev/component-utilities/formatting';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
 	import { colours } from '@evidence-dev/component-utilities/colours';
@@ -36,11 +33,6 @@
 
 	export let hideValue = false;
 	$: hideValue = hideValue === 'true' || hideValue === true;
-
-	export let valueFmt = undefined;
-	if (valueFmt) {
-		valueFmt = getFormatObjectFromString(valueFmt);
-	}
 
 	let colorList = {
 		red: { lineColor: '#b04646', labelColor: '#b04646' },
@@ -171,13 +163,13 @@
 						if (params.name === '') {
 							// If no label supplied
 							result = !hideValue
-								? `${formatValue(params.value, valueFmt ?? (y ? yFormat : x ? xFormat : 'string'))}`
+								? `${formatValue(params.value, y ? yFormat : x ? xFormat : 'string')}`
 								: '';
 						} else {
 							result = !hideValue
 								? `${params.name} (${formatValue(
 										params.value,
-										valueFmt ?? (y ? yFormat : x ? xFormat : 'string')
+										y ? yFormat : x ? xFormat : 'string'
 								  )})`
 								: `${params.name}`;
 						}

--- a/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
@@ -6,7 +6,10 @@
 	import ECharts from './ECharts.svelte';
 
 	import { colours } from '@evidence-dev/component-utilities/colours';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 
 	export let data = undefined;
 	export let sourceCol = 'source';
@@ -14,7 +17,7 @@
 	export let valueCol = 'value';
 
 	export let valueFmt = undefined;
-	if(valueFmt){
+	if (valueFmt) {
 		valueFmt = getFormatObjectFromString(valueFmt);
 	}
 

--- a/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
@@ -6,12 +6,17 @@
 	import ECharts from './ECharts.svelte';
 
 	import { colours } from '@evidence-dev/component-utilities/colours';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 
 	export let data = undefined;
 	export let sourceCol = 'source';
 	export let targetCol = 'target';
 	export let valueCol = 'value';
+
+	export let valueFmt = undefined;
+	if(valueFmt){
+		valueFmt = getFormatObjectFromString(valueFmt);
+	}
 
 	export let title = undefined;
 	export let subtitle = undefined;
@@ -129,7 +134,7 @@
 					? `${formatValue(params.data.name)}`
 					: `${formatValue(params.data[sourceCol])} to ${formatValue(
 							params.data.target
-					  )}, ${formatValue(params.data.value)}`;
+					  )}: ${formatValue(params.data.value, valueFmt)}`;
 			},
 			padding: 6,
 			borderRadius: 4,

--- a/packages/core-components/src/lib/unsorted/viz/ScatterPlot.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ScatterPlot.svelte
@@ -12,6 +12,9 @@
 	export let series = undefined;
 	export let xType = undefined;
 
+	export let yFmt = undefined;
+	export let xFmt = undefined;
+
 	export let title = undefined;
 	export let subtitle = undefined;
 	export let legend = undefined;
@@ -49,6 +52,8 @@
 	{data}
 	{x}
 	{y}
+	{xFmt}
+	{yFmt}
 	{series}
 	{tooltipTitle}
 	{xType}

--- a/packages/core-components/src/lib/unsorted/viz/USMap.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/USMap.svelte
@@ -27,9 +27,6 @@
 	export let subtitle = undefined;
 
 	export let fmt = undefined;
-	if (fmt) {
-		fmt = getFormatObjectFromString(fmt);
-	}
 
 	export let link = undefined;
 	let hasLink = link !== undefined;
@@ -111,6 +108,11 @@
 		let maxValue = max ?? Math.max(...data.map((d) => d[value]));
 
 		columnSummary = getColumnSummary(data);
+
+		// Override format for values:
+		if (fmt) {
+			fmt = getFormatObjectFromString(fmt, columnSummary[value].format);
+		}
 
 		let mapData = JSON.parse(JSON.stringify(data));
 		for (let i = 0; i < data.length; i++) {

--- a/packages/core-components/src/lib/unsorted/viz/USMap.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/USMap.svelte
@@ -10,7 +10,10 @@
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { colours } from '@evidence-dev/component-utilities/colours';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 
 	export let data = undefined;
 
@@ -24,7 +27,7 @@
 	export let subtitle = undefined;
 
 	export let fmt = undefined;
-	if(fmt){
+	if (fmt) {
 		fmt = getFormatObjectFromString(fmt);
 	}
 
@@ -147,18 +150,12 @@
 					// Use axis to trigger tooltip
 					type: 'shadow' // 'shadow' as default; can also be 'line' or 'shadow'
 				},
-				formatter: function(params) {
+				formatter: function (params) {
 					let tooltipOutput = `
 						<span id="tooltip" style='font-weight: 600;'>${params.name}</span>
 						<br/>
-						<span>${formatTitle(
-								value,
-								fmt
-							)}: </span>
-							<span style='float:right; margin-left: 10px;'>${formatValue(
-								params.value,
-								fmt
-							)}</span>`;
+						<span>${formatTitle(value, fmt)}: </span>
+							<span style='float:right; margin-left: 10px;'>${formatValue(params.value, fmt)}</span>`;
 
 					return tooltipOutput;
 				},

--- a/packages/core-components/src/lib/unsorted/viz/USMap.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/USMap.svelte
@@ -10,6 +10,7 @@
 	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { colours } from '@evidence-dev/component-utilities/colours';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 
 	export let data = undefined;
 
@@ -21,6 +22,11 @@
 
 	export let title = undefined;
 	export let subtitle = undefined;
+
+	export let fmt = undefined;
+	if(fmt){
+		fmt = getFormatObjectFromString(fmt);
+	}
 
 	export let link = undefined;
 	let hasLink = link !== undefined;
@@ -140,6 +146,21 @@
 				axisPointer: {
 					// Use axis to trigger tooltip
 					type: 'shadow' // 'shadow' as default; can also be 'line' or 'shadow'
+				},
+				formatter: function(params) {
+					let tooltipOutput = `
+						<span id="tooltip" style='font-weight: 600;'>${params.name}</span>
+						<br/>
+						<span>${formatTitle(
+								value,
+								fmt
+							)}: </span>
+							<span style='float:right; margin-left: 10px;'>${formatValue(
+								params.value,
+								fmt
+							)}</span>`;
+
+					return tooltipOutput;
 				},
 				padding: 6,
 				borderRadius: 4,

--- a/packages/core-components/src/lib/unsorted/viz/Value.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Value.svelte
@@ -4,7 +4,7 @@
 
 <script>
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
-	import { formatValue } from '@evidence-dev/component-utilities/formatting';
+	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
 	import { convertColumnToDate } from '@evidence-dev/component-utilities/dateParsing';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import PulseNumber from './PulseNumber.svelte';
@@ -19,8 +19,13 @@
 	// Placeholder text when data not supplied:
 	export let placeholder = null;
 
+	// Value Formatting:
+	export let fmt = undefined;
+	if(fmt){
+		fmt = getFormatObjectFromString(fmt);
+	}
+
 	let value;
-	let fmt;
 	let error;
 
 	let columnSummary;
@@ -63,7 +68,9 @@
 
 					value = data[row][column];
 					columnSummary = columnSummary.filter((d) => d.id === column);
-					fmt = columnSummary[0].format;
+					if(!fmt){
+						fmt = columnSummary[0].format;
+					}
 				} else {
 					throw Error(
 						'No data provided. If you referenced a query result, check that the name is correct.'

--- a/packages/core-components/src/lib/unsorted/viz/Value.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Value.svelte
@@ -24,9 +24,6 @@
 
 	// Value Formatting:
 	export let fmt = undefined;
-	if (fmt) {
-		fmt = getFormatObjectFromString(fmt);
-	}
 
 	let value;
 	let error;
@@ -71,7 +68,9 @@
 
 					value = data[row][column];
 					columnSummary = columnSummary.filter((d) => d.id === column);
-					if (!fmt) {
+					if (fmt) {
+						fmt = getFormatObjectFromString(fmt, columnSummary[0].format.valueType);
+					} else {
 						fmt = columnSummary[0].format;
 					}
 				} else {

--- a/packages/core-components/src/lib/unsorted/viz/Value.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Value.svelte
@@ -4,7 +4,10 @@
 
 <script>
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
-	import { formatValue, getFormatObjectFromString } from '@evidence-dev/component-utilities/formatting';
+	import {
+		formatValue,
+		getFormatObjectFromString
+	} from '@evidence-dev/component-utilities/formatting';
 	import { convertColumnToDate } from '@evidence-dev/component-utilities/dateParsing';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import PulseNumber from './PulseNumber.svelte';
@@ -21,7 +24,7 @@
 
 	// Value Formatting:
 	export let fmt = undefined;
-	if(fmt){
+	if (fmt) {
 		fmt = getFormatObjectFromString(fmt);
 	}
 
@@ -68,7 +71,7 @@
 
 					value = data[row][column];
 					columnSummary = columnSummary.filter((d) => d.id === column);
-					if(!fmt){
+					if (!fmt) {
 						fmt = columnSummary[0].format;
 					}
 				} else {

--- a/packages/preprocess/src/process-queries.cjs
+++ b/packages/preprocess/src/process-queries.cjs
@@ -26,7 +26,7 @@ const createDefaultProps = function (filename, componentDevelopmentMode, fileQue
         import { setContext, getContext, beforeUpdate } from 'svelte';
         
         // Functions
-        import { formatValue as fmt } from '@evidence-dev/component-utilities/formatting';
+        import { fmt } from '@evidence-dev/component-utilities/formatting';
 
 		import { CUSTOM_FORMATTING_SETTINGS_CONTEXT_KEY } from '@evidence-dev/component-utilities/globalContexts';
         

--- a/sites/docs/docs/components/annotations.md
+++ b/sites/docs/docs/components/annotations.md
@@ -193,7 +193,7 @@ When a dataset is provided, `ReferenceArea` can generate multiple areas - one fo
 ##### Continuous Axis Bar Charts
 On a continous x-axis (dates or numbers), the reference area will start and stop at the exact point on the x-axis. This means it will appear in the middle of whichever bar is at that point. If you would prefer to see the area cover the full bar, there are 2 ways to achieve this:
 1. Add a buffer on either side of the range you want to highlight (e.g., instead of ending the area at `2020-07-01`, end it at `2020-07-15`)
-2. Change your x-axis to categorical data (using `xType=category`). If using a date axis, you may also want to retain the axis label formatting for dates - to achieve this, you can use a format tag for your x-axis column (e.g., `x=date_mmm`)
+2. Change your x-axis to categorical data (using `xType=category`). If using a date axis, you may also want to retain the axis label formatting for dates - to achieve this, you can use the `xFmt` prop (e.g., `xFmt=mmm`)
 
 #### Reference Area Box
 <img src="/img/refarea-box.png"  width='600px'/>

--- a/sites/docs/docs/components/area-chart.md
+++ b/sites/docs/docs/components/area-chart.md
@@ -67,6 +67,9 @@ hide_table_of_contents: false
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default sort is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>handleMissing</td>	<td>Treatment of missing values in the dataset</td>	<td class='tcenter'>-</td>	<td class='tcenter'>gap | connect | zero</td>	<td class='tcenter'>gap (single series) | zero (multi-series)</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+
 </table>
 
 ### Series

--- a/sites/docs/docs/components/bar-chart.md
+++ b/sites/docs/docs/components/bar-chart.md
@@ -159,6 +159,8 @@ If you create a bar chart with many x-axis items (e.g., names of departments), E
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default sort is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false </td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 </table>
 
 ### Series

--- a/sites/docs/docs/components/big-value.md
+++ b/sites/docs/docs/components/big-value.md
@@ -101,4 +101,18 @@ Multiple cards will align themselves into a row.
         <td class='tcenter'>% or px value</td>	
         <td class='tcenter'>none</td>
     </tr>
+    <tr>	
+        <td>fmt</td>	
+        <td>Sets format for the value (<a href='/core-concepts/formatting'>see available formats</a>)</td>	
+        <td class='tcenter'>-</td>	
+        <td class='tcenter'>Excel-style format | built-in format | custom format</td>	
+        <td class='tcenter'>-</td>
+    </tr>
+    <tr>	
+        <td>comparisonFmt</td>	
+        <td>Sets format for the comparison (<a href='/core-concepts/formatting'>see available formats</a>)</td>	
+        <td class='tcenter'>-</td>	
+        <td class='tcenter'>Excel-style format | built-in format | custom format</td>	
+        <td class='tcenter'>-</td>
+    </tr>
 </table>

--- a/sites/docs/docs/components/bubble-chart.md
+++ b/sites/docs/docs/components/bubble-chart.md
@@ -73,6 +73,9 @@ hide_table_of_contents: false
 <tr>	<td>fillColor</td>	<td>Color to override default series color. Only accepts a single color.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>CSS name | hexademical | RGB | HSL</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>outlineWidth</td>	<td>Width of line surrounding each shape</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>0</td>	</tr>
 <tr>	<td>outlineColor</td>	<td>Color to use for outline if outlineWidth > 0</td>	<td class='tcenter'>-</td>	<td class='tcenter'>CSS name | hexademical | RGB | HSL</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>sizeFmt</td>	<td>Format to use for size column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 </table>
 
 ### Chart

--- a/sites/docs/docs/components/data-table.md
+++ b/sites/docs/docs/components/data-table.md
@@ -301,6 +301,13 @@ Use the `Column` component to choose specific columns to display in your table, 
         <td class='tcenter'>left</td>
     </tr>
     <tr>	
+        <td>fmt</td>
+        <td>Format the values in the column (<a href='/core-concepts/formatting'>see available formats</a>)</td>
+        <td class='tcenter'>-</td>
+        <td class='tcenter'>Excel-style format | built-in format | custom format</td>
+        <td class='tcenter'>-</td>
+    </tr>
+    <tr>	
         <td>wrap</td>
         <td>Wrap column text</td>
         <td class='tcenter'>-</td>

--- a/sites/docs/docs/components/funnel-chart.md
+++ b/sites/docs/docs/components/funnel-chart.md
@@ -51,6 +51,7 @@ hide_table_of_contents: false
 <tr> <td>data</td> <td>Query name, wrapped in curly braces</td> <td class='tcenter'>Yes</td> <td class='tcenter'>query name</td> <td class='tcenter'>-</td> </tr>
 <tr> <td>nameCol</td> <td>Column to use for the name of the chart</td> <td class='tcenter'>Yes</td> <td class='tcenter'>column name</td> <td class='tcenter'>-</td> </tr>
 <tr> <td>valueCol</td> <td>Column to use for the value of the chart</td> <td class='tcenter'>Yes</td> <td class='tcenter'>column name</td> <td class='tcenter'>-</td> </tr>
+<tr> <td>valueFmt</td> <td>Format to use for `valueCol` (<a href='/core-concepts/formatting'>see available formats</a>)</td> <td class='tcenter'>-</td> <td class='tcenter'>Excel-style format | built-in format | custom format</td> <td class='tcenter'>-</td> </tr>
 
 </table>
 

--- a/sites/docs/docs/components/histogram.md
+++ b/sites/docs/docs/components/histogram.md
@@ -35,6 +35,7 @@ hide_table_of_contents: false
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
 <tr>	<td>data</td>	<td>Query name, wrapped in curly braces</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>query name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>x</td>	<td>Column which contains the data you want to summarize</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>First column</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 </table>
 
 ### Series

--- a/sites/docs/docs/components/line-chart.md
+++ b/sites/docs/docs/components/line-chart.md
@@ -76,6 +76,8 @@ Evidence will automatically pick the first column as `x` and use all other numer
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>handleMissing</td>	<td>Treatment of missing values in the dataset</td>	<td class='tcenter'>-</td>	<td class='tcenter'>gap | connect | zero</td>	<td class='tcenter'>gap</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 </table>
 
 ### Series

--- a/sites/docs/docs/components/mixed-type-charts.md
+++ b/sites/docs/docs/components/mixed-type-charts.md
@@ -51,6 +51,9 @@ This structure also gives you control over the individual series on your chart. 
 <tr>	<td>y</td>	<td>Column(s) to use for the y-axis of the chart</td>	<td class='tcenter'>Yes</td>	<td class='tcenter'>column name | array of column names</td>	<td class='tcenter'>Any non-assigned numeric columns</td>	</tr>
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+
 </table>
 
 #### Chart Props

--- a/sites/docs/docs/components/sankey-diagram.md
+++ b/sites/docs/docs/components/sankey-diagram.md
@@ -39,6 +39,7 @@ hide_table_of_contents: false
 <tr> <td>sourceCol</td> <td>Column to use for the source of the diagram</td> <td class='tcenter'>Yes</td> <td class='tcenter'>column name</td> <td class='tcenter'>-</td> </tr>
 <tr> <td>tagretCol</td> <td>Column to use for the target of the diagram</td> <td class='tcenter'>Yes</td> <td class='tcenter'>column name</td> <td class='tcenter'>-</td> </tr>
 <tr> <td>valueCol</td> <td>Column to use for the value of the diagram</td> <td class='tcenter'>Yes</td> <td class='tcenter'>column name</td> <td class='tcenter'>-</td> </tr>
+<tr> <td>valueFmt</td> <td>Format to use for `valueCol` (<a href='/core-concepts/formatting'>see available formats</a>)</td> <td class='tcenter'>-</td> <td class='tcenter'>Excel-style format | built-in format | custom format</td> <td class='tcenter'>-</td> </tr>
 
 </table>
 

--- a/sites/docs/docs/components/scatter-plot.md
+++ b/sites/docs/docs/components/scatter-plot.md
@@ -57,6 +57,8 @@ hide_table_of_contents: false
 <tr>	<td>sort</td>	<td>Whether to apply default sort to your data. Default is x ascending for number and date x-axes, and y descending for category x-axes</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
 <tr>	<td>series</td>	<td>Column to use as the series (groups) in a multi-series chart</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>tooltipTitle</td>	<td>Column to use as the title for each tooltip. Typically, this is a name to identify each point.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>xFmt</td>	<td>Format to use for x column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>yFmt</td>	<td>Format to use for y column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | buil-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 </table>
 
 ### Series

--- a/sites/docs/docs/components/us-map.md
+++ b/sites/docs/docs/components/us-map.md
@@ -139,4 +139,10 @@ hide_table_of_contents: false
         <td class='tcenter'>column name</td>	
         <td class='tcenter'>-</td>
     </tr>
+    <tr>	
+        <td>fmt</td>	
+        <td>Format to use for values (<a href='/core-concepts/formatting'>see available formats</a>)</td>	
+        <td class='tcenter'>Excel-style format | built-in format | custom format</td>	
+        <td class='tcenter'>-</td>
+    </tr>
 </table>

--- a/sites/docs/docs/components/value.md
+++ b/sites/docs/docs/components/value.md
@@ -15,7 +15,11 @@ By default, `Value` will display the value from the first row of the first colum
 
 ## Specifying Rows and Columns
 
-Optionally supply a `column` and/or a `row` argument to display other values from `data`. `row` is zero-indexed, so `row=0` displays the first row.
+Optionally supply a `column` and/or a `row` argument to display other values from `data`. 
+
+:::info Row index
+`row` is zero-indexed, so `row=0` displays the first row.
+:::
 
 ```markdown
 <!-- Show the **7th row** from column_name -->
@@ -49,6 +53,9 @@ Override errors with the optional `placeholder` argument. This is useful for dra
 
 ![value-placeholder](/img/value-placeholder.png)
 
+## Formatting Values
+Evidence supports a variety of formats - see [value formatting](/core-concepts/formatting) and the `fmt` prop below for more info.
+
 ## All Options
 
 <table>						 
@@ -80,6 +87,12 @@ Override errors with the optional `placeholder` argument. This is useful for dra
         <td>placeholder</td>	
         <td>Text to display in place of an error</td>	
         <td class='tcenter'>-</td>	
+        <td class='tcenter'>-</td>
+    </tr>
+    <tr>	
+        <td>fmt</td>	
+        <td>Format to use for the value (<a href='/core-concepts/formatting'>see available formats</a>)</td>	
+        <td class='tcenter'>Excel-style format | built-in format | custom format</td>	
         <td class='tcenter'>-</td>
     </tr>
 </table>

--- a/sites/docs/docs/core-concepts/formatting/_category_.json
+++ b/sites/docs/docs/core-concepts/formatting/_category_.json
@@ -1,4 +1,4 @@
 {
-	"label": "Number Formatting",
+	"label": "Value Formatting",
 	"position": 5
 }

--- a/sites/docs/docs/core-concepts/formatting/index.md
+++ b/sites/docs/docs/core-concepts/formatting/index.md
@@ -5,7 +5,7 @@ title: 'Value Formatting'
 description: 'Number and date formatting options in Evidence'
 ---
 
-The easiest way to format numbers and dates in Evidence is through component props. You can pass in any of the follwing:
+The easiest way to format numbers and dates in Evidence is through component props. You can pass in any of the following:
 - Excel-style format codes
 - Evidence's [built-in formats](#built-in-formats)
 - [Custom formats](#custom-formats)

--- a/sites/docs/docs/core-concepts/formatting/index.md
+++ b/sites/docs/docs/core-concepts/formatting/index.md
@@ -1,78 +1,75 @@
 ---
 sidebar_position: 5
 hide_table_of_contents: false
-title: 'Number Formatting'
-description: 'Formats are defined using the column names in your SQL query'
+title: 'Value Formatting'
+description: 'Number and date formatting options in Evidence'
 ---
 
-[Format tags](#format-tags) are the primary way to format numbers and dates in Evidence. Format tags are appended to column names in your SQL query to format how they are displayed in components.
+The easiest way to format numbers and dates in Evidence is through component props. You can pass in any of the follwing:
+- Excel-style format codes
+- Evidence's [built-in formats](#built-in-formats)
+- [Custom formats](#custom-formats)
 
-[The format function](#format-function) can be used directly, when using numbers outside components. For example, when using [expressions](../syntax/#expressions) it is not possible to use format tags.
+For example, you can use the `fmt` prop to format values inside a Value component:
 
-## Format Tags
+```html
+<Value data={sales_data} column=sales fmt='$#,##0' />
+```
 
-Formats for numbers and dates are defined using the column names in your SQL query.
+Within charts, you can format individual columns using `xFmt` and `yFmt` (and `sizeFmt` for bubble charts):
 
-A **format tag** can be appended to your column name to ensure the right format (see table below for accepted tags).
+```html
+<LineChart 
+    data={sales_data} 
+    x=date 
+    y=sales 
+    xFmt="m/d"
+    yFmt="eur"
+/>
+```
 
-Format tags are appended with an underscore: for example, to append the percentage format to a column named `growth`, it would be `growth_pct`.
+In the example above, `xFmt` is passing in an Excel-style code to format the dates and `yFmt` is referencing a built-in format ([see the full list](#built-in-formats) of supported tags below, or [create your own](#custom-formats)).
 
-Formatting can be configured in the Value Formatting Section of the Evidence Settings.
+:::info Date formatting
+Formatting does not apply to the date axis of a chart. For example, if you set `xFmt` to `m/d/yy`, you will only see that formatting reflected in your chart tooltips and annotations. This is to ensure that the chart axis labels have the correct spacing.
+:::
 
-Format tags are case-insensitive, so `growth_pct` and `GROWTH_PCT` are equivalent.
 
-### Built-in Value Format Tags
+#### Reusable Formats
+For a more reusable approach, you can use [SQL format tags](#sql-format-tags), which let you define formats within your SQL. This guarantees that your columns will be formatted in the same way wherever they are used in Evidence.
 
-Evidence supports a variety of date/time, number, percentage, and currency formats. You can find the full list of format tags [below](#format-reference)
+You can also create your own [custom formats](#custom-formats), which are format codes you can reuse across your project.
 
-### Custom Value Format Tags
+#### Formatting Directly in Markdown
+If you need to format values outside of components, [the format function](#format-function) can be used directly. For example, when using [expressions](/core-concepts/syntax#expressions) it is not possible to use component props or format tags.
 
-Custom formats can be added in the Value Formatting Section of the Evidence Settings. Formats can be coded using [Excel style custom format codes](https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68).
+## Supported Formats
 
-### Title Formatting
+### Excel Format Codes
+Evidence supports [Excel style custom format codes](https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68), which can be passed directly to a component prop, the [format function](#format-function), or saved as a [custom format code](#custom-formats) that you want to reuse.
 
-When creating a table, Evidence formats column titles based on the name of the column and its format tag. Format tags that do not add to the meaning of the column name are not printed as part of the title.
+:::info Including strings inside formats
+To include a string inside an Excel-style format code, you need to use double-quotes to surround the string, and single-quotes to surround the format code. For example, in a chart you might use `yFmt = '#,##0.00 "mpg"'`
+:::
 
-#### Examples
-
-<table>
-<tr>
-<th>Column Name</th>
-<th>Formatted Title</th>
-</tr>
-<tr>
-<td>sales_usd</td>
-<td>Sales ($)</td>
-</tr>
-<tr>
-<td>customer_id</td>
-<td>Customer ID</td>
-</tr>
-<tr>
-<td>growth_pct</td>
-<td>Growth</td>
-</tr>
-<tr>
-<td>customer_number_num2k</td>
-<td>Customer Number</td>
-</tr>
-</table>
-
-### Large Numbers
-
-Evidence automatically formats large numbers into shortened versions based on the size of the median number in a column (e.g., 4,000,000 &rarr; 4M).
-
-You can choose to handle these numbers differently by choosing a specific format code. For example, if Evidence is formatting a column as millions, but you want to see all numbers in thousands, you could use the `num0k` format tag, which will show all numbers in the column in thousands with 0 decimal places.
-
-### Format Reference
+### Built-in Formats
+Evidence supports a variety of date/time, number, percentage, and currency formats. You can find the full list of formats below.
 
 <!-- These are pasted in from the settings menu HTML, with edits -->
+
+#### Auto-Formatting
+
+Wherever you see `auto` listed beside a format, that means Evidence will automatically format your value based on the context it is in.
+
+For example, Evidence automatically formats large numbers into shortened versions based on the size of the median number in a column (e.g., 4,000,000 &rarr; 4M).
+
+You can choose to handle these numbers differently by choosing a specific format code. For example, if Evidence is formatting a column as millions, but you want to see all numbers in thousands, you could use the `num0k` format, which will show all numbers in the column in thousands with 0 decimal places.
 
 #### Dates
 
 <table class="wide">
 <thead >
-    <th class="align_left narrow_column">Format Tag</th>
+    <th class="align_left narrow_column">Format Name</th>
     <th class="align_left wide_column">Format Code</th>
     <th class="align_left wide_column">Example Input</th>
     <th class="tright wide_column">Example Output</th>
@@ -176,7 +173,7 @@ For example, the available tags for USD are:
 
 <table>
 <thead>
-    <th class="align_left narrow_column">Format Tag</th> 
+    <th class="align_left narrow_column">Format Name</th> 
     <th class="align_left wide_column">Format Code</th> 
     <th class="align_left wide_column">Example Input</th> 
     <th class="tright wide_column">Example Output</th>
@@ -267,7 +264,7 @@ For example, the available tags for USD are:
 
 <table>
 <thead>
-    <th class="align_left narrow_column">Format Tag</th> 
+    <th class="align_left narrow_column">Format Name</th> 
     <th class="align_left wide_column">Format Code</th> 
     <th class="align_left wide_column">Example Input</th> 
     <th class="tright wide_column">Example Output</th>
@@ -406,7 +403,7 @@ For example, the available tags for USD are:
 
 <table>
 <thead>
-    <th class="align_left narrow_column">Format Tag</th> 
+    <th class="align_left narrow_column">Format Name</th> 
     <th class="align_left wide_column">Format Code</th> 
     <th class="align_left wide_column">Example Input</th> 
     <th class="tright wide_column">Example Output</th>
@@ -446,21 +443,72 @@ For example, the available tags for USD are:
 </table>
 
 
-## Format Function
+### Custom Formats
 
-The format function is used to format expressions which return _numbers_. The format function _cannot_ be used to format dates or times. The syntax is:
+Custom formats can be added in the Value Formatting Section of the Evidence Settings. 
 
-```javascript
-fmt(expression, formatCode)
+With custom formats, you define the format you want to use (using [Excel style custom format codes](https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68)), and give the format a name (e.g., `mydate`). That format name will now be accessible in any place you can format your data in Evidence. For example:
+
+```html
+<Value data={sales_data} column=date fmt=mydate />
 ```
 
-This is useful when you cannot use a component.
+
+## SQL Format Tags
+
+SQL format tags let you define formats for your columns within your SQL query. This ensures that columns are formatted in the same way wherever they are used.
+
+A **format tag** is appended to your column name with an underscore: for example, to append the percentage format to a column named `growth`, it would be `growth_pct`.
+
+Formatting can be configured in the Value Formatting Section of the Evidence Settings.
+
+Format tags are case-insensitive, so `growth_pct` and `GROWTH_PCT` are equivalent.
+
+### Title Formatting
+
+When creating a table, Evidence formats column titles based on the name of the column and its format tag. Format tags that do not add to the meaning of the column name are not printed as part of the title. All columns are printed with proper casing.
+
+#### Examples
+
+<table>
+<tr>
+<th>Column Name</th>
+<th>Formatted Title</th>
+</tr>
+<tr>
+<td>sales_usd</td>
+<td>Sales ($)</td>
+</tr>
+<tr>
+<td>customer_id</td>
+<td>Customer ID</td>
+</tr>
+<tr>
+<td>growth_pct</td>
+<td>Growth</td>
+</tr>
+<tr>
+<td>customer_number_num2k</td>
+<td>Customer Number</td>
+</tr>
+</table>
 
 
+## Format Function
 
-:::info Format Codes
-The format function, `fmt()` accepts Excel style format codes, not format tags
-:::
+The format function is used to format expressions within markdown. This is useful when you cannot use a component.
+
+The syntax is:
+
+```javascript
+{fmt(expression, formatCode)}
+```
+
+`formatCode` can be any one of the following:
+- An Excel-style format code (e.g., `$#,##0.0`)
+- A built-in Evidence format (e.g., `eur`)
+- A custom-defined format code (see section above on custom formats)
+
 
 ### Example
 

--- a/sites/docs/docs/getting-started/install-evidence.md
+++ b/sites/docs/docs/getting-started/install-evidence.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
 <TabItem value="vscode" label="VSCode Extension" default>
 
-1. Download the Evidence Extensinon from the VSCode Marketplace
+1. Download the Evidence Extension from the VSCode Marketplace
 2. Open the Command Palette (F1) and enter `Evidence: New Evidence Project` to create a new project
 3. Click `Start Evidence`
 

--- a/sites/example-project/src/pages/charts/line-chart/+page.md
+++ b/sites/example-project/src/pages/charts/line-chart/+page.md
@@ -84,6 +84,8 @@ select '2023-04-14' as start_date, null as end_date, 'Campaign C' as label
     x=month
     y=sales_usd0k 
     yAxisTitle="Sales per Month"
+    yFmt=eur
+    xFmt='mmm d'
 />
 
 ## Multi-Series Line


### PR DESCRIPTION
### Description
This PR adds formatting control to components. It adds a new function to take a string and return an Evidence formatting object, as well as props for each component to accept formats from users.

Closes #709 

![CleanShot 2023-06-20 at 18 32 39](https://github.com/evidence-dev/evidence/assets/12602440/cf0e1a05-58e4-4443-86df-66b47bb7fec3)

### Setting a Format
The new format props accept a string. The format can be in any one of the categories below:
- Custom Format Tag
- Evidence Built-in Format Tag
- Excel-style format code

### New Props

#### Charts:
- `xFmt`
- `yFmt`
- `sizeFmt` (for BubbleChart)
- `valueFmt` (for Sankey and Funnel Charts)

#### Tables
In the `Column` component:
- `fmt`

#### Value Component
- `fmt`

#### BigValue Component
- `fmt`
- `comparisonFmt`

#### Annotations
In ReferenceLine:
- ReferenceLine inherits the formatting of whichever column you're using
- Adding a `valueFmt` override was initially considered, but is not included in this PR

## Limitations
- Formatting of date axes on charts cannot be overridden at this time. You can still pass in a format, but it will only be used for tooltip or annotation formatting


### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

