### PR TITLE
Enable classes to be added to markdown-generated tags

### DIFF
--- a/.changeset/warm-crews-sparkle.md
+++ b/.changeset/warm-crews-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/preprocess': patch
+---
+
+added ability for classes to be added to markdown-generated tags

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -2,7 +2,7 @@ const mdsvex = require('mdsvex');
 const { highlighter } = require('./src/utils/highlighter.cjs');
 const addScriptTags = require('./src/add-script-tags.cjs');
 const processQueries = require('./src/process-queries.cjs');
-const addClasses = require("./src/add-classes.cjs");
+const addClasses = require('./src/add-classes.cjs');
 // This is includes future proofing to add support for Prism highlighting
 const processFrontmatter = require('./src/frontmatter/process-frontmatter.cjs');
 
@@ -20,7 +20,14 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 			highlight: {
 				highlighter
 			},
-            rehypePlugins: [[addClasses, { /* 'p': 'is-md' */ }]]
+			rehypePlugins: [
+				[
+					addClasses,
+					{
+						/* 'p': 'is-md' */
+					}
+				]
+			]
 		}),
 		// Add both script tags to all markdown files, if they are missing
 		addScriptTags,

--- a/packages/preprocess/index.cjs
+++ b/packages/preprocess/index.cjs
@@ -2,6 +2,7 @@ const mdsvex = require('mdsvex');
 const { highlighter } = require('./src/utils/highlighter.cjs');
 const addScriptTags = require('./src/add-script-tags.cjs');
 const processQueries = require('./src/process-queries.cjs');
+const addClasses = require("./src/add-classes.cjs");
 // This is includes future proofing to add support for Prism highlighting
 const processFrontmatter = require('./src/frontmatter/process-frontmatter.cjs');
 
@@ -18,7 +19,8 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 			},
 			highlight: {
 				highlighter
-			}
+			},
+            rehypePlugins: [[addClasses, { /* 'p': 'is-md' */ }]]
 		}),
 		// Add both script tags to all markdown files, if they are missing
 		addScriptTags,

--- a/packages/preprocess/package.json
+++ b/packages/preprocess/package.json
@@ -17,6 +17,7 @@
 		"blueimp-md5": "^2.19.0",
 		"chalk": "4.1.0",
 		"fs-extra": "^9.1.0",
+		"hast-util-select": "^5.0.5",
 		"mdsvex": "^0.10.6",
 		"prismjs": "^1.29.0",
 		"remark-parse": "8.0.2",

--- a/packages/preprocess/src/add-classes.cjs
+++ b/packages/preprocess/src/add-classes.cjs
@@ -1,0 +1,18 @@
+const selector = require('hast-util-select');
+
+const { selectAll } = selector;
+
+module.exports = additions => {
+    const adders = Object.entries(additions).map(adder);
+    return node => adders.forEach(a => a(node));
+};
+
+const adder = ([selector, className]) => {
+    const writer = write(className);
+    return node => selectAll(selector, node).forEach(writer);
+};
+
+const write = className => ({ properties }) => {
+    if(!properties.className) properties.className = className;
+    else properties.className += ` ${className}`;
+};

--- a/packages/preprocess/src/add-classes.cjs
+++ b/packages/preprocess/src/add-classes.cjs
@@ -2,17 +2,19 @@ const selector = require('hast-util-select');
 
 const { selectAll } = selector;
 
