### PR TITLE
Fix frontmatter HMR

### DIFF
--- a/.changeset/little-baboons-hear.md
+++ b/.changeset/little-baboons-hear.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/preprocess': patch
+---
+
+stop exporting the metadata object from mdsvex frontmatter

--- a/packages/preprocess/src/frontmatter/process-frontmatter.cjs
+++ b/packages/preprocess/src/frontmatter/process-frontmatter.cjs
@@ -25,6 +25,9 @@ module.exports = () => {
 				// There is no frontmatter, and we want to make sure that it as at least defined.
 				// Technically this won't _break_ things, just spam the logs with a vite warning.
 				return { code: content + ';const metadata = undefined;' };
+			} else {
+				// exporting makes tailwind break HMR
+				return { code: content.replace('export const metadata =', 'const metadata =') };
 			}
 		}
 	};


### PR DESCRIPTION
### Description

Fixes #963 

remove export from mdsvex-generated `export const metadata` because it makes tailwind break HMR

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
