### PR TITLE
Standardize dates to ISO string during CSV export

### DIFF
--- a/.changeset/chatty-tomatoes-laugh.md
+++ b/.changeset/chatty-tomatoes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+standardize exported date strings to ISO

--- a/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
@@ -24,7 +24,7 @@
 			useKeysAsHeaders: true
 		};
 
-        const data_copy = JSON.parse(JSON.stringify(data));
+		const data_copy = JSON.parse(JSON.stringify(data));
 
 		const csvExporter = new ExportToCsv(options);
 

--- a/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
@@ -24,17 +24,11 @@
 			useKeysAsHeaders: true
 		};
 
-		for (const row of data) {
-			for (const key in row) {
-				if (row[key] instanceof Date) {
-					row[key] = row[key].toISOString();
-				}
-			}
-		}
+        const data_copy = JSON.parse(JSON.stringify(data));
 
 		const csvExporter = new ExportToCsv(options);
 
-		csvExporter.generateCsv(data);
+		csvExporter.generateCsv(data_copy);
 	};
 </script>
 

--- a/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/DownloadData.svelte
@@ -24,6 +24,14 @@
 			useKeysAsHeaders: true
 		};
 
+		for (const row of data) {
+			for (const key in row) {
+				if (row[key] instanceof Date) {
+					row[key] = row[key].toISOString();
+				}
+			}
+		}
+
 		const csvExporter = new ExportToCsv(options);
 
 		csvExporter.generateCsv(data);


### PR DESCRIPTION
### Description

Converts date values to ISO strings before exporting to CSV

Does it by running it through `JSON.parse(JSON.stringify(data))` (which calls `.toISOString()` on the dates) to avoid modifying the original data

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
