### PR TITLE
sets animation duration to 500ms for sankey chart - #1090

### DIFF
--- a/.changeset/tasty-suns-sleep.md
+++ b/.changeset/tasty-suns-sleep.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': major
+---
+
+updates sankey chart animation duration to match other charts.

--- a/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/SankeyChart.svelte
@@ -153,7 +153,8 @@
 		},
 
 		data: nameData,
-		links: links
+		links: links,
+		animationDuration: 500
 	};
 
 	$: config = {


### PR DESCRIPTION
### Description

Sets animation duration for sankey chart to 500ms to match other charts for #1090 

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after.
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset).

|      Before      |      After      |
| :---------------------: | :---------------------: |
| ![before-sankey](https://github.com/evidence-dev/evidence/assets/129554482/1ac31b2e-c6ea-470c-bd8d-5103bd6e9e38) |![after-sankey](https://github.com/evidence-dev/evidence/assets/129554482/c3bc505d-48d5-4420-a497-9d75f4eb7134) |
