### PR TITLE
support massive files + non-directories in sources

### DIFF
--- a/.changeset/pink-pets-bake.md
+++ b/.changeset/pink-pets-bake.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+skip massive files and non-directories in sources

--- a/packages/csv/CHANGELOG.md
+++ b/packages/csv/CHANGELOG.md
@@ -1,4 +1,5 @@
 # @evidence-dev/csv
+
 ## 0.1.5
 
 ### Patch Changes
@@ -6,6 +7,7 @@
 - Updated dependencies [4e783f36]
 - Updated dependencies [e12fef6c]
   - @evidence-dev/duckdb@0.1.1
+
 ## 1.0.0-usql.2
 
 ### Minor Changes

--- a/packages/db-orchestrator/CHANGELOG.md
+++ b/packages/db-orchestrator/CHANGELOG.md
@@ -1,4 +1,5 @@
 # @evidence-dev/db-orchestrator
+
 ## 2.2.3
 
 ### Patch Changes

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -65,6 +65,9 @@ export const getSources = async (sourcesDir) => {
 	const datasourceSpecs = await Promise.all(
 		sourcesDirectories.map(async (dirName) => {
 			const sourceDir = path.join(sourcesDir, dirName);
+			const possibleDir = await fs.stat(sourceDir);
+			if (!possibleDir.isDirectory()) return false;
+
 			const contents = await fs.readdir(sourceDir);
 
 			const connParams = await loadConnectionConfiguration(sourceDir);
@@ -87,7 +90,7 @@ export const getSources = async (sourcesDir) => {
 				queries: queries
 			};
 		})
-	).then((r) => r.filter(Boolean));
+	).then((r) => /** @type {Exclude<typeof r[number], false>[]} */ (r.filter(Boolean)));
 
 	return datasourceSpecs;
 };

--- a/packages/plugin-connector/src/data-sources/schemas/datasource-spec.schema.js
+++ b/packages/plugin-connector/src/data-sources/schemas/datasource-spec.schema.js
@@ -3,7 +3,7 @@ import { QueryResultSchema } from './query-runner.schema';
 
 export const DatasourceQuerySchema = z.object({
 	filepath: z.string(),
-	content: z.string()
+	content: z.string().or(z.null())
 });
 
 export const DatasourceSpecFileSchema = z.object({

--- a/packages/plugin-connector/src/data-sources/types.d.ts
+++ b/packages/plugin-connector/src/data-sources/types.d.ts
@@ -1,6 +1,0 @@
-declare interface PluginDatabases {
-	[database: string]: {
-		package: EvidencePluginPackage<EvidenceDatabasePackage>;
-		factory: DatabaseConnectorFactory;
-	};
-}

--- a/packages/plugin-connector/types/types.d.ts
+++ b/packages/plugin-connector/types/types.d.ts
@@ -31,6 +31,13 @@ declare global {
 		main: string;
 	};
 
+	type PluginDatabases = {
+		[database: string]: {
+			package: EvidencePluginPackage<EvidenceDatabasePackage>;
+			factory: DatabaseConnectorFactory;
+		};
+	};
+
 	type ValidPackage = z.infer<typeof ValidPackageSchema>;
 
 	type EvidenceConfig = z.infer<typeof EvidenceConfigSchema>;


### PR DESCRIPTION
### Description

- returns `null` + filepath for massive files so adapters have the option of reading them manually
- checks if a source dir is a directory before attempting to read as such

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
