### PR TITLE
[next] Execute query and save to file in one step

### DIFF
--- a/.changeset/large-zoos-hug.md
+++ b/.changeset/large-zoos-hug.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+Tweak source building to increase max possible result set

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -246,7 +246,6 @@ async function getQueries(sourceDir, contents) {
 		 */
 		(r) => r.flat(1)
 	);
-	console.log({ queryFiles });
 
 	const queries = await Promise.all(
 		queryFiles.map(async (filename) => {


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

Prior to this change; all queries for a source were executed, then they were all flushed to files.
This meant that all the results for a single source needed to fit into memory at once.
This change runs a single query at a time, and then saves it to a file before moving on - meaning it can be garbage collected.


### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
