### PR TITLE
Consolidate db types

### DIFF
--- a/.changeset/young-steaks-teach.md
+++ b/.changeset/young-steaks-teach.md
@@ -1,0 +1,15 @@
+---
+'@evidence-dev/bigquery': patch
+'@evidence-dev/csv': patch
+'@evidence-dev/db-commons': patch
+'@evidence-dev/duckdb': patch
+'@evidence-dev/evidence': patch
+'@evidence-dev/mssql': patch
+'@evidence-dev/mysql': patch
+'@evidence-dev/postgres': patch
+'@evidence-dev/redshift': patch
+'@evidence-dev/snowflake': patch
+'@evidence-dev/sqlite': patch
+---
+
+added stricter types to db adapters

--- a/packages/bigquery/index.cjs
+++ b/packages/bigquery/index.cjs
@@ -39,7 +39,7 @@ const envMap = {
  * @returns {Record<string, unknown>[]}
  */
 const standardizeResult = (result) => {
-	var output = [];
+	const output = [];
 	result.forEach((row) => {
 		const standardized = {};
 		for (const [key, value] of Object.entries(row)) {
@@ -68,7 +68,7 @@ const standardizeResult = (result) => {
 };
 
 /**
- * @param {BigQueryOptions} database
+ * @param {Partial<BigQueryOptions>} database
  * @returns {import("@google-cloud/bigquery").BigQueryOptions}
  */
 const getCredentials = (database = {}) => {
@@ -99,7 +99,7 @@ const getCredentials = (database = {}) => {
 	}
 };
 
-/** @type {import("@evidence-dev/db-commons").RunQuery} */
+/** @type {import("@evidence-dev/db-commons").RunQuery<BigQueryOptions>} */
 const runQuery = async (queryString, database) => {
 	try {
 		const credentials = getCredentials(database);
@@ -214,10 +214,7 @@ module.exports = runQuery;
  * @typedef {BigQueryBaseOptions & (BigQueryServiceAccountOptions | BigQueryOauthOptions | BigQueryCliOptions)} BigQueryOptions
  */
 
-/**
- * @param {BigQueryOptions} opts
- * @returns {(queryString: string, queryPath: string) => Promise<QueryResult>}
- */
+/** @type {import("@evidence-dev/db-commons").GetRunner<BigQueryOptions>} */
 module.exports.getRunner = async (opts) => {
 	return async (queryContent, queryPath) => {
 		// Filter out non-sql files

--- a/packages/csv/index.cjs
+++ b/packages/csv/index.cjs
@@ -1,5 +1,6 @@
 const runQuery = require('@evidence-dev/duckdb');
 
+/** @type {import("@evidence-dev/db-commons").RunQuery<never>} */
 module.exports = async (queryString) => {
 	return runQuery(queryString, { filename: ':memory:' });
 };

--- a/packages/db-commons/index.cjs
+++ b/packages/db-commons/index.cjs
@@ -27,11 +27,6 @@ const TypeFidelity = /** @type {const} */ ({
  * @property {TypeFidelity} typeFidelity
  */
 
-/** @typedef {number | boolean | string | Date} EvidenceColumnType */
-
-// TODO: should be generic but jsdoc doesn't like that for some reason?
-/** @typedef {(queryString: string, database: Record<string, unknown>) => Promise<QueryResult>} RunQuery */
-
 /**
  * Infers the evidence type of a column value
  * @param {unknown} columnValue

--- a/packages/db-commons/index.d.ts
+++ b/packages/db-commons/index.d.ts
@@ -1,0 +1,1 @@
+export * from './index.cjs';

--- a/packages/db-commons/index.d.ts
+++ b/packages/db-commons/index.d.ts
@@ -1,1 +1,13 @@
 export * from './index.cjs';
+
+export type RunQuery<T extends Record<string, unknown>> = (
+	queryString: string,
+	database: T
+) => Promise<QueryResult>;
+
+export type EvidenceColumnType = number | boolean | string | Date;
+
+export type GetRunner<T extends Record<string, unknown>> = (
+	opts: T,
+	directory: string
+) => (queryContent: string, queryPath: string) => Promise<QueryResult>;

--- a/packages/duckdb/index.cjs
+++ b/packages/duckdb/index.cjs
@@ -1,4 +1,4 @@
-const { getEnv } = require('@evidence-dev/db-commons');
+const { getEnv, EvidenceType, TypeFidelity } = require('@evidence-dev/db-commons');
 const { Database, OPEN_READONLY, OPEN_READWRITE } = require('duckdb-async');
 const path = require('path');
 
@@ -11,36 +11,47 @@ const envMap = {
 	]
 };
 
+/**
+ *
+ * @param {unknown} data
+ * @returns {EvidenceType | undefined}
+ */
 function nativeTypeToEvidenceType(data) {
 	switch (typeof data) {
 		case 'number':
-			return 'number';
+			return EvidenceType.NUMBER;
 		case 'string':
-			return 'string';
+			return EvidenceType.STRING;
 		case 'boolean':
-			return 'boolean';
+			return EvidenceType.BOOLEAN;
 		case 'object':
 			if (data instanceof Date) {
-				return 'date';
+				return EvidenceType.DATE;
 			}
-			return undefined;
+			throw new Error(`Unsupported object type: ${data}`);
 		default:
-			return 'string';
+			return EvidenceType.STRING;
 	}
 }
 
+/**
+ *
+ * @param {Record<string, unknown>[]} rows
+ * @returns {import('@evidence-dev/db-commons').ColumnDefinition[]}
+ */
 const mapResultsToEvidenceColumnTypes = function (rows) {
 	return Object.entries(rows[0]).map(([name, value]) => {
-		let typeFidelity = 'precise';
+		let typeFidelity = TypeFidelity.PRECISE;
 		let evidenceType = nativeTypeToEvidenceType(value);
 		if (!evidenceType) {
-			typeFidelity = 'inferred';
-			evidenceType = 'string';
+			typeFidelity = TypeFidelity.INFERRED;
+			evidenceType = EvidenceType.STRING;
 		}
 		return { name, evidenceType, typeFidelity };
 	});
 };
 
+/** @type {import("@evidence-dev/db-commons").RunQuery<DuckDBOptions>} */
 const runQuery = async (queryString, database) => {
 	const filename = database ? database.filename : getEnv(envMap, 'filename');
 	const mode = filename !== ':memory:' ? OPEN_READONLY : OPEN_READWRITE;
@@ -71,19 +82,12 @@ module.exports = runQuery;
  * @property { { name: string, evidenceType: string, typeFidelity: string }[] } columnTypes
  */
 
-/**
- * @param {DuckDBOptions} opts
- * @returns { (queryString: string, queryOpts: DuckDBOptions ) => Promise<QueryResult> }
- */
+/** @type {import("@evidence-dev/db-commons").GetRunner<DuckDBOptions>} */
 module.exports.getRunner = async (opts, directory) => {
 	if (!opts.filename) {
 		console.error(`Missing required duckdb option 'filename' (${directory})`);
 	}
-	/**
-	 * @param {string} queryContent
-	 * @param {string} queryPath
-	 * @returns {Promise<QueryResult>}
-	 */
+
 	return async (queryContent, queryPath) => {
 		// Filter out non-sql files
 		if (!queryPath.endsWith('.sql')) return null;

--- a/packages/mssql/index.cjs
+++ b/packages/mssql/index.cjs
@@ -1,4 +1,4 @@
-const { getEnv } = require('@evidence-dev/db-commons');
+const { getEnv, EvidenceType, TypeFidelity } = require('@evidence-dev/db-commons');
 const mssql = require('mssql');
 
 const envMap = {
@@ -46,6 +46,12 @@ const envMap = {
 	]
 };
 
+/**
+ *
+ * @param {mssql["TYPES"][keyof mssql["TYPES"]]} data_type
+ * @param {undefined} defaultType
+ * @returns {EvidenceType | undefined}
+ */
 function nativeTypeToEvidenceType(data_type, defaultType = undefined) {
 	switch (data_type) {
 		case mssql.TYPES.Int:
@@ -58,14 +64,14 @@ function nativeTypeToEvidenceType(data_type, defaultType = undefined) {
 		case mssql.TYPES.Numeric:
 		case mssql.TYPES.SmallMoney:
 		case mssql.TYPES.Money:
-			return 'number';
+			return EvidenceType.NUMBER;
 
 		case mssql.TYPES.DateTime:
 		case mssql.TYPES.SmallDateTime:
 		case mssql.TYPES.DateTimeOffset:
 		case mssql.TYPES.Date:
 		case mssql.TYPES.DateTime2:
-			return 'date';
+			return EvidenceType.DATE;
 
 		case mssql.TYPES.VarChar:
 		case mssql.TYPES.NVarChar:
@@ -74,10 +80,10 @@ function nativeTypeToEvidenceType(data_type, defaultType = undefined) {
 		case mssql.TYPES.Xml:
 		case mssql.TYPES.Text:
 		case mssql.TYPES.NText:
-			return 'string';
+			return EvidenceType.STRING;
 
 		case mssql.TYPES.Bit:
-			return 'boolean';
+			return EvidenceType.BOOLEAN;
 
 		case mssql.TYPES.Time:
 		case mssql.TYPES.UniqueIdentifier:
@@ -94,13 +100,18 @@ function nativeTypeToEvidenceType(data_type, defaultType = undefined) {
 	}
 }
 
+/**
+ *
+ * @param {mssql.IColumnMetadata} fields
+ * @returns
+ */
 const mapResultsToEvidenceColumnTypes = function (fields) {
 	return Object.values(fields).map((field) => {
-		let typeFidelity = 'precise';
+		let typeFidelity = TypeFidelity.PRECISE;
 		let evidenceType = nativeTypeToEvidenceType(field.type);
 		if (!evidenceType) {
-			typeFidelity = 'inferred';
-			evidenceType = 'string';
+			typeFidelity = TypeFidelity.INFERRED;
+			evidenceType = EvidenceType.STRING;
 		}
 		return {
 			name: field.name,
@@ -110,6 +121,7 @@ const mapResultsToEvidenceColumnTypes = function (fields) {
 	});
 };
 
+/** @type {import("@evidence-dev/db-commons").RunQuery<MsSQLOptions>} */
 const runQuery = async (queryString, database = {}) => {
 	try {
 		const trust_server_certificate =
@@ -127,6 +139,7 @@ const runQuery = async (queryString, database = {}) => {
 			}
 		};
 
+		/** @type {mssql.ConnectionPool} */
 		const pool = await mssql.connect(credentials);
 		const { recordset } = await pool.query(queryString);
 
@@ -153,22 +166,8 @@ module.exports = runQuery;
  * @property {boolean} encrypt
  */
 
-/**
- * @typedef {Object} QueryResult
- * @property { Record<string, any>[] } rows
- * @property { { name: string, evidenceType: string, typeFidelity: string }[] } columnTypes
- */
-
-/**
- * @param {MsSQLOptions} opts
- * @returns { (queryString: string, queryOpts: PostgresOptions ) => Promise<QueryResult> }
- */
+/** @type {import('@evidence-dev/db-commons').GetRunner<MsSQLOptions>} */
 module.exports.getRunner = async (opts) => {
-	/**
-	 * @param {string} queryContent
-	 * @param {string} queryPath
-	 * @returns {Promise<QueryResult>}
-	 */
 	return async (queryContent, queryPath) => {
 		// Filter out non-sql files
 		if (!queryPath.endsWith('.sql')) return null;

--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -1,6 +1,6 @@
 const pg = require('pg');
 const { Pool } = pg;
-const { EvidenceType, getEnv } = require('@evidence-dev/db-commons');
+const { EvidenceType, getEnv, TypeFidelity } = require('@evidence-dev/db-commons');
 
 const envMap = {
 	host: [
@@ -57,10 +57,6 @@ const envMap = {
  * Some types that are not defined in the PG library
  */
 const pgBuiltInTypeExtentions = {
-	CHAR: 18,
-	JSON: 114,
-	JSONB: 3802,
-	XML: 142,
 	UUID: 2950,
 	NAME: 19,
 	JSONPATH: 4072,
@@ -71,6 +67,13 @@ const pgBuiltInTypeExtentions = {
 	_BOOL: 1000,
 	_CHAR: 1002
 };
+
+/**
+ *
+ * @param {pg["types"]["builtins"]} dataTypeId
+ * @param {undefined} defaultType
+ * @returns {EvidenceType | undefined}
+ */
 const nativeTypeToEvidenceType = function (dataTypeId, defaultType = undefined) {
 	switch (dataTypeId) {
 		case pg.types.builtins.BOOL:
@@ -86,9 +89,9 @@ const nativeTypeToEvidenceType = function (dataTypeId, defaultType = undefined) 
 		case pg.types.builtins.VARCHAR:
 		case pg.types.builtins.TEXT:
 		case pg.types.builtins.STRING:
-		case pgBuiltInTypeExtentions.CHAR:
-		case pgBuiltInTypeExtentions.JSON:
-		case pgBuiltInTypeExtentions.XML:
+		case pg.types.builtins.CHAR:
+		case pg.types.builtins.JSON:
+		case pg.types.builtins.XML:
 		case pgBuiltInTypeExtentions.NAME:
 			return EvidenceType.STRING;
 		case pg.types.builtins.DATE:
@@ -102,12 +105,17 @@ const nativeTypeToEvidenceType = function (dataTypeId, defaultType = undefined) 
 	}
 };
 
+/**
+ *
+ * @param {pg.QueryResult} results
+ * @returns {import('@evidence-dev/db-commons').ColumnDefinition[] | undefined}
+ */
 const mapResultsToEvidenceColumnTypes = function (results) {
 	return results?.fields?.map((field) => {
-		let typeFidelity = 'precise';
+		let typeFidelity = TypeFidelity.PRECISE;
 		let evidenceType = nativeTypeToEvidenceType(field.dataTypeID);
 		if (!evidenceType) {
-			typeFidelity = 'inferred';
+			typeFidelity = TypeFidelity.INFERRED;
 			evidenceType = EvidenceType.STRING;
 		}
 		return {
@@ -118,8 +126,13 @@ const mapResultsToEvidenceColumnTypes = function (results) {
 	});
 };
 
-const standardizeResult = async (result) => {
-	var output = [];
+/**
+ *
+ * @param {Record<string, unknown>[]} result
+ * @returns {Record<string, unknown>[]}
+ */
+const standardizeResult = (result) => {
+	const output = [];
 	result.forEach((row) => {
 		const lowerCasedRow = {};
 		for (const [key, value] of Object.entries(row)) {
@@ -130,6 +143,7 @@ const standardizeResult = async (result) => {
 	return output;
 };
 
+/** @type {import('@evidence-dev/db-commons').RunQuery<PostgresOptions>} */
 const runQuery = async (queryString, database) => {
 	try {
 		const credentials = {
@@ -172,9 +186,10 @@ const runQuery = async (queryString, database) => {
 				client.query(`SET search_path TO ${schema}`);
 			});
 		}
-		var result = await pool.query(queryString);
+		/** @type {pg.QueryResult} */
+		const result = await pool.query(queryString);
 
-		const standardizedRows = await standardizeResult(result.rows);
+		const standardizedRows = standardizeResult(result.rows);
 
 		return { rows: standardizedRows, columnTypes: mapResultsToEvidenceColumnTypes(result) };
 	} catch (err) {
@@ -198,22 +213,8 @@ module.exports = runQuery;
  * @property {Object | undefined} ssl
  */
 
-/**
- * @typedef {Object} QueryResult
- * @property { Record<string, any>[] } rows
- * @property { { name: string, evidenceType: string, typeFidelity: string }[] } columnTypes
- */
-
-/**
- * @param {PostgresOptions} opts
- * @returns { (queryString: string, queryOpts: PostgresOptions ) => Promise<QueryResult> }
- */
+/** @type {import('@evidence-dev/db-commons').GetRunner<PostgresOptions>} */
 module.exports.getRunner = async (opts) => {
-	/**
-	 * @param {string} queryContent
-	 * @param {string} queryPath
-	 * @returns {Promise<QueryResult>}
-	 */
 	return async (queryContent, queryPath) => {
 		// Filter out non-sql files
 		if (!queryPath.endsWith('.sql')) return null;

--- a/packages/snowflake/package.json
+++ b/packages/snowflake/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@evidence-dev/db-commons": "workspace:^",
+		"@types/snowflake-sdk": "^1.6.13",
 		"asn1.js": "^5.0.0",
 		"fs-extra": "^11.1.1",
 		"node-fetch": "^3.3.1",

--- a/packages/sqlite/index.cjs
+++ b/packages/sqlite/index.cjs
@@ -12,6 +12,7 @@ const envMap = {
 	]
 };
 
+/** @type {import('@evidence-dev/db-commons').RunQuery<SQLiteOptions>} */
 const runQuery = async (queryString, database) => {
 	const filename = database ? database.filename : getEnv(envMap, 'filename');
 	const filepath = filename !== ':memory:' ? '../../' + filename : filename;
@@ -43,22 +44,8 @@ module.exports = runQuery;
  * @property {string} filename
  */
 
-/**
- * @typedef {Object} QueryResult
- * @property { Record<string, any>[] } rows
- * @property { { name: string, evidenceType: string, typeFidelity: string }[] } columnTypes
- */
-
-/**
- * @param {SQLiteOptions} opts
- * @returns { (queryString: string, queryOpts: SQLiteOptions ) => Promise<QueryResult> }
- */
+/** @type {import('@evidence-dev/db-commons').GetRunner<SQLiteOptions>} */
 module.exports.getRunner = async (opts) => {
-	/**
-	 * @param {string} queryContent
-	 * @param {string} queryPath
-	 * @returns {Promise<QueryResult>}
-	 */
 	return async (queryContent, queryPath) => {
 		// Filter out non-sql files
 		if (!queryPath.endsWith('.sql')) return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,6 +494,7 @@ importers:
   packages/snowflake:
     specifiers:
       '@evidence-dev/db-commons': workspace:^
+      '@types/snowflake-sdk': ^1.6.13
       asn1.js: ^5.0.0
       dotenv: ^16.0.1
       fs-extra: ^11.1.1
@@ -502,6 +503,7 @@ importers:
       snowflake-sdk: 1.6.13
     dependencies:
       '@evidence-dev/db-commons': link:../db-commons
+      '@types/snowflake-sdk': 1.6.13
       asn1.js: 5.4.1
       fs-extra: 11.1.1
       node-fetch: 3.3.1
@@ -8579,6 +8581,13 @@ packages:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
       '@types/node': 20.3.3
+
+  /@types/snowflake-sdk/1.6.13:
+    resolution: {integrity: sha512-WOOyHcrJWozRlapES0T7+Uk2e55xIW+ur81xKx1RbzHwgelosGiu+kvwvbLPVpkoh9p0sOvuPUednil1LLLW5Q==}
+    dependencies:
+      '@types/node': 20.3.3
+      generic-pool: 3.9.0
+    dev: false
 
   /@types/sockjs/0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}


### PR DESCRIPTION
### Description

Added types for every db adapter function, and centralized the common types in `db-commons`

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
