### PR TITLE
feat: enable custom sveltekit configs

### DIFF
--- a/.changeset/slow-actors-march.md
+++ b/.changeset/slow-actors-march.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+User projects can now extend svelte.config.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -21,3 +21,6 @@ yarn.lock
 **/sites/docs/*
 **/dist/*
 .changeset/*
+
+# Ignore this file because it uses top-level await and ESLint can't parse that.
+packages/evidence/scripts/svelte.config.js

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -32,7 +32,9 @@ fsExtra.emptyDirSync('./template/sources');
 
 
 
-const configFileLocation = fs.realpathSync(new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js')));
+const configFileLocation__ = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'))
+const configFileLocation = 
+	process.platform.includes("win") ? configFileLocation__.href : fs.realpathSync(configFileLocation__);
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -32,10 +32,7 @@ fsExtra.emptyDirSync('./template/sources');
 
 
 
-const configFileDir = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'))
-const configFileLocation = configFileDir.pathname;
-const dirContent = fs.lstatSync(configFileDir)
-console.log({configFileLocation, configFileDir, dirContent})
+const configFileLocation = fs.realpathSync(new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js')));
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,10 +30,12 @@ templatePaths.forEach((p) => {
 
 fs.emptyDirSync('./template/sources');
 
-
-const configFileLocation = path.join(path.parse(import.meta.url).dir, "svelte.config.js").split("file:").at(-1)
+const configFileLocation = path
+	.join(path.parse(import.meta.url).dir, 'svelte.config.js')
+	.split('file:')
+	.at(-1);
 // Create a clean SK config (workspace's is modified)
-fs.copySync(configFileLocation, './template/svelte.config.js')
+fs.copySync(configFileLocation, './template/svelte.config.js');
 
 fs.outputFileSync(
 	'./template/vite.config.js',

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,7 +30,7 @@ templatePaths.forEach((p) => {
 
 fsExtra.emptyDirSync('./template/sources');
 
-const configFileLocation = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'));
+const configFileLocation = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js')).pathname;
 
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -32,9 +32,7 @@ fsExtra.emptyDirSync('./template/sources');
 
 
 
-const configFileLocation__ = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'))
-const configFileLocation = 
-	process.platform.includes("win") ? configFileLocation__.href : fs.realpathSync(configFileLocation__);
+const configFileLocation = new URL('svelte.config.js', import.meta.url);
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,40 +30,10 @@ templatePaths.forEach((p) => {
 
 fs.emptyDirSync('./template/sources');
 
+
+const configFileLocation = path.join(path.parse(import.meta.url).dir, "svelte.config.js").split("file:").at(-1)
 // Create a clean SK config (workspace's is modified)
-fs.outputFileSync(
-	'./template/svelte.config.js',
-	`
-    import evidencePreprocess from '@evidence-dev/preprocess'
-    import preprocess from "svelte-preprocess";
-    import adapter from '@sveltejs/adapter-static';
-    import { evidencePlugins } from '@evidence-dev/plugin-connector';
-    
-    /** @type {import('@sveltejs/kit').Config} */
-    
-    const config = {
-        extensions: ['.svelte', ".md"], 
-        preprocess: [
-            ...evidencePreprocess(true),
-            evidencePlugins(),
-            preprocess({
-              postcss: true,
-            }),
-        ],
-        kit: {
-            adapter: adapter({
-                strict: false
-            }),
-            files: {
-                routes: 'src/pages',
-                lib: 'src/components'
-            }
-        }
-    };
-    
-    export default config    
-    `
-);
+fs.copySync(configFileLocation, './template/svelte.config.js')
 
 fs.outputFileSync(
 	'./template/vite.config.js',

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,8 +30,12 @@ templatePaths.forEach((p) => {
 
 fsExtra.emptyDirSync('./template/sources');
 
-const configFileLocation = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js')).pathname;
 
+
+const configFileDir = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'))
+const configFileLocation = configFileDir.pathname;
+const dirContent = fs.lstatSync(configFileDir)
+console.log({configFileLocation, configFileDir, dirContent})
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -1,7 +1,7 @@
 // Populate the template that's shipped with the package using a subset of files from the example-project
 import path from 'path';
-import fs from 'fs-extra';
-
+import fsExtra from 'fs-extra';
+import fs from 'fs';
 const templatePaths = [
 	'.npmrc',
 	'static/',
@@ -22,28 +22,20 @@ const templatePaths = [
 	'postcss.config.cjs'
 ];
 
-fs.emptyDirSync('./template/');
+fsExtra.emptyDirSync('./template/');
 
 templatePaths.forEach((p) => {
-	fs.copySync(path.join('../../sites/example-project', p), path.join('./template', p));
+	fsExtra.copySync(path.join('../../sites/example-project', p), path.join('./template', p));
 });
 
-fs.emptyDirSync('./template/sources');
+fsExtra.emptyDirSync('./template/sources');
 
-const configFileLocation = path.join(
-	...import.meta.url
-		.split(path.sep)
-		.slice(0, -1)
-		.join(path.sep)
-		.split(path.delimiter)
-		.at(-1)
-		.split(path.delimiter),
-	'svelte.config.js'
-);
+const configFileLocation = new URL(path.join(path.parse(import.meta.url).dir, 'svelte.config.js'));
+
 // Create a clean SK config (workspace's is modified)
-fs.copySync(configFileLocation, './template/svelte.config.js');
+fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));
 
-fs.outputFileSync(
+fsExtra.outputFileSync(
 	'./template/vite.config.js',
 	`import { sveltekit } from "@sveltejs/kit/vite"
     const strictFs = (process.env.NODE_ENV === 'development') ? false : true;
