### PR TITLE
Reuse connection & extract database initialization

### DIFF
--- a/packages/preprocess/src/utils/highlighter.cjs
+++ b/packages/preprocess/src/utils/highlighter.cjs
@@ -17,8 +17,8 @@ function highlighter(code, lang, meta) {
 		const queryId = lang.toLowerCase() === 'sql' && meta ? meta : lang;
 		return `
         {#if ${queryId} }
-            <QueryViewer 
-                pageQueries = {data.evidencemeta.queries}
+            <QueryViewer
+                pageQueries = {$page.data.evidencemeta.queries}
                 queryID = "${queryId ?? 'untitled'}"
                 queryResult = {${queryId ?? 'untitled'}}
             /> 

--- a/packages/universal-sql/src/client-duckdb/browser.js
+++ b/packages/universal-sql/src/client-duckdb/browser.js
@@ -49,7 +49,7 @@ export async function initDB() {
 /**
  * Updates the duckdb search path to include only the list of included schemas
  * @param {string[]} schemas
- * @returns {void}
+ * @returns {Promise<void>}
  */
 export async function updateSearchPath(schemas) {
 	if (!db) await initDB();

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -47,7 +47,6 @@ export async function initDB() {
 	connection = db.connect();
 }
 
-
 /**
  * Updates the duckdb search path to include only the list of included schemas
  * @param {string[]} schemas

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -17,6 +17,9 @@ export { tableFromIPC } from 'apache-arrow';
 /** @type {import("@duckdb/duckdb-wasm/dist/types/src/bindings/bindings_node_base").DuckDBNodeBindings} */
 let db;
 
+/** @type {import("@duckdb/duckdb-wasm/dist/types/src/bindings/connection").DuckDBConnection} */
+let connection;
+
 /**
  * Initializes the database.
  *
@@ -41,20 +44,17 @@ export async function initDB() {
 	db = await createDuckDB(DUCKDB_BUNDLES, logger, NODE_RUNTIME);
 	await db.instantiate();
 	db.open({ query: { castBigIntToDouble: true, castTimestampToDate: true } });
+	connection = db.connect();
 }
 
 
 /**
  * Updates the duckdb search path to include only the list of included schemas
  * @param {string[]} schemas
- * @returns {Promise<void>}
+ * @returns {void}
  */
 export function updateSearchPath(schemas) {
-	const connection = db.connect();
-
 	connection.query(`PRAGMA search_path='${schemas.join(',')}'`);
-
-	connection.close();
 }
 
 /**
@@ -64,8 +64,6 @@ export function updateSearchPath(schemas) {
  * @returns {void}
  */
 export async function setParquetURLs(urls) {
-	const connection = db.connect();
-
 	for (const source in urls) {
 		connection.query(`CREATE SCHEMA IF NOT EXISTS ${source};`);
 		for (const url of urls[source]) {
@@ -77,8 +75,6 @@ export async function setParquetURLs(urls) {
 			);
 		}
 	}
-
-	connection.close();
 }
 
 /**
@@ -89,9 +85,7 @@ export async function setParquetURLs(urls) {
  * @returns {import('apache-arrow').Table | null}
  */
 export function query(sql, cache_options) {
-	const connection = db.connect();
 	const res = connection.query(sql);
-	connection.close();
 
 	if (cache_options) {
 		cache_for_hash(cache_options.route_hash, sql, cache_options.query_name, res);

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -30,7 +30,7 @@ export const load = async ({
 	fetch,
 	data: { customFormattingSettings, routeHash, isUserPage, evidencemeta }
 }) => {
-	await database_initialization;
+	if (!browser) await database_initialization;
 
 	const data = {};
 
@@ -47,7 +47,9 @@ export const load = async ({
 	return {
 		__db: {
 			query(sql, query_name) {
-				if (browser) return query(sql);
+				if (browser) {
+					return database_initialization.then(() => query(sql));
+				}
 
 				const query_results = query(sql, { route_hash: routeHash, query_name });
 

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -43,7 +43,6 @@ export const load = async ({
 			}) ?? []
 		);
 	}
-	data.evidencemeta = evidencemeta;
 
 	return {
 		__db: {
@@ -61,6 +60,7 @@ export const load = async ({
 		},
 		data,
 		customFormattingSettings,
-		isUserPage
+		isUserPage,
+		evidencemeta
 	};
 };

--- a/sites/example-project/src/pages/+layout.server.js
+++ b/sites/example-project/src/pages/+layout.server.js
@@ -22,15 +22,9 @@ export async function load({ fetch, route }) {
 	const customFormattingSettingsRes = await GET();
 	const { customFormattingSettings } = await customFormattingSettingsRes.json();
 
-	/** @type {{ renderedFiles: Record<string, string[]> }} */
-	const { renderedFiles = {} } = await fetch('/data/manifest.json')
-		.then((res) => res.json())
-		.catch(() => ({}));
-
 	return {
 		routeHash,
 		customFormattingSettings,
-		renderedFiles,
 		isUserPage,
 		evidencemeta: getQueries(routeHash)
 	};


### PR DESCRIPTION
### Description

General speedups, database initialization was taking a bit on each page load so it's better to do it once in an IIFE -- though might have to change a bit when rebuilding sources while dev server is active down the line