### PR TITLE
Update Details component styling and props

### DIFF
--- a/.changeset/heavy-tables-call.md
+++ b/.changeset/heavy-tables-call.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Change details component styling, adds open prop

--- a/packages/core-components/src/lib/unsorted/ui/Details.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Details.svelte
@@ -5,49 +5,39 @@
 <script>
 	export let title = 'Details';
 	export let open = false;
-    import { slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 </script>
 
 <div class="mb-4 mt-3 ml-1">
+	<button class="italic text-base text-grey-800 cursor-pointer" on:click={() => (open = !open)}>
+		<span class={open ? 'marker rotate-marker' : 'marker'} />
+		{title}
+	</button>
 
-<button 
-    class="italic text-base text-grey-800 cursor-pointer" 
-    on:click={() => (open = !open)}>
-    <span 
-        class={open ? "marker rotate-marker" : "marker"} />
-        {title}
-</button>
-
-{#if open}
-    <div 
-        class="ml-3 pt-3 mb-6 text-base"
-        transition:slide
-    >
-        <slot />
-    </div>
-{/if}
-
+	{#if open}
+		<div class="ml-3 pt-3 mb-6 text-base" transition:slide>
+			<slot />
+		</div>
+	{/if}
 </div>
 
 <style>
-    .marker {
-        
-        border-left: 5px solid transparent;
-        border-right: 5px solid transparent;
-        border-top: 9px solid var(--grey-800);
-        margin-right: 8px;
-        transform: rotate(-90deg);
-        transition: transform 0.2s ease;
-    }
+	.marker {
+		border-left: 5px solid transparent;
+		border-right: 5px solid transparent;
+		border-top: 9px solid var(--grey-800);
+		margin-right: 8px;
+		transform: rotate(-90deg);
+		transition: transform 0.2s ease;
+	}
 
-    .rotate-marker {
-        transform: rotate(0deg);
-    }
+	.rotate-marker {
+		transform: rotate(0deg);
+	}
 
-    button {
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-        
-    }
+	button {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+	}
 </style>

--- a/packages/core-components/src/lib/unsorted/ui/Details.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Details.svelte
@@ -4,13 +4,50 @@
 
 <script>
 	export let title = 'Details';
+	export let open = false;
+    import { slide } from 'svelte/transition';
 </script>
 
-<details class="mb-4 mt-3 ml-1">
-	<summary class="italic text-base text-grey-800 cursor-pointer">
-		{title}
-	</summary>
-	<div class="ml-3 pt-3 mb-6 text-base">
-		<slot />
-	</div>
-</details>
+<div class="mb-4 mt-3 ml-1">
+
+<button 
+    class="italic text-base text-grey-800 cursor-pointer" 
+    on:click={() => (open = !open)}>
+    <span 
+        class={open ? "marker rotate-marker" : "marker"} />
+        {title}
+</button>
+
+{#if open}
+    <div 
+        class="ml-3 pt-3 mb-6 text-base"
+        transition:slide
+    >
+        <slot />
+    </div>
+{/if}
+
+</div>
+
+<style>
+    .marker {
+        
+        border-left: 5px solid transparent;
+        border-right: 5px solid transparent;
+        border-top: 9px solid var(--grey-800);
+        margin-right: 8px;
+        transform: rotate(-90deg);
+        transition: transform 0.2s ease;
+    }
+
+    .rotate-marker {
+        transform: rotate(0deg);
+    }
+
+    button {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        
+    }
+</style>

--- a/sites/docs/docs/components/details.md
+++ b/sites/docs/docs/components/details.md
@@ -34,8 +34,9 @@ The details component allows you to add a collapsible section to your markdown. 
 
 ## Props
 
-| Name   | Description                                                             | Required | 
-|--------|-------------------------------------------------------------------------|----------|
-| title  | The text show next to the triangle icon.                                | No       |
+| Name   | Description                                                | Required | Default  |
+|--------|------------------------------------------------------------|----------|----------|
+| title  | The text shown next to the triangle icon.                  | -       | Details  |
+| open   | Whether expanded or closed by default.                     | -       | false    |
 
 


### PR DESCRIPTION
### Description

- Moves from semantic HTML to div which addresses issues with any content which is `onMount`-ed / rendered in the browser
- Adds slide transition on expand
- Adds `open` prop that allows you to have it expanded (off by default)

### Before

![CleanShot 2023-08-02 at 09 29 48](https://github.com/evidence-dev/evidence/assets/58074498/d2f27dbf-b3a2-49c5-855a-a4c8d80e75d3)

### After

![CleanShot 2023-08-02 at 09 31 44](https://github.com/evidence-dev/evidence/assets/58074498/85b58ca6-911c-4d2c-845b-725fbc64e494)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