@@ -68,7 +60,7 @@ fs.outputFileSync(
 );
 
 // Create a readme
-fs.outputFileSync(
+fsExtra.outputFileSync(
 	'./template/README.md',
 	`
 # Evidence Template Project

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,10 +30,16 @@ templatePaths.forEach((p) => {
 
 fs.emptyDirSync('./template/sources');
 
-const configFileLocation = path
-	.join(path.parse(import.meta.url).dir, 'svelte.config.js')
-	.split('file:')
-	.at(-1);
+const configFileLocation = path.join(
+	...import.meta.url
+		.split(path.sep)
+		.slice(0, -1)
+		.join(path.sep)
+		.split(path.delimiter)
+		.at(-1)
+		.split(path.delimiter),
+	'svelte.config.js'
+);
 // Create a clean SK config (workspace's is modified)
 fs.copySync(configFileLocation, './template/svelte.config.js');
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -30,8 +30,6 @@ templatePaths.forEach((p) => {
 
 fsExtra.emptyDirSync('./template/sources');
 
-
-
 const configFileLocation = new URL('svelte.config.js', import.meta.url);
 // Create a clean SK config (workspace's is modified)
 fs.writeFileSync('./template/svelte.config.js', fs.readFileSync(configFileLocation));

--- a/packages/evidence/scripts/svelte.config.js
+++ b/packages/evidence/scripts/svelte.config.js
@@ -50,8 +50,10 @@ async function loadUserConfiguration() {
 
 	if (!rootDirContents.includes('svelte.config.js')) return;
 
+    const configFileLocation = path.join(rootDir, 'svelte.config.js');
+    const configURL = new URL(`file:///${configFileLocation}`).href;
 	/** @type {import("@sveltejs/kit").Config} */
-	const userConfig = await import(path.join(rootDir, 'svelte.config.js')).then((r) => r.default);
+	const userConfig = await import(configURL).then((r) => r.default);
 
 	if ('preprocess' in userConfig) {
 		if ('preprocess' in config) {

--- a/packages/evidence/scripts/svelte.config.js
+++ b/packages/evidence/scripts/svelte.config.js
@@ -1,79 +1,75 @@
-import evidencePreprocess from '@evidence-dev/preprocess'
-import preprocess from "svelte-preprocess";
+import evidencePreprocess from '@evidence-dev/preprocess';
+import preprocess from 'svelte-preprocess';
 import adapter from '@sveltejs/adapter-static';
-import {evidencePlugins} from '@evidence-dev/plugin-connector';
-import fs from "fs";
-import path from "path";
+import { evidencePlugins } from '@evidence-dev/plugin-connector';
+import fs from 'fs';
+import path from 'path';
 
 /**
  * @param {Object} a
  * @param {Object} b
  * @returns {Object}
  */
-const deepMerge = (a,b) => {
-    for (const key in b) {
-        if (typeof b[key] === 'object' && !Array.isArray(b[key])) {
-            if (!a[key]) a[key] = {}
-            deepMerge(a[key], b[key])
-        } else {
-            Object.assign(a, { [key]: b[key] })
-        }
-    }
-    return a;
-}
-
-
+const deepMerge = (a, b) => {
+	for (const key in b) {
+		if (typeof b[key] === 'object' && !Array.isArray(b[key])) {
+			if (!a[key]) a[key] = {};
+			deepMerge(a[key], b[key]);
+		} else {
+			Object.assign(a, { [key]: b[key] });
+		}
+	}
+	return a;
+};
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-    extensions: ['.svelte', ".md"],
-    preprocess: [
-        ...evidencePreprocess(true),
-        evidencePlugins(),
-        preprocess({
-            postcss: true,
-        }),
-    ],
-    kit: {
-        adapter: adapter({
-            strict: false
-        }),
-        files: {
-            routes: 'src/pages',
-            lib: 'src/components'
-        }
-    }
+	extensions: ['.svelte', '.md'],
+	preprocess: [
+		...evidencePreprocess(true),
+		evidencePlugins(),
+		preprocess({
+			postcss: true
+		})
+	],
+	kit: {
+		adapter: adapter({
+			strict: false
+		}),
+		files: {
+			routes: 'src/pages',
+			lib: 'src/components'
+		}
+	}
 };
 
-
 async function loadUserConfiguration() {
-    if (!process.cwd().includes(".evidence")) return;
-    const rootDir = process.cwd().split(".evidence")[0]
-    const rootDirContents = fs.readdirSync(rootDir)
+	if (!process.cwd().includes('.evidence')) return;
+	const rootDir = process.cwd().split('.evidence')[0];
+	const rootDirContents = fs.readdirSync(rootDir);
 
-    if (!rootDirContents.includes("svelte.config.js")) return;
+	if (!rootDirContents.includes('svelte.config.js')) return;
 
-    /** @type {import("@sveltejs/kit").Config} */
-    const userConfig = await import(path.join(rootDir, "svelte.config.js")).then(r => r.default)
+	/** @type {import("@sveltejs/kit").Config} */
+	const userConfig = await import(path.join(rootDir, 'svelte.config.js')).then((r) => r.default);
 
-    if ("preprocess" in userConfig) {
-        console.warn("Configuring preprocess is disabled for Evidence projects.")
-        delete userConfig.preprocess
-    }
-    if ("extensions" in userConfig) {
-        console.warn("Configuring extensions is disabled for Evidence projects.")
-        delete userConfig.extensions
-    }
-    if ("kit" in userConfig && "files" in userConfig.kit) {
-        console.warn("Configuring file locations is disabled for Evidence projects.")
-        delete userConfig.kit.files
-    }
+	if ('preprocess' in userConfig) {
+		console.warn('Configuring preprocess is disabled for Evidence projects.');
+		delete userConfig.preprocess;
+	}
+	if ('extensions' in userConfig) {
+		console.warn('Configuring extensions is disabled for Evidence projects.');
+		delete userConfig.extensions;
+	}
+	if ('kit' in userConfig && 'files' in userConfig.kit) {
+		console.warn('Configuring file locations is disabled for Evidence projects.');
+		delete userConfig.kit.files;
+	}
 
-    deepMerge(config, userConfig)
-    console.log("Custom svelte.config.js applied")
+	deepMerge(config, userConfig);
+	console.log('Custom svelte.config.js applied');
 }
 
-await loadUserConfiguration()
+await loadUserConfiguration();
 
-
-export default config
+export default config;

--- a/packages/evidence/scripts/svelte.config.js
+++ b/packages/evidence/scripts/svelte.config.js
@@ -54,7 +54,12 @@ async function loadUserConfiguration() {
 	const userConfig = await import(path.join(rootDir, 'svelte.config.js')).then((r) => r.default);
 
 	if ('preprocess' in userConfig) {
-		console.warn('Configuring preprocess is disabled for Evidence projects.');
+		if ('preprocess' in config) {
+			config.preprocess.push(...userConfig.preprocess);
+		} else {
+			// This case shouldn't ever be reached.
+			config.preprocess = userConfig.preprocess;
+		}
 		delete userConfig.preprocess;
 	}
 	if ('extensions' in userConfig) {

--- a/packages/evidence/scripts/svelte.config.js
+++ b/packages/evidence/scripts/svelte.config.js
@@ -50,8 +50,8 @@ async function loadUserConfiguration() {
 
 	if (!rootDirContents.includes('svelte.config.js')) return;
 
-    const configFileLocation = path.join(rootDir, 'svelte.config.js');
-    const configURL = new URL(`file:///${configFileLocation}`).href;
+	const configFileLocation = path.join(rootDir, 'svelte.config.js');
+	const configURL = new URL(`file:///${configFileLocation}`).href;
 	/** @type {import("@sveltejs/kit").Config} */
 	const userConfig = await import(configURL).then((r) => r.default);
 

--- a/packages/evidence/scripts/svelte.config.js
+++ b/packages/evidence/scripts/svelte.config.js
@@ -1,0 +1,79 @@
+import evidencePreprocess from '@evidence-dev/preprocess'
+import preprocess from "svelte-preprocess";
+import adapter from '@sveltejs/adapter-static';
+import {evidencePlugins} from '@evidence-dev/plugin-connector';
+import fs from "fs";
+import path from "path";
+
+/**
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {Object}
+ */
+const deepMerge = (a,b) => {
+    for (const key in b) {
+        if (typeof b[key] === 'object' && !Array.isArray(b[key])) {
+            if (!a[key]) a[key] = {}
+            deepMerge(a[key], b[key])
+        } else {
+            Object.assign(a, { [key]: b[key] })
+        }
+    }
+    return a;
+}
+
+
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+    extensions: ['.svelte', ".md"],
+    preprocess: [
+        ...evidencePreprocess(true),
+        evidencePlugins(),
+        preprocess({
+            postcss: true,
+        }),
+    ],
+    kit: {
+        adapter: adapter({
+            strict: false
+        }),
+        files: {
+            routes: 'src/pages',
+            lib: 'src/components'
+        }
+    }
+};
+
+
+async function loadUserConfiguration() {
+    if (!process.cwd().includes(".evidence")) return;
+    const rootDir = process.cwd().split(".evidence")[0]
+    const rootDirContents = fs.readdirSync(rootDir)
+
+    if (!rootDirContents.includes("svelte.config.js")) return;
+
+    /** @type {import("@sveltejs/kit").Config} */
+    const userConfig = await import(path.join(rootDir, "svelte.config.js")).then(r => r.default)
+
+    if ("preprocess" in userConfig) {
+        console.warn("Configuring preprocess is disabled for Evidence projects.")
+        delete userConfig.preprocess
+    }
+    if ("extensions" in userConfig) {
+        console.warn("Configuring extensions is disabled for Evidence projects.")
+        delete userConfig.extensions
+    }
+    if ("kit" in userConfig && "files" in userConfig.kit) {
+        console.warn("Configuring file locations is disabled for Evidence projects.")
+        delete userConfig.kit.files
+    }
+
+    deepMerge(config, userConfig)
+    console.log("Custom svelte.config.js applied")
+}
+
+await loadUserConfiguration()
+
+
+export default config

--- a/sites/test-env/svelte.config.js
+++ b/sites/test-env/svelte.config.js
@@ -1,16 +1,15 @@
 /** @type {import("@sveltejs/kit").Config} */
 export default {
-    preprocess: [],
-    extensions: [],
-    kit: {
-        files: {}
-    },
-    vite: {
-        server: {
-            watch: {
-                usePolling: true
-            }
-        }
-    }
-}
-
+	preprocess: [],
+	extensions: [],
+	kit: {
+		files: {}
+	},
+	vite: {
+		server: {
+			watch: {
+				usePolling: true
+			}
+		}
+	}
+};

--- a/sites/test-env/svelte.config.js
+++ b/sites/test-env/svelte.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@sveltejs/kit").Config} */
+export default {
+    preprocess: [],
+    extensions: [],
+    kit: {
+        files: {}
+    },
+    vite: {
+        server: {
+            watch: {
+                usePolling: true
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Description

An evidence project can now have a `svelte.config.js` file at the root of the project that will be merged _over_ Evidence's own configuration. Certain fields that are required for Evidence and it's components to function properly are ignored.

- Preprocessors form the basis of Evidence, users should not mess with them (yet)
- File locations are hard-coded into the CLI; changing them will completely break the app
- Extensions are also hard-coded in many places, and changing them will likely break everything.


Resolves #1182

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
