### PR TITLE
Fix for getCompletedData function

### DIFF
--- a/.changeset/honest-dogs-invent.md
+++ b/.changeset/honest-dogs-invent.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': patch
+'@evidence-dev/components': patch
+---
+
+Patch for getCompletedData function

--- a/packages/component-utilities/src/getCompletedData.js
+++ b/packages/component-utilities/src/getCompletedData.js
@@ -27,8 +27,8 @@ export default function getCompletedData(data, x, y, series, nullsZero = false, 
 
 	const output = [];
 
-	let xIsDate = Object.values(groups)[0][0]?.[x] instanceof Date; 
-		
+	let xIsDate = Object.values(groups)[0][0]?.[x] instanceof Date;
+
 	const nullySpec = { [series]: null };
 	if (nullsZero) {
 		nullySpec[y] = 0;
@@ -83,4 +83,3 @@ export default function getCompletedData(data, x, y, series, nullsZero = false, 
 
 	return output;
 }
-

--- a/packages/component-utilities/src/tests/getCompletedData.spec.js
+++ b/packages/component-utilities/src/tests/getCompletedData.spec.js
@@ -75,11 +75,22 @@ describe('getCompletedData', () => {
 				}
 			});
 
-			it('does not fill x-axis values if fillX is not set', () => {
+			it('returns identical columns to the original data', () => {
 				const result = getCompletedData(data, 'time', 'value', 'series', false, false);
 
-				// Expect specific behavior here based on your function's logic
-				expect(result.every((r) => data.some((d) => r.time === d.time && r.series === d.series)));
+				const r = Object.keys(result[0]);
+				const d = Object.keys(data[0]);
+				expect(r).toEqual(d);
+			});
+
+			it('contains series each with identical lengths', () => {
+				const result = getCompletedData(data, 'time', 'value', 'series', false, false);
+				let seriesLengths = [];
+				for (const seriesName in series) {
+					seriesLengths.push(result.filter((d) => d.series === seriesName).length);
+				}
+
+				expect(seriesLengths.every((val) => val === seriesLengths[0])).toEqual(true);
 			});
 
 			it('returns the original data if series is not defined', () => {

--- a/sites/example-project/src/pages/chart-testing/1. Background/+page.md
+++ b/sites/example-project/src/pages/chart-testing/1. Background/+page.md
@@ -1,0 +1,99 @@
+# Background on Data Completion
+
+The way we use ECharts, the data for each series on a chart is separated from the x-axis it sits on. ECharts constructs the axis and the series separately, and then puts them together on the page. 
+
+Most of the time this is fine, but there is a risk that things become out of order and ECharts won't be able to recognize there is an issue - there are 2 cases where this breaks:
+1. Unsorted data
+2. Missing data
+
+### Background - ECharts Axis Types
+ECharts includes 4 axis types, of which we use the first 3:
+1. Time
+2. Value
+3. Category
+4. Log
+
+## Unsorted Data
+
+This only impacts line charts with a `value` x-axis. The chart will attempt to plot the data in the order it is received, so if the data is unsorted, it can result in the line chart making odd turns and going in the wrong direction.
+
+This doesn't apply to `time` axes because ECharts is able to handle the ordering correctly.
+
+## Missing Data
+
+There are several scenarios possible for missing data. The terminology here needs improvement, but is used in the rest of this Chart Testing section.
+
+The scenarios are all combinations of (1) Data Structure and (2) Missing Data Type
+
+### Data Structure
+1. Single Series
+    ```html 
+    <LineChart data={countries} x=year y=sales/>
+    ```
+2. Multi-Series Using `series` Column
+    ```html 
+    <LineChart data={countries} x=year y=sales series=country/>
+    ```
+3. Multi-Series Using Multiple `y` Columns
+    ```html 
+    <LineChart data={countries} x=year y={['revenue', 'gross_profit']}/>
+    ```
+4. Multi-Series Using `series` Column and Multiple `y` Columns
+    ```html 
+    <LineChart data={countries} x=year y=sales series=country y={['revenue', 'gross_profit']}/>
+    ```
+
+Wherever a "series" is referenced, it applies to any combination from #2-4 above. 
+
+#### Examples of a "series":
+- **"Canada"** (single value from the `series` column)
+- **"Revenue"** (column name of one of the `y` columns supplied)
+- **"Revenue - Canada"** (combo of `y` column name and value from `series` column)
+
+### Missing Data Type
+1. Missing X ("Dataset Missing X")
+   - An entire x value is missing from the dataset. E.g, if x-axis was years from 1990 to 2000, and 1994 did not appear in the data
+2. Missing Y ("Series Missing X")
+   - This name is misleading
+   - Applies only to multi-series charts
+   - This is when a series in the dataset is missing an x value
+   - E.g., if you had x-axis with years from 1990 to 2000, and `series=country` with "Canada" and "US" as values - if Canada is missing 1994, that is considered a "Missing Y" scenario
+3. X out of Sync ("Series X Out of Sync")
+   - Applies only to multi-series charts
+   - This is when the x values of the series in a dataset should line up, but don't
+   - E.g., if you had on x-axis values from 0 to 5 incrementing by 0.5 and `series=country` with "Canada" and "US" - if Canada has 3.4 instead of 3.5, that's considered "X out of Sync"
+4. Nulls
+   - This one is straightforward - if any of the values in the dataset are null
+
+
+## Filling in Missing Data
+
+### Nulls
+For `4. Nulls`, in most cases we don't need to do anything because the chart will handle the missing value automatically. For example, on a scatter plot or a bar chart, there won't be any point to plot, so nothing will appear. 
+
+Issues can appear in line charts and area charts because the line needs to interpolate between points. Depending on your situation, you may want nulls handled differently.
+
+To solve this, we offer the `handleMissing` prop in line and area charts, which can have these options:
+- `gap`: line will show a gap where the null is
+- `zero`: line will go down to 0 at that point
+- `connect`: line will connect from the previous value to the next value (effectively ignoring the null)
+
+### Missing X Values
+The other 3 missing data types are all some variation of the dataset missing values on the x-axis. The solution is to fill those values into the dataset and send the completed dataset to ECharts.
+
+There are 2 ways to fill missing x values:
+1. Use the `complete` function from `TidyJS` to ensure that all combinations of `x` and `series` are fully included in the data (e.g., in the Missing Y example above, we need to insert a row with "Canada" and 1994 into the data, with nulls for any value columns)
+2. `fillX` - determine the interval of data on the x-axis and ensure that every increment is represented in the data
+   - This one is hard
+
+These are all handled in the `getCompletedData` function in `component-utilities`.
+
+## Testing `getCompletedData`  
+
+These conditions must be true of the output of the function:
+- Columns of the original data object and the ouput should be identical (no new columns, no name changes)
+- Each series should contain the same number of rows as all other series
+- Each series should contain the same x-values as all other series
+- No duplicate rows
+- Should fill in missing values with 0 if nullsZero is set
+- When `fillX` is used, the interval between each x-value should be the same

--- a/sites/example-project/src/pages/chart-testing/dateSeriesMulty/+page.md
+++ b/sites/example-project/src/pages/chart-testing/dateSeriesMulty/+page.md
@@ -211,9 +211,9 @@ let nulls =
 
 <h2>100% Stacked Bar Chart</h2>
 <BarChart data={full}  series=series title="Full Data" type=stacked100/>
-<BarChart data={missingX}  series=series title="Missing X" type=stacked10/>
-<BarChart data={missingY} series=series title="Missing Y" type=stacked10/>
-<BarChart data={nulls}  series=series title="Nulls" type=stacked10/>
+<BarChart data={missingX}  series=series title="Missing X" type=stacked100/>
+<BarChart data={missingY} series=series title="Missing Y" type=stacked100/>
+<BarChart data={nulls}  series=series title="Nulls" type=stacked100/>
 
 <!-- <h2>horizontal Stacked Bar Chart</h2>
 <BarChart data={full}  swapXY=true series=series title="Full Data" xType=value/>


### PR DESCRIPTION
### Description
A customer noticed an issue with a multi-series bar chart, which showed the series shifted across the x-axis. It turns out this was related to the `getCompletedData` function, which wasn't filling in missing values for the specific situation in that chart (a "missing Y" situation per the `example-project` terminology.

Issue can be seen here in a previous deploy preview (stacked area and bar charts for Missing Y):
https://deploy-preview-1166--evidence-development-workspace.netlify.app/chart-testing/dateSeries/

Here's what's been changed:
- Removed the loop around the tidyJS completion function  - each iteration didn't have access to the full combination of x and series needed to fill everything in
   - As part of this change, used `data` instead of `value` from the loop
- In the `nullySpec`, changed to referenced the `series` column name dynamically
- Added `x` to the `expandKeys` for scenarios where `x` is not to be filled  

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
