### PR TITLE
Link fixes for VS Code Simple Browser

### DIFF
--- a/.changeset/fifty-rabbits-enjoy.md
+++ b/.changeset/fifty-rabbits-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Link fixes for VS Code Simple Browser

--- a/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
@@ -10,15 +10,12 @@
 	<li>Schedule updates to your data</li>
 	<li>Re-build when you push changes to your project</li>
 </ul>
-<p>Evidence Cloud is in private beta. Request early access below.</p>
-<div class="new-format-buttons">
-	<button
-		type="button"
-		on:click={() =>
-			window.open(
-				'https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel'
-			)}>Request Early Access</button
-	>
+<p>Evidence Cloud is invite-only. Request an invite below.</p>
+
+<div class="new-format-buttons mb-3">
+	<button type="button">
+		<a class="text-white no-underline hover:no-underline" href='https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel'>Request an Invite</a>
+	</button>
 </div>
 
 <style>

--- a/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
@@ -14,7 +14,11 @@
 
 <div class="new-format-buttons mb-3">
 	<button type="button">
-		<a class="text-white no-underline hover:no-underline" href='https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel'>Request an Invite</a>
+		<a
+			class="text-white no-underline hover:no-underline"
+			href="https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel"
+			>Request an Invite</a
+		>
 	</button>
 </div>
 

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
@@ -81,7 +81,6 @@ from table`;
 			<p>
 				Add new formats to your project. Custom formats use <a
 					class="docs-link"
-					target="none"
 					href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68"
 					>excel-style format codes.</a
 				>
@@ -93,7 +92,6 @@ from table`;
 		<span
 			>Learn more about <a
 				class="docs-link"
-				target="none"
 				href="https://docs.evidence.dev/core-concepts/formatting/"
 			>
 				formatting in Evidence &rarr;</a

--- a/packages/core-components/src/lib/unsorted/ui/PageMenu.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/PageMenu.svelte
@@ -5,7 +5,7 @@
 <script>
 	import { dev } from '$app/environment';
 	import { Icon } from '@steeze-ui/svelte-icon';
-	import { DotsVertical, ExternalLink } from '@steeze-ui/tabler-icons';
+	import { DotsVertical } from '@steeze-ui/tabler-icons';
 
 	import clickOutside from '@evidence-dev/component-utilities/clickOutside';
 	import { showQueries, pageHasQueries } from '@evidence-dev/component-utilities/stores';

--- a/packages/core-components/src/lib/unsorted/ui/PageMenu.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/PageMenu.svelte
@@ -67,9 +67,8 @@
 						{:else if option.label === 'Export PDF'}
 							<button class="dropdown first" on:click={print}>{option.label}</button>
 						{:else if option.url.includes('http')}
-							<a href={option.url} target="_blank" rel="noreferrer">
+							<a href={option.url} rel="noreferrer">
 								{option.label}
-								<Icon src={ExternalLink} class="h-3 w-3" />
 							</a>
 						{:else}
 							<a href={option.url} target="_self">{option.label}</a>


### PR DESCRIPTION
### Description
Some links don't open in VS Code Simple Browser. This PR gets as many of the links to work as possible by ensuring links open in the current active window and tab.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
