### PR TITLE
Don't fully overwrite manifest.json on filtered builds

### DIFF
--- a/.changeset/breezy-hounds-crash.md
+++ b/.changeset/breezy-hounds-crash.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+don't fully overwrite manifest.json on filtered builds

--- a/.changeset/real-moose-happen.md
+++ b/.changeset/real-moose-happen.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+fix spelling mistake

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -205,7 +205,7 @@ prog
 	.example('npx evidence build:sources --changed')
 	.example('npx evidence build:sources --sources needful_things --queries orders,reviews')
 	.example('npx evidence build:sources --queries needful_things.orders,needful_things.reviews')
-	.example('npx evidence build:sources --sorces needful_things,social_media')
+	.example('npx evidence build:sources --sources needful_things,social_media')
 	.action(async (opts) => {
 		const sources = opts.sources?.split(',') ?? null;
 		const queries = opts.queries?.split(',') ?? null;

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -2,7 +2,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import yaml from 'yaml';
 import chalk from 'chalk';
-import { DatasourceSpecFileSchema, DatasourceCacheSchema } from './schemas/datasource-spec.schema';
+import {
+	DatasourceSpecFileSchema,
+	DatasourceCacheSchema,
+	DatasourceManifestSchema
+} from './schemas/datasource-spec.schema';
 import { cleanZodErrors } from '../lib/clean-zod-errors.js';
 import { createHash } from 'node:crypto';
 
@@ -101,6 +105,46 @@ export const getSources = async (sourcesDir) => {
 	return datasourceSpecs;
 };
 
+/**
+ *
+ * @template {import("zod").ZodType} T
+ * @param {T} zod_schema
+ * @param {string} file_path
+ * @param {import("zod").infer<T>} default_value
+ * @param {string} error_message
+ * @returns {Promise<import("zod").infer<T>>}
+ */
+async function validateFile(zod_schema, file_path, default_value, error_message) {
+	const string_default = JSON.stringify(default_value);
+
+	const file_contents = await fs.readFile(file_path, 'utf-8').catch(() => string_default);
+	const parsed = JSON.parse(file_contents);
+	const validated = zod_schema.safeParse(parsed);
+
+	if (!validated.success) {
+		console.error(chalk.bold.red(error_message));
+		await fs.writeFile(file_path, string_default);
+		return default_value;
+	}
+
+	return validated.data;
+}
+
+/**
+ *
+ * @param {string} outDir
+ * @returns {Promise<import("zod").infer<typeof DatasourceManifestSchema>>}
+ */
+export async function getCurrentManifest(outDir) {
+	const manifestPath = path.join(outDir, 'manifest.json');
+	return validateFile(
+		DatasourceManifestSchema,
+		manifestPath,
+		{ renderedFiles: {} },
+		'[!] Unable to parse manifest, ignoring'
+	);
+}
+
 const hash_location = './.evidence/template/.evidence-queries/sources/hashes.json';
 
 /**
@@ -108,17 +152,12 @@ const hash_location = './.evidence/template/.evidence-queries/sources/hashes.jso
  * @returns {Promise<import("zod").infer<typeof DatasourceCacheSchema>>}
  */
 export async function getPastSourceHashes() {
-	const hashes = await fs.readFile(hash_location, 'utf-8').catch(() => '{}');
-	const parsed = JSON.parse(hashes);
-	const validated = DatasourceCacheSchema.safeParse(parsed);
-
-	if (!validated.success) {
-		console.error(chalk.bold.red('[!] Unable to parse source query hashes, ignoring'));
-		await fs.writeFile(hash_location, '{}');
-		return {};
-	}
-
-	return validated.data;
+	return validateFile(
+		DatasourceCacheSchema,
+		hash_location,
+		{},
+		'[!] Unable to parse source query hashes, ignoring'
+	);
 }
 
 /**

--- a/packages/plugin-connector/src/data-sources/index.js
+++ b/packages/plugin-connector/src/data-sources/index.js
@@ -30,6 +30,7 @@ async function updateManifest(outputFiles, outDir, datasources) {
 		current_manifest.renderedFiles[source.name] = (
 			current_manifest.renderedFiles[source.name] ?? []
 		).filter((file) =>
+			// this is the same way we name files so it's safe
 			source.queries.find((query) => query.name === path.basename(file, '.parquet'))
 		);
 	}

--- a/packages/plugin-connector/src/data-sources/schemas/datasource-spec.schema.js
+++ b/packages/plugin-connector/src/data-sources/schemas/datasource-spec.schema.js
@@ -26,3 +26,7 @@ export const DatasourceQueryResultSchema = z.object({
 });
 
 export const DatasourceCacheSchema = z.record(z.record(z.string().or(z.null())));
+
+export const DatasourceManifestSchema = z.object({
+	renderedFiles: z.record(z.array(z.string()))
+});


### PR DESCRIPTION
### Description

Also removes references to sources/queries that no longer exist
- Should we be attempting to remove parquet as well if sources or queries are found to be removed?
- Should we be attempting to remove queries who's parquet is found to be removed (basically just `queries.filter(x => fs.exists(x))`)?

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
