### PR TITLE
Add delta content type to datatable

### DIFF
--- a/.changeset/curvy-schools-complain.md
+++ b/.changeset/curvy-schools-complain.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': minor
+'@evidence-dev/components': minor
+---
+
+Adds delta content type to DataTable

--- a/packages/core-components/src/lib/unsorted/viz/Column.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Column.svelte
@@ -38,6 +38,7 @@
 		align = 'center';
 	}
 	export let wrap = false;
+	wrap = wrap === 'true' || wrap === true;
 
 	// COLUMN CONTENT TYPES:
 	export let contentType = undefined;
@@ -56,6 +57,15 @@
 	// Formatting:
 	export let fmt = undefined;
 
+	// Delta:
+	export let downIsGood = false;
+	downIsGood = downIsGood === 'true' || downIsGood === true;
+
+	export let deltaLabel = undefined;
+	export let deltaSymbol = true;
+	deltaSymbol = deltaSymbol === 'true' || deltaSymbol === true;
+
+
 	let options = {
 		id: id,
 		title: title,
@@ -67,7 +77,10 @@
 		alt: alt,
 		openInNewTab: openInNewTab,
 		linkLabel: linkLabel,
-		fmt: fmt
+		fmt: fmt,
+		downIsGood: downIsGood,
+		deltaLabel: deltaLabel,
+		deltaSymbol: deltaSymbol
 	};
 
 	props.update((d) => {

--- a/packages/core-components/src/lib/unsorted/viz/Column.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Column.svelte
@@ -61,7 +61,6 @@
 	export let downIsGood = false;
 	downIsGood = downIsGood === 'true' || downIsGood === true;
 
-	export let deltaLabel = undefined;
 	export let deltaSymbol = true;
 	deltaSymbol = deltaSymbol === 'true' || deltaSymbol === true;
 
@@ -79,7 +78,6 @@
 		linkLabel: linkLabel,
 		fmt: fmt,
 		downIsGood: downIsGood,
-		deltaLabel: deltaLabel,
 		deltaSymbol: deltaSymbol
 	};
 

--- a/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
@@ -434,6 +434,26 @@
 												)}
 											{/if}
 										</a>
