### PR TITLE
Add note to db connection panel

### DIFF
--- a/.changeset/chatty-jobs-kneel.md
+++ b/.changeset/chatty-jobs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Add note to db connection settings panel

--- a/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
@@ -103,7 +103,8 @@
 				the deployment panel.
 			</p>
 			<p>
-				To use the demo database included with the starter template, choose <code>DuckDB</code> and <code>needful_things.duckdb</code>
+				To use the demo database included with the starter template, choose <code>DuckDB</code> and
+				<code>needful_things.duckdb</code>
 			</p>
 			<h3>Connection Type</h3>
 			<select

--- a/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
@@ -102,6 +102,9 @@
 				These credentials will be used when running locally. For your production environment, see
 				the deployment panel.
 			</p>
+			<p>
+				To use the demo database included with the starter template, choose <code>DuckDB</code> and <code>needful_things.duckdb</code>
+			</p>
 			<h3>Connection Type</h3>
 			<select
 				data-test-id="dbConnectionType"


### PR DESCRIPTION
### Description
Adds a note to the db connection panel for users who are starting with the demo database. 

In most scenarios, new projects get db credentials auto-added, but there are 2 situations where this doesn't happen:
1. "Use This Template" button in the template repo on Github
2. Creating a new template project from Evidence Cloud

The best way to start editing these projects locally is to clone the repos, but that means the db connection won't automatically be set up.

A few alternatives I considered:
- Add a command to our VS Code extension to "Add demo database credentials", which would create an `evidence.settings.json` file
- Add a button to the db connection settings panel to "Use demo database", which would fill out the form with the information
- Add an entry to our db dropdown for "demo database"

And one other more involved option: having the demo db always as a backup if no other credentials are supplied by the user

<img width="868" alt="CleanShot 2023-09-05 at 14 15 56@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/8ca7da98-23e2-46fd-90c4-0d9b0620f51a">

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
