### PR TITLE
Get DuckDB type information from result types instead of inferring

### DIFF
--- a/.changeset/ninety-berries-yell.md
+++ b/.changeset/ninety-berries-yell.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/duckdb': patch
+---
+
+get precise types instead of inferring

--- a/packages/duckdb/test/test.js
+++ b/packages/duckdb/test/test.js
@@ -23,7 +23,7 @@ test('query runs', async () => {
 
 		let expectedColumnTypes = ['number', 'date', 'date', 'string', 'boolean'];
 		let expectedColumnNames = ['number_col', 'date_col', 'timestamp_col', 'string_col', 'bool_col'];
-		let expectedTypePrecision = Array(5).fill(TypeFidelity.INFERRED);
+		let expectedTypePrecision = Array(5).fill(TypeFidelity.PRECISE);
 
 		assert.equal(
 			true,


### PR DESCRIPTION
### Description

Gets the types based on the returned objects instead of inferring, partial fix for #927 

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