+									{:else if column.contentType === 'delta' && row[column.id] !== undefined}
+										<div class="m-0 text-xs font-medium font-ui" style={`color:${((row[column.id] >= 0 && !column.downIsGood) || (row[column.id] < 0 && column.downIsGood)) ? 'var(--green-700)' : 'var(--red-700)'}`}>
+											<div style="text-align: right;">
+												<span>
+												{formatValue(
+													row[column.id],
+													column.fmt
+														? getFormatObjectFromString(
+																column.fmt,
+																safeExtractColumn(column).format.valueType
+														)
+														: safeExtractColumn(column).format,
+													safeExtractColumn(column).columnUnitSummary
+												)}
+												</span>
+												{#if column.deltaSymbol}
+													<span>{@html row[column.id] >= 0 ? '&#9650;' : '&#9660;'}</span>
+												{/if}
+											</div>
+										</div>
 									{:else}
 										{formatValue(
 											row[column.id],

--- a/sites/example-project/src/pages/tables/new-table/+page.md
+++ b/sites/example-project/src/pages/tables/new-table/+page.md
@@ -1,65 +1,65 @@
 ```sql tableq
-select date('2020-04-30') as date, 87 as value_usd, 'Austria' as country, 'B' as category, 100384 as country_id, 'AT' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AT.png' as flag, 'https://www.google.ca/search?q=austria' as country_url
+select date '2020-04-30' as date, 87 as value_usd, 0.0234 as yoy, 'Austria' as country, 'B' as category, 100384 as country_id, 'AT' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AT.png' as flag, 'https://www.google.ca/search?q=austria' as country_url
 union all
-select date('2020-05-01') as date, 95 as value_usd, 'Australia' as country, 'C' as category, 104942 as country_id, 'AU' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AU.png' as flag, 'https://www.google.ca/search?q=australia' as country_url
+select date '2020-05-01' as date, 95 as value_usd, 0.0534 as yoy, 'Australia' as country, 'C' as category, 104942 as country_id, 'AU' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/AU.png' as flag, 'https://www.google.ca/search?q=australia' as country_url
 union all
-select date('2020-05-02') as date, 163 as value_usd, 'Brazil' as country, 'A' as category, 100842 as country_id, 'BR' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/BR.png' as flag, 'https://www.google.ca/search?q=brazil' as country_url
+select date '2020-05-02' as date, 163 as value_usd, 0.0264 as yoy, 'Brazil' as country, 'A' as category, 100842 as country_id, 'BR' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/BR.png' as flag, 'https://www.google.ca/search?q=brazil' as country_url
 union all
-select date('2020-05-03') as date, 174 as value_usd, 'Canada' as country, 'A' as category, 104975 as country_id, 'CA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CA.png' as flag, 'https://www.google.ca/search?q=canada' as country_url
+select date '2020-05-03' as date, 174 as value_usd, 0.0727 as yoy, 'Canada' as country, 'A' as category, 104975 as country_id, 'CA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CA.png' as flag, 'https://www.google.ca/search?q=canada' as country_url
 union all
-select date('2020-05-04') as date, 214 as value_usd, 'Chile' as country, 'B' as category, 100644 as country_id, 'CL' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CL.png' as flag, 'https://www.google.ca/search?q=chile' as country_url
+select date '2020-05-04' as date, 214 as value_usd, -0.1223 as yoy, 'Chile' as country, 'B' as category, 100644 as country_id, 'CL' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/CL.png' as flag, 'https://www.google.ca/search?q=chile' as country_url
 union all
-select date('2020-05-05') as date, 342 as value_usd, 'Denmark' as country, 'B' as category, 102948 as country_id, 'DK' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/DK.png' as flag, 'https://www.google.ca/search?q=denmark' as country_url
+select date '2020-05-05' as date, 342 as value_usd, 0.0124 as yoy, 'Denmark' as country, 'B' as category, 102948 as country_id, 'DK' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/DK.png' as flag, 'https://www.google.ca/search?q=denmark' as country_url
 union all
-select date('2020-05-06') as date, 331 as value_usd, 'Estonia' as country, 'D' as category, 102495 as country_id, 'EE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/EE.png' as flag, 'https://www.google.ca/search?q=estonia' as country_url
+select date '2020-05-06' as date, 331 as value_usd, 0.0252 as yoy, 'Estonia' as country, 'D' as category, 102495 as country_id, 'EE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/EE.png' as flag, 'https://www.google.ca/search?q=estonia' as country_url
 union all
-select date('2020-05-07') as date, 98 as value_usd, 'Finland' as country, 'B' as category, 104962 as country_id, 'FI' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/FI.png' as flag, 'https://www.google.ca/search?q=finland' as country_url
+select date '2020-05-07' as date, 98 as value_usd, 0.0754 as yoy, 'Finland' as country, 'B' as category, 104962 as country_id, 'FI' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/FI.png' as flag, 'https://www.google.ca/search?q=finland' as country_url
 union all
-select date('2020-05-08') as date, 128 as value_usd, 'Ghana' as country, 'C' as category, 100599 as country_id, 'GH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/GH.png' as flag, 'https://www.google.ca/search?q=ghana' as country_url
+select date '2020-05-08' as date, 128 as value_usd, -0.0246 as yoy, 'Ghana' as country, 'C' as category, 100599 as country_id, 'GH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/GH.png' as flag, 'https://www.google.ca/search?q=ghana' as country_url
 union all
-select date('2020-05-09') as date, 153 as value_usd, 'Honduras' as country, 'D' as category, 102494 as country_id, 'HN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/HN.png' as flag, 'https://www.google.ca/search?q=honduras' as country_url
+select date '2020-05-09' as date, 153 as value_usd, 0.0447 as yoy, 'Honduras' as country, 'D' as category, 102494 as country_id, 'HN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/HN.png' as flag, 'https://www.google.ca/search?q=honduras' as country_url
 union all
-select date('2020-05-10') as date, 384 as value_usd, 'India' as country, 'A' as category, 101948 as country_id, 'IN' as country_code,  'https://flaglog.com/codes/standardized-rectangle-120px/IN.png' as flag, 'https://www.google.ca/search?q=india' as country_url
+select date '2020-05-10' as date, 384 as value_usd, -0.0255 as yoy, 'India' as country, 'A' as category, 101948 as country_id, 'IN' as country_code,  'https://flaglog.com/codes/standardized-rectangle-120px/IN.png' as flag, 'https://www.google.ca/search?q=india' as country_url
 union all
-select date('2020-05-11') as date, 234 as value_usd, 'Ireland' as country, 'B' as category, 100987 as country_id, 'IE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/IE.png' as flag, 'https://www.google.ca/search?q=ireland' as country_url
+select date '2020-05-11' as date, 234 as value_usd, 0.0855 as yoy, 'Ireland' as country, 'B' as category, 100987 as country_id, 'IE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/IE.png' as flag, 'https://www.google.ca/search?q=ireland' as country_url
 union all
-select date('2020-05-12') as date, 67 as value_usd, 'Jamaica' as country, 'C' as category, 101248 as country_id, 'JM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/JM.png' as flag, 'https://www.google.ca/search?q=jamaica' as country_url
+select date '2020-05-12' as date, 67 as value_usd, 0.0635 as yoy, 'Jamaica' as country, 'C' as category, 101248 as country_id, 'JM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/JM.png' as flag, 'https://www.google.ca/search?q=jamaica' as country_url
 union all
-select date('2020-05-13') as date, 125 as value_usd, 'Kenya' as country, 'C' as category, 101947 as country_id, 'KE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/KE.png' as flag, 'https://www.google.ca/search?q=kenya' as country_url
+select date '2020-05-13' as date, 125 as value_usd, -0.0232 as yoy, 'Kenya' as country, 'C' as category, 101947 as country_id, 'KE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/KE.png' as flag, 'https://www.google.ca/search?q=kenya' as country_url
 union all
-select date('2020-05-14') as date, 118 as value_usd, 'Lebanon' as country, 'D' as category, 108849 as country_id, 'LB' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/LB.png' as flag, 'https://www.google.ca/search?q=lebanon' as country_url
+select date '2020-05-14' as date, 118 as value_usd, -0.0343 as yoy, 'Lebanon' as country, 'D' as category, 108849 as country_id, 'LB' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/LB.png' as flag, 'https://www.google.ca/search?q=lebanon' as country_url
 union all
-select date('2020-05-15') as date, 263 as value_usd, 'Mexico' as country, 'B' as category, 100763 as country_id, 'MX' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/MX.png' as flag, 'https://www.google.ca/search?q=mexico' as country_url
+select date '2020-05-15' as date, 263 as value_usd, 0.0883 as yoy, 'Mexico' as country, 'B' as category, 100763 as country_id, 'MX' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/MX.png' as flag, 'https://www.google.ca/search?q=mexico' as country_url
 union all
-select date('2020-05-16') as date, 211 as value_usd, 'Nigeria' as country, 'A' as category, 100837 as country_id, 'NG' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/NG.png' as flag, 'https://www.google.ca/search?q=nigeria' as country_url
+select date '2020-05-16' as date, 211 as value_usd, 0.0395 as yoy, 'Nigeria' as country, 'A' as category, 100837 as country_id, 'NG' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/NG.png' as flag, 'https://www.google.ca/search?q=nigeria' as country_url
 union all
-select date('2020-05-17') as date, 192 as value_usd, 'Oman' as country, 'D' as category, 100993 as country_id, 'OM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/OM.png' as flag, 'https://www.google.ca/search?q=oman' as country_url
+select date '2020-05-17' as date, 192 as value_usd, 0.0234 as yoy, 'Oman' as country, 'D' as category, 100993 as country_id, 'OM' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/OM.png' as flag, 'https://www.google.ca/search?q=oman' as country_url
 union all
-select date('2020-05-18') as date, 59 as value_usd, 'Philippines' as country, 'D' as category, 104128 as country_id, 'PH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/PH.png' as flag, 'https://www.google.ca/search?q=philippines' as country_url
+select date '2020-05-18' as date, 59 as value_usd, 0.0828 as yoy, 'Philippines' as country, 'D' as category, 104128 as country_id, 'PH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/PH.png' as flag, 'https://www.google.ca/search?q=philippines' as country_url
 union all
-select date('2020-05-19') as date, 113 as value_usd, 'Qatar' as country, 'C' as category, 100181 as country_id, 'QA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/QA.png' as flag, 'https://www.google.ca/search?q=qatar' as country_url
+select date '2020-05-19' as date, 113 as value_usd, 0.0554 as yoy, 'Qatar' as country, 'C' as category, 100181 as country_id, 'QA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/QA.png' as flag, 'https://www.google.ca/search?q=qatar' as country_url
 union all
-select date('2020-05-20') as date, 190 as value_usd, 'Romania' as country, 'A' as category, 101384 as country_id, 'RO' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/RO.png' as flag, 'https://www.google.ca/search?q=romania ! startups' as country_url
+select date '2020-05-20' as date, 190 as value_usd, 0.0134 as yoy, 'Romania' as country, 'A' as category, 101384 as country_id, 'RO' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/RO.png' as flag, 'https://www.google.ca/search?q=romania ! startups' as country_url
 union all
-select date('2020-05-21') as date, 190 as value_usd, 'Sweden' as country, 'B' as category, 101847 as country_id, 'SE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/SE.png' as flag, 'https://www.google.ca/search?q=sweden' as country_url
+select date '2020-05-21' as date, 190 as value_usd, -0.0554 as yoy, 'Sweden' as country, 'B' as category, 101847 as country_id, 'SE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/SE.png' as flag, 'https://www.google.ca/search?q=sweden' as country_url
 union all
-select date('2020-05-22') as date, 248 as value_usd, 'Thailand' as country, 'C' as category, 104837 as country_id, 'TH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/TH.png' as flag, 'https://www.google.ca/search?q=thailand' as country_url
+select date '2020-05-22' as date, 248 as value_usd, 0.0254 as yoy, 'Thailand' as country, 'C' as category, 104837 as country_id, 'TH' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/TH.png' as flag, 'https://www.google.ca/search?q=thailand' as country_url
 union all
-select date('2020-05-23') as date, 168 as value_usd, 'Ukraine' as country, 'C' as category, 101938 as country_id, 'UA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/UA.png' as flag, 'https://www.google.ca/search?q=ukraine' as country_url
+select date '2020-05-23' as date, 168 as value_usd, 0.0294 as yoy, 'Ukraine' as country, 'C' as category, 101938 as country_id, 'UA' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/UA.png' as flag, 'https://www.google.ca/search?q=ukraine' as country_url
 union all
-select date('2020-05-24') as date, 101 as value_usd, 'Vietnam' as country, 'A' as category, 104948 as country_id, 'VN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/VN.png' as flag, 'https://www.google.ca/search?q=vietnam' as country_url
+select date '2020-05-24' as date, 101 as value_usd, 0.0234 as yoy, 'Vietnam' as country, 'A' as category, 104948 as country_id, 'VN' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/VN.png' as flag, 'https://www.google.ca/search?q=vietnam' as country_url
 union all
-select date('2020-05-25') as date, 67 as value_usd, 'Yemen' as country, 'B' as category, 100774 as country_id, 'YE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/YE.png' as flag, 'https://www.google.ca/search?q=yemen' as country_url
+select date '2020-05-25' as date, 67 as value_usd, 0.0294 as yoy, 'Yemen' as country, 'B' as category, 100774 as country_id, 'YE' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/YE.png' as flag, 'https://www.google.ca/search?q=yemen' as country_url
 union all
-select date('2020-05-26') as date, 100 as value_usd, 'Zimbabwe' as country, 'A' as category, 100337 as country_id, 'ZW' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/ZW.png' as flag, 'https://www.google.ca/search?q=zimbabwe' as country_url
+select date '2020-05-26' as date, 100 as value_usd, 0.011 as yoy, 'Zimbabwe' as country, 'A' as category, 100337 as country_id, 'ZW' as country_code, 'https://flaglog.com/codes/standardized-rectangle-120px/ZW.png' as flag, 'https://www.google.ca/search?q=zimbabwe' as country_url
 ```
 
 <DataTable data={tableq} search=true rowShading=false link=country_url>
     <Column id=country />
     <Column id=country_id align=center/>
-    <Column id=flag contentType=image height=40px  align=center />
     <Column id=category align=center/>
     <Column id=value_usd/>
+    <Column id=yoy contentType=delta fmt=pct title="Y/Y Chg" deltaSymbol=false deltaLabel="vs PY"/>
     <Column id=country_url contentType=link linkLabel="Details &rarr;" title="Country Details" align=right openInNewTab=true/>
 </DataTable>
 


### PR DESCRIPTION
### Description
Adds a new `contentType` to `Column` called `delta` (name TBC).

Props/options in `Column`:
- `contentType=delta`
- `downIsGood` - true/false - same as in BigValue. Default false (positive = green, negative = red)
- `deltaSymbol` - true/false - shows or hides triangle symbol

### Example

```html
    <Column id=yoy contentType=delta fmt=pct title="Y/Y Chg"/>
```

<img width="578" alt="CleanShot 2023-08-10 at 17 59 34@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/ecb991bf-8dcd-4f96-83cd-284bad44b698">

#### With `deltaSymbol=false`:
<img width="571" alt="CleanShot 2023-08-10 at 17 59 45@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/41df294a-eb50-4991-b8fe-343c82d0e681">

#### Custom Format
You can also use custom formatting to replace the symbol, like in the Value column below:

```html
    <Column id=value_usd contentType=delta fmt='[>=0]"+ "$#,##0;"- "$#,##0' deltaSymbol=false/>
```

<img width="570" alt="CleanShot 2023-08-10 at 18 19 09@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/426e6d52-7cf7-467e-90ae-bf4870531d06">

### Considerations
Ideally, would have wanted symbol on the left, but it's difficult to align everything well. We need the symbol aligned on the left and the numbers aligned on the right, without too much space showing up in between. `display: flex` and `justify-content: space-between` almost gets there.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