-module.exports = additions => {
-    const adders = Object.entries(additions).map(adder);
-    return node => adders.forEach(a => a(node));
+module.exports = (additions) => {
+	const adders = Object.entries(additions).map(adder);
+	return (node) => adders.forEach((a) => a(node));
 };
 
 const adder = ([selector, className]) => {
-    const writer = write(className);
-    return node => selectAll(selector, node).forEach(writer);
+	const writer = write(className);
+	return (node) => selectAll(selector, node).forEach(writer);
 };
 
-const write = className => ({ properties }) => {
-    if(!properties.className) properties.className = className;
-    else properties.className += ` ${className}`;
+const write = (className) => {
+	return ({ properties }) => {
+		if (!properties.className) properties.className = className;
+		else properties.className += ` ${className}`;
+	};
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,7 @@ importers:
       blueimp-md5: ^2.19.0
       chalk: 4.1.0
       fs-extra: ^9.1.0
+      hast-util-select: ^5.0.5
       jest: ^28.1.3
       mdsvex: ^0.10.6
       parcel: ^2.8.3
@@ -438,6 +439,7 @@ importers:
       blueimp-md5: 2.19.0
       chalk: 4.1.0
       fs-extra: 9.1.0
+      hast-util-select: 5.0.5
       mdsvex: 0.10.6_svelte@3.55.0
       prismjs: 1.29.0
       remark-parse: 8.0.2
@@ -8726,6 +8728,10 @@ packages:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
 
+  /bcp-47-match/2.0.3:
+    resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
+    dev: false
+
   /better-opn/2.1.1:
     resolution: {integrity: sha512-kIPXZS5qwyKiX/HcRvDYfmBQUa8XP17I0mYZZ0y4UhpYOSvtsLHDYqmomS+Mj20aDvD3knEiQ0ecQy2nhio3yA==}
     engines: {node: '>8.0.0'}
@@ -9469,6 +9475,10 @@ packages:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
     dev: false
 
+  /comma-separated-tokens/2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+    dev: false
+
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -9820,6 +9830,10 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       nth-check: 2.1.1
+    dev: false
+
+  /css-selector-parser/1.4.1:
+    resolution: {integrity: sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==}
     dev: false
 
   /css-tree/1.0.0-alpha.37:
@@ -10373,6 +10387,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+
+  /direction/2.0.1:
+    resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
+    hasBin: true
+    dev: false
 
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -12343,6 +12362,10 @@ packages:
       web-namespaces: 1.1.4
     dev: false
 
+  /hast-util-has-property/2.0.1:
+    resolution: {integrity: sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==}
+    dev: false
+
   /hast-util-is-element/1.1.0:
     resolution: {integrity: sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==}
     dev: false
@@ -12366,6 +12389,26 @@ packages:
       zwitch: 1.0.5
     dev: false
 
+  /hast-util-select/5.0.5:
+    resolution: {integrity: sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      '@types/unist': 2.0.6
+      bcp-47-match: 2.0.3
+      comma-separated-tokens: 2.0.3
+      css-selector-parser: 1.4.1
+      direction: 2.0.1
+      hast-util-has-property: 2.0.1
+      hast-util-to-string: 2.0.0
+      hast-util-whitespace: 2.0.1
+      not: 0.1.0
+      nth-check: 2.1.1
+      property-information: 6.2.0
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 4.1.2
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-parse5/6.0.0:
     resolution: {integrity: sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==}
     dependencies:
@@ -12376,12 +12419,22 @@ packages:
       zwitch: 1.0.5
     dev: false
 
+  /hast-util-to-string/2.0.0:
+    resolution: {integrity: sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==}
+    dependencies:
+      '@types/hast': 2.3.4
+    dev: false
+
   /hast-util-to-text/2.0.1:
     resolution: {integrity: sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==}
     dependencies:
       hast-util-is-element: 1.1.0
       repeat-string: 1.6.1
       unist-util-find-after: 3.0.0
+    dev: false
+
+  /hast-util-whitespace/2.0.1:
+    resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
     dev: false
 
   /hastscript/6.0.0:
@@ -15423,6 +15476,10 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
+  /not/0.1.0:
+    resolution: {integrity: sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA==}
+    dev: false
+
   /npm-bundled/2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -17205,6 +17262,10 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /property-information/6.2.0:
+    resolution: {integrity: sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==}
+    dev: false
+
   /proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -18710,6 +18771,10 @@ packages:
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
+
+  /space-separated-tokens/2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+    dev: false
 
   /spawndamnit/2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
@@ -21638,4 +21703,8 @@ packages:
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+    dev: false
+
+  /zwitch/2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false


### PR DESCRIPTION
### Description

Allows for styling targeting markdown generated tags. `rehype-add-classes` was misconfigured(?) so the functionality was just put in `src/add-classes.cjs`

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)



*edit* resolves #919 