### PR TITLE
shove all `duckdb-wasm` deps into `universal-sql`

### DIFF
--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -61,8 +61,7 @@
 		"svelte2tsx": "0.6.0",
 		"tailwindcss": "^3.3.1",
 		"typescript": "4.9.5",
-		"unist-util-visit": "4.1.2",
-		"@duckdb/duckdb-wasm": "1.27.0"
+		"unist-util-visit": "4.1.2"
 	},
 	"engines": {
 		"node": "^16.14 || >=18"

--- a/packages/universal-sql/package.json
+++ b/packages/universal-sql/package.json
@@ -14,9 +14,7 @@
 	"dependencies": {
 		"chalk": "^5.2.0",
 		"duckdb": "^0.8.1",
-		"parquet-wasm": "0.3.1"
-	},
-	"peerDependencies": {
+		"parquet-wasm": "0.3.1",
 		"@duckdb/duckdb-wasm": "^1.27.0",
 		"apache-arrow": "^11.0.0"
 	},

--- a/packages/universal-sql/src/client-duckdb/browser.d.ts
+++ b/packages/universal-sql/src/client-duckdb/browser.d.ts
@@ -1,3 +1,5 @@
+export { tableFromIPC } from 'apache-arrow';
+
 /**
  * Initializes the database.
  *

--- a/packages/universal-sql/src/client-duckdb/browser.js
+++ b/packages/universal-sql/src/client-duckdb/browser.js
@@ -6,6 +6,8 @@ import {
 	getPlatformFeatures
 } from '@duckdb/duckdb-wasm';
 
+export { tableFromIPC } from 'apache-arrow';
+
 /** @type {import("@duckdb/duckdb-wasm").AsyncDuckDB} */
 let db;
 

--- a/packages/universal-sql/src/client-duckdb/node.d.ts
+++ b/packages/universal-sql/src/client-duckdb/node.d.ts
@@ -1,3 +1,5 @@
+export { tableFromIPC } from 'apache-arrow';
+
 /**
  * Initializes the database.
  *

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -11,6 +11,8 @@ import { cache_for_hash } from '../cache-duckdb.js';
 const require = createRequire(import.meta.url);
 const DUCKDB_DIST = dirname(require.resolve('@duckdb/duckdb-wasm'));
 
+export { tableFromIPC } from 'apache-arrow';
+
 /** @type {import("@duckdb/duckdb-wasm/dist/types/src/bindings/bindings_node_base").DuckDBNodeBindings} */
 let db;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,10 +548,14 @@ importers:
 
   packages/universal-sql:
     specifiers:
+      '@duckdb/duckdb-wasm': ^1.27.0
+      apache-arrow: ^11.0.0
       chalk: ^5.2.0
       duckdb: ^0.8.1
       parquet-wasm: 0.3.1
     dependencies:
+      '@duckdb/duckdb-wasm': 1.27.0
+      apache-arrow: 11.0.0
       chalk: 5.3.0
       duckdb: 0.8.1
       parquet-wasm: 0.3.1
@@ -599,7 +603,6 @@ importers:
 
   sites/example-project:
     specifiers:
-      '@duckdb/duckdb-wasm': ^1.27.0
       '@evidence-dev/component-utilities': workspace:^
       '@evidence-dev/core-components': workspace:^
       '@evidence-dev/duckdb': workspace:^1.0.0-usql.0
@@ -636,7 +639,6 @@ importers:
       unist-util-visit: 4.1.2
       vite: 4.3.9
     dependencies:
-      '@duckdb/duckdb-wasm': 1.27.0
       '@evidence-dev/component-utilities': link:../../packages/component-utilities
       '@evidence-dev/core-components': link:../../packages/core-components
       '@evidence-dev/duckdb': link:../../packages/duckdb

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -8,7 +8,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@duckdb/duckdb-wasm": "^1.27.0",
 		"@evidence-dev/component-utilities": "workspace:^",
 		"@evidence-dev/universal-sql": "workspace:^",
 		"@evidence-dev/core-components": "workspace:^",

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,6 +1,5 @@
 import { browser, building } from '$app/environment';
-import { initDB, setParquetURLs, query } from '@evidence-dev/universal-sql/client-duckdb';
-import { tableFromIPC } from 'apache-arrow';
+import { tableFromIPC, initDB, setParquetURLs, query } from '@evidence-dev/universal-sql/client-duckdb';
 
 /** @satisfies {import("./$types").LayoutLoad} */
 export const load = async ({

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,5 +1,10 @@
 import { browser, building } from '$app/environment';
-import { tableFromIPC, initDB, setParquetURLs, query } from '@evidence-dev/universal-sql/client-duckdb';
+import {
+	tableFromIPC,
+	initDB,
+	setParquetURLs,
+	query
+} from '@evidence-dev/universal-sql/client-duckdb';
 
 /** @satisfies {import("./$types").LayoutLoad} */
 export const load = async ({


### PR DESCRIPTION
### Description

Stops linting test from failing because it can't find `apache-arrow`