### PR TITLE
Add redshift env vars to PG connector

### DIFF
--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -6,48 +6,72 @@ const envMap = {
 	host: [
 		{ key: 'EVIDENCE_POSTGRES_HOST', deprecated: false },
 		{ key: 'POSTGRES_HOST', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_HOST', deprecated: false },
+		{ key: 'REDSHIFT_HOST', deprecated: false },
 		{ key: 'host', deprecated: true },
 		{ key: 'HOST', deprecated: true }
 	],
 	port: [
 		{ key: 'EVIDENCE_POSTGRES_PORT', deprecated: false },
 		{ key: 'POSTGRES_PORT', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_PORT', deprecated: false },
+		{ key: 'REDSHIFT_PORT', deprecated: false },
 		{ key: 'port', deprecated: true },
 		{ key: 'PORT', deprecated: true }
 	],
 	database: [
 		{ key: 'EVIDENCE_POSTGRES_DATABASE', deprecated: false },
 		{ key: 'POSTGRES_DATABASE', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_DATABASE', deprecated: false },
+		{ key: 'REDSHIFT_DATABASE', deprecated: false },
 		{ key: 'database', deprecated: true },
 		{ key: 'DATABASE', deprecated: true }
 	],
 	user: [
 		{ key: 'EVIDENCE_POSTGRES_USER', deprecated: false },
 		{ key: 'POSTGRES_USER', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_USER', deprecated: false },
+		{ key: 'REDSHIFT_USER', deprecated: false },
 		{ key: 'user', deprecated: true },
 		{ key: 'USER', deprecated: true }
 	],
 	password: [
 		{ key: 'EVIDENCE_POSTGRES_PASSWORD', deprecated: false },
 		{ key: 'POSTGRES_PASSWORD', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_PASSWORD', deprecated: false },
+		{ key: 'REDSHIFT_PASSWORD', deprecated: false },
 		{ key: 'password', deprecated: true },
 		{ key: 'PASSWORD', deprecated: true }
 	],
 	ssl: [
 		{ key: 'EVIDENCE_POSTGRES_SSL', deprecated: false },
 		{ key: 'POSTGRES_SSL', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_SSL', deprecated: false },
+		{ key: 'REDSHIFT_SSL', deprecated: false },
 		{ key: 'ssl', deprecated: true },
 		{ key: 'SSL', deprecated: true }
 	],
 	connString: [
 		{ key: 'EVIDENCE_POSTGRES_CONNECTIONSTRING', deprecated: false },
 		{ key: 'POSTGRES_CONNECTIONSTRING', deprecated: false },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_CONNECTIONSTRING', deprecated: false },
+		{ key: 'REDSHIFT_CONNECTIONSTRING', deprecated: false },
 		{ key: 'CONNECTIONSTRING', deprecated: true },
 		{ key: 'connectionString', deprecated: true }
 	],
 	schema: [
 		{ key: 'EVIDENCE_POSTGRES_SCHEMA', deprecated: false },
 		{ key: 'POSTGRES_SCHEMA', deprecated: true },
+		// Redshift uses this env var
+		{ key: 'EVIDENCE_REDSHIFT_SCHEMA', deprecated: false },
+		{ key: 'REDSHIFT_SCHEMA', deprecated: true },
 		{ key: 'schema', deprecated: true },
 		{ key: 'SCHEMA', deprecated: true }
 	]

--- a/sites/docs/docs/cli/index.md
+++ b/sites/docs/docs/cli/index.md
@@ -59,9 +59,17 @@ Evidence does not currently support a `.env` file, but you can set environment v
 | EVIDENCE_SNOWFLAKE_PRIVATE_KEY      | Snowflake Private Key                                           |                                                                                       |
 | EVIDENCE_SNOWFLAKE_PASSPHRASE       | Snowflake Passphrase                                            |                                                                                       |
 | EVIDENCE_SNOWFLAKE_OKTA_URL         | Snowflake Okta URL                                              |                                                                                       |
-| EVIDENCE_POSTGRES_USER              | Postgres Username                                               |                                                                                       |
+| EVIDENCE_REDSHIFT_HOST              | Redshift Host                                                   |                                                                                       |
+| EVIDENCE_REDSHIFT_DATABASE          | Redshift Database                                               |                                                                                       |
+| EVIDENCE_REDSHIFT_USER              | Redshift Username                                               |                                                                                       |
+| EVIDENCE_REDSHIFT_PASSWORD          | Redshift Password                                               |                                                                                       |
+| EVIDENCE_REDSHIFT_PORT              | Redshift Port                                                   |                                                                                       |
+| EVIDENCE_REDSHIFT_SCHEMA            | Redshift Schema                                                 |                                                                                       |
+| EVIDENCE_REDSHIFT_SSL               | Redshift SSL                                                    | `true` , `false`, `no-verify`                                                         |
+| EVIDENCE_REDSHIFT_CONNECTIONSTRING  | Redshift Connection String                                      |                                                                                       |
 | EVIDENCE_POSTGRES_HOST              | Postgres Host                                                   |                                                                                       |
 | EVIDENCE_POSTGRES_DATABASE          | Postgres Database                                               |                                                                                       |
+| EVIDENCE_POSTGRES_USER              | Postgres Username                                               |                                                                                       |
 | EVIDENCE_POSTGRES_PASSWORD          | Postgres Password                                               |                                                                                       |
 | EVIDENCE_POSTGRES_PORT              | Postgres Port                                                   |                                                                                       |
 | EVIDENCE_POSTGRES_SCHEMA            | Postgres Schema                                                 |                                                                                       |


### PR DESCRIPTION
### Description

fixes #1199

I feel like there is probably a more elegant way where we could put the env maps into the redshift connector directly, but I dont really understand cjs and therefore how to achieve this

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
