### PR TITLE
Resolve extra margin on code element (class: 'my-2') fixed issues wit…

### DIFF
--- a/packages/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -44,8 +44,8 @@
 		</button>
 		{/if}
 		</div>
-<code class="my-2"
-		>{#if source}{source}
+<code>
+		{#if source}{source}
 		{:else}<slot />
 		{/if}
 </code>		


### PR DESCRIPTION
### Description

Issue number: #966

> Resolves the extra margin issue on the "< code >" element with the class "my-2".

### Checklist

- [x] before 
![image](https://github.com/evidence-dev/evidence/assets/136234404/a97c7894-9d37-4610-a662-d42dc6473668)

- [x] after 
![image](https://github.com/evidence-dev/evidence/assets/136234404/e6d72e83-6e49-47d6-9cd4-2c40cd64851d)

- [x] full component
![image](https://github.com/evidence-dev/evidence/assets/136234404/bb0fe4e3-def1-4d87-a00a-b8264d4fc76c)

- [x] pnpm version 7.30.1
![image](https://github.com/evidence-dev/evidence/assets/136234404/90562269-7c91-41ce-8dca-7050c9838c73)



