### PR TITLE
Fix for grouped bar charts

### DIFF
--- a/.changeset/smooth-dolls-smile.md
+++ b/.changeset/smooth-dolls-smile.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix for grouped bar charts

--- a/packages/core-components/src/lib/unsorted/viz/Bar.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Bar.svelte
@@ -84,7 +84,7 @@
 			// Set up stacks
 			stackName = stackName ?? 'stack1';
 		} else {
-			stackName = 'stack1';
+			stackName = undefined;
 		}
 	}
 

--- a/packages/core-components/src/lib/unsorted/viz/ReferenceArea.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ReferenceArea.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script>
-	import { getContext } from 'svelte';
+	import { getContext, beforeUpdate } from 'svelte';
 	import { propKey, configKey } from './context';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ErrorChart from './ErrorChart.svelte';
@@ -194,6 +194,34 @@
 			return d;
 		});
 	}
+
+	$: chartOverrides = {
+		// Evidence definition of axes (yAxis = dependent, xAxis = independent)
+		xAxis: {
+			axisTick: {
+				alignWithLabel: false
+			}
+		}
+	};
+
+	beforeUpdate(() => {
+		// beforeUpdate ensures that these overrides always run before we render the chart.
+		// otherwise, this block won't re-execute after a change to the data object, and
+		// the chart will re-render using the base config from Chart.svelte
+
+		if (chartOverrides) {
+			config.update((d) => {
+				if (swapXY) {
+					d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
+					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
+				} else {
+					d.yAxis = { ...d.yAxis, ...chartOverrides.yAxis };
+					d.xAxis = { ...d.xAxis, ...chartOverrides.xAxis };
+				}
+				return d;
+			});
+		}
+	});
 </script>
 
 {#if error}


### PR DESCRIPTION
### Description
Due to a change introduced with ReferenceArea, grouped bar charts were being overridden and changed to stacked bar charts. This PR fixes that issue.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
