### PR TITLE
Speed up date handling

### DIFF
--- a/.changeset/popular-geese-leave.md
+++ b/.changeset/popular-geese-leave.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': patch
+'@evidence-dev/universal-sql': patch
+---
+
+move date standardization

--- a/packages/component-utilities/src/dateParsing.js
+++ b/packages/component-utilities/src/dateParsing.js
@@ -1,10 +1,6 @@
 import { tidy, mutate } from '@tidyjs/tidy';
 
 export function standardizeDateString(date) {
-	if (date instanceof Date) {
-		return date.toISOString().slice(0, -1);
-	}
-
 	if (date && typeof date === 'string') {
 		// Parses an individual string into a JS date object
 

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -172,6 +172,11 @@ function applyFormatting(
 			try {
 				if (columnFormat.valueType === 'date' && typeof value === 'string') {
 					typedValue = new Date(standardizeDateString(value));
+				} else if (value instanceof Date) {
+					// "2023-09-06T22:40:43.000Z" minus the Z is interpreted 
+					// as local time
+					// similar in behavior to standardizeDateString
+					typedValue = new Date(value.toISOString().slice(0, -1));
 				} else if (
 					columnFormat.valueType === 'number' &&
 					typeof value !== 'number' &&

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -173,7 +173,7 @@ function applyFormatting(
 				if (columnFormat.valueType === 'date' && typeof value === 'string') {
 					typedValue = new Date(standardizeDateString(value));
 				} else if (value instanceof Date) {
-					// "2023-09-06T22:40:43.000Z" minus the Z is interpreted 
+					// "2023-09-06T22:40:43.000Z" minus the Z is interpreted
 					// as local time
 					// similar in behavior to standardizeDateString
 					typedValue = new Date(value.toISOString().slice(0, -1));

--- a/packages/universal-sql/src/client-duckdb/browser.js
+++ b/packages/universal-sql/src/client-duckdb/browser.js
@@ -54,7 +54,14 @@ export async function initDB() {
 		// and asynchronous database
 		db = new AsyncDuckDB(logger, worker);
 		await db.instantiate(DUCKDB_CONFIG.mainModule);
-		await db.open({ query: { castBigIntToDouble: true, castTimestampToDate: true } });
+		await db.open({
+			query: {
+				castBigIntToDouble: true,
+				castTimestampToDate: true,
+				castDecimalToDouble: true,
+				castDurationToTime64: true
+			}
+		});
 		connection = await db.connect();
 		resolveInit();
 	} catch (e) {

--- a/sites/test-env/pages/date-formatting-and-performance.md
+++ b/sites/test-env/pages/date-formatting-and-performance.md
@@ -3,14 +3,13 @@
 ### This shoudn't take forever
 
 ```whole_lotta_dates
-SELECT 
-	* 
+SELECT
+	*
 FROM range('1990-01-01'::DATE, '4747-11-29'::DATE, interval '1' day);
 -- approx 1 million days
 ```
 
 <DataTable data={whole_lotta_dates} />
-
 
 ### These columns should match
 
@@ -19,9 +18,9 @@ SELECT
 	'1970-01-01' as str_date, '1970-01-01'::DATE as reg_date
 UNION ALL SELECT
 	'2020-01-01' as str_date, '2020-01-01'::DATE as reg_date
-UNION ALL SELECT 
+UNION ALL SELECT
 	'2020-01-01' as str_date, '2020-01-01 00:00:00'::TIMESTAMP as reg_date
-UNION ALL SELECT 
+UNION ALL SELECT
 	'2020-01-01' as str_date, '2020-01-01 23:59:59'::TIMESTAMP as reg_date
 UNION ALL SELECT
 	'2020-02-29' as str_date, '2020-02-29'::DATE as reg_date

--- a/sites/test-env/pages/date-formatting-and-performance.md
+++ b/sites/test-env/pages/date-formatting-and-performance.md
@@ -1,0 +1,34 @@
+# Date Formatting and Performance
+
+### This shoudn't take forever
+
+```whole_lotta_dates
+SELECT 
+	* 
+FROM range('1990-01-01'::DATE, '4747-11-29'::DATE, interval '1' day);
+-- approx 1 million days
+```
+
+<DataTable data={whole_lotta_dates} />
+
+
+### These columns should match
+
+```try_to_break_dates
+SELECT
+	'1970-01-01' as str_date, '1970-01-01'::DATE as reg_date
+UNION ALL SELECT
+	'2020-01-01' as str_date, '2020-01-01'::DATE as reg_date
+UNION ALL SELECT 
+	'2020-01-01' as str_date, '2020-01-01 00:00:00'::TIMESTAMP as reg_date
+UNION ALL SELECT 
+	'2020-01-01' as str_date, '2020-01-01 23:59:59'::TIMESTAMP as reg_date
+UNION ALL SELECT
+	'2020-02-29' as str_date, '2020-02-29'::DATE as reg_date
+UNION ALL SELECT
+	'2020-02-29' as str_date, '2020-02-29 00:00:00'::TIMESTAMP as reg_date
+UNION ALL SELECT
+	'2020-02-29' as str_date, '2020-02-29 23:59:59'::TIMESTAMP as reg_date
+```
+
+<DataTable data={try_to_break_dates} rows={Infinity} />


### PR DESCRIPTION
### Description

Moves `Date` object standardization to `formatValue` instead of `standardizeDateString`.

Worth considering removing `convertColumnToDate` in favour of doing all standardization on-demand in `formatValue` to speed up component initialization and improving perf for large datasets

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
