### PR TITLE
Add a data source for Trino/Presto

### DIFF
--- a/.changeset/lovely-dolls-shop.md
+++ b/.changeset/lovely-dolls-shop.md
@@ -1,0 +1,12 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/db-orchestrator': patch
+'@evidence-dev/evidence': patch
+'@evidence-dev/postgres': patch
+'@evidence-dev/trino': patch
+'evidence-docs': patch
+'@evidence-dev/components': patch
+'evidence-test-environment': patch
+---
+
+Add support for Trino as a data source

--- a/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/DatabaseSettingsPanel.svelte
@@ -5,6 +5,7 @@
 <script>
 	import BigqueryForm from './BigqueryForm.svelte';
 	import PostgresForm from './PostgresForm.svelte';
+	import TrinoForm from './TrinoForm.svelte';
 	import SnowflakeForm from './SnowflakeForm.svelte';
 	import RedshiftForm from './RedshiftForm.svelte';
 	import MysqlForm from './MysqlForm.svelte';
@@ -33,6 +34,7 @@
 			docsHref: 'https://docs.evidence.dev/core-concepts/data-sources/#bigquery'
 		},
 		{ id: 'postgres', name: 'PostgreSQL', formComponent: PostgresForm },
+		{ id: 'trino', name: 'Trino', formComponent: TrinoForm },
 		{ id: 'mysql', name: 'MySQL', formComponent: MysqlForm },
 		{ id: 'redshift', name: 'Redshift', formComponent: RedshiftForm }, // Redshift uses the postgres connector under the hood
 		{ id: 'snowflake', name: 'Snowflake', formComponent: SnowflakeForm },

--- a/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
@@ -51,7 +51,7 @@
 			id: 'password',
 			label: 'Password',
 			type: 'password',
-			optional: false,
+			optional: true,
 			override: false,
 			placeholder: 'password',
 			value: credentials.password ?? ''

--- a/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
@@ -27,7 +27,7 @@
 			override: false,
 			placeholder: 'true',
 			value: credentials.ssl ?? '',
-			additionalInstructions: 'Options are true and false'
+			additionalInstructions: `Options are 'true' and 'false'. Must be set to 'true' for HTTPS`
 		},
 		{
 			id: 'port',
@@ -75,6 +75,16 @@
 			placeholder: 'metadata',
 			value: credentials.schema ?? '',
 			additionalInstructions: 'The default schema to run queries against.'
+		},
+		{
+			id: 'engine',
+			label: 'Engine',
+			type: 'text',
+			optional: true,
+			override: false,
+			placeholder: 'trino',
+			value: credentials.engine ?? '',
+			additionalInstructions: `The engine to use. Options are 'trino' and 'presto'. Default is 'trino'.`
 		}
 	];
 

--- a/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/TrinoForm.svelte
@@ -1,0 +1,84 @@
+<script context="module">
+	export const evidenceInclude = true;
+</script>
+
+<script>
+	export let credentials;
+	export let existingCredentials;
+	export let disableSave;
+
+	credentials = { ...existingCredentials };
+
+	let opts = [
+		{
+			id: 'host',
+			label: 'Host',
+			type: 'text',
+			optional: false,
+			override: false,
+			placeholder: 'database.server.com',
+			value: credentials.host ?? ''
+		},
+		{
+			id: 'ssl',
+			label: 'SSL',
+			type: 'text',
+			optional: true,
+			override: false,
+			placeholder: 'true',
+			value: credentials.ssl ?? '',
+			additionalInstructions: 'Options are true and false'
+		},
+		{
+			id: 'port',
+			label: 'Port',
+			type: 'text',
+			optional: false,
+			override: false,
+			placeholder: '443',
+			value: credentials.port ?? ''
+		},
+		{
+			id: 'user',
+			label: 'User',
+			type: 'text',
+			optional: false,
+			override: false,
+			placeholder: 'evidence',
+			value: credentials.user ?? ''
+		},
+		{
+			id: 'password',
+			label: 'Password',
+			type: 'password',
+			optional: false,
+			override: false,
+			placeholder: 'password',
+			value: credentials.password ?? ''
+		},
+		{
+			id: 'catalog',
+			label: 'Catalog',
+			type: 'text',
+			optional: true,
+			override: false,
+			placeholder: 'system',
+			value: credentials.catalog ?? '',
+			additionalInstructions: 'The default catalog to run queries against.'
+		},
+		{
+			id: 'schema',
+			label: 'Schema',
+			type: 'text',
+			optional: true,
+			override: false,
+			placeholder: 'metadata',
+			value: credentials.schema ?? '',
+			additionalInstructions: 'The default schema to run queries against.'
+		}
+	];
+
+	import GenericForm from './GenericForm.svelte';
+</script>
+
+<GenericForm {opts} bind:credentials bind:disableSave />

--- a/packages/core-components/src/lib/unsorted/ui/Databases/index.js
+++ b/packages/core-components/src/lib/unsorted/ui/Databases/index.js
@@ -7,6 +7,7 @@ export { default as InfoIcon } from './InfoIcon.svelte';
 export { default as MSSQLForm } from './MSSQLForm.svelte';
 export { default as MysqlForm } from './MysqlForm.svelte';
 export { default as PostgresForm } from './PostgresForm.svelte';
+export { default as TrinoForm } from './TrinoForm.svelte';
 export { default as RedshiftForm } from './RedshiftForm.svelte';
 export { default as SnowflakeForm } from './SnowflakeForm.svelte';
 export { default as SqliteForm } from './SqliteForm.svelte';

--- a/packages/db-orchestrator/package.json
+++ b/packages/db-orchestrator/package.json
@@ -13,6 +13,7 @@
 		"@evidence-dev/mssql": "workspace:^",
 		"@evidence-dev/mysql": "workspace:^",
 		"@evidence-dev/postgres": "workspace:^",
+		"@evidence-dev/trino": "workspace:^",
 		"@evidence-dev/redshift": "workspace:^",
 		"@evidence-dev/snowflake": "workspace:^",
 		"@evidence-dev/sqlite": "workspace:^",

--- a/packages/trino/.gitignore
+++ b/packages/trino/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/trino/index.cjs
+++ b/packages/trino/index.cjs
@@ -86,7 +86,7 @@ const runQuery = async (queryString, database) => {
 };
 
 const auth = (user, password) => {
-	user !== null && password !== null ? { user, password } : null;
+	return user !== null && password !== null ? { user, password } : null;
 };
 
 const adjustResult = (result) => {

--- a/packages/trino/index.cjs
+++ b/packages/trino/index.cjs
@@ -1,0 +1,135 @@
+const trino = require('presto-client');
+const { getEnv, EvidenceType, TypeFidelity } = require('@evidence-dev/db-commons');
+
+const envMap = {
+	host: [
+		{ key: 'EVIDENCE_TRINO_HOST', deprecated: false },
+		{ key: 'TRINO_HOST', deprecated: false },
+	],
+	ssl: [
+		{ key: 'EVIDENCE_TRINO_SSL', deprecated: false },
+		{ key: 'TRINO_SSL', deprecated: false },
+	],
+	port: [
+		{ key: 'EVIDENCE_TRINO_PORT', deprecated: false },
+		{ key: 'TRINO_PORT', deprecated: false },
+	],
+	user: [
+		{ key: 'EVIDENCE_TRINO_USER', deprecated: false },
+		{ key: 'TRINO_USER', deprecated: false },
+	],
+	password: [
+		{ key: 'EVIDENCE_TRINO_PASSWORD', deprecated: false },
+		{ key: 'TRINO_PASSWORD', deprecated: false },
+	],
+	catalog: [
+		{ key: 'EVIDENCE_TRINO_CATALOG', deprecated: false },
+		{ key: 'TRINO_CATALOG', deprecated: true },
+	],
+	schema: [
+		{ key: 'EVIDENCE_TRINO_SCHEMA', deprecated: false },
+		{ key: 'TRINO_SCHEMA', deprecated: true },
+	]
+};
+
+const runQuery = async (queryString, database) => {
+
+	const ssl = database ? database.ssl : getEnv(envMap, 'ssl')
+
+	const client = new trino.Client({
+		host: database ? database.host : getEnv(envMap, 'host'),
+		ssl: ssl === 'true' ? {} : undefined,
+		port: database ? database.port : getEnv(envMap, 'port'),
+		user: database ? database.user : getEnv(envMap, 'user'),
+		source: 'evidence',
+		basic_auth: database ? auth(database.user, database.password) : auth(getEnv(envMap, 'user'), getEnv(envMap, 'password')),
+		catalog: database ? database.catalog : getEnv(envMap, 'catalog'),
+		schema: database ? database.schema : getEnv(envMap, 'schema'),
+		engine: 'trino',
+	});
+
+	const result = await new Promise((resolve, reject) => {
+		let rows = []
+		let columnTypes = []
+		client.execute({
+			query: queryString,
+    	columns: function(_error, newColumnTypes){ columnTypes = columnTypes.concat(newColumnTypes) },
+			data: function(_error, newRows){ rows = rows.concat(newRows) },
+			callback: function(error){ error === null ? resolve({ rows, columnTypes }) : reject({ error }) },
+		});
+	});
+
+	const adjustedResult = adjustResult(result)
+
+	return adjustedResult;
+
+};
+
+const auth = (user, password) => {
+	user !== null && password !== null ? { user, password } : null
+};
+
+const adjustResult = (result) => {
+	const columnTypes = result.columnTypes.map((c) => {
+		return { name: normalizeColumnName(c.name), evidenceType: mapTrinoTypeToEvidenceType(c.type), typeFidelity: TypeFidelity.PRECISE }
+	})
+	const rows = result.rows.map((row) => {
+		const rowObj = {}
+		row.forEach((v, i) => {
+			let vAdjusted = typeof v === 'object' && v !== null ? v.toString() : v
+			rowObj[columnTypes[i].name] = vAdjusted
+		})
+		return rowObj
+	})
+	return { rows, columnTypes }
+};
+
+const normalizeColumnName = (name) => {
+	return name.toLowerCase().replaceAll(' ', '_')
+}
+
+const mapTrinoTypeToEvidenceType = (type) => {
+	const typeLower = type.toLowerCase()
+	// Trino's types as reported by the API can be found here:
+	// https://github.com/trinodb/trino/blob/master/client/trino-client/src/main/java/io/trino/client/ClientStandardTypes.java
+	switch (typeLower) {
+		case 'boolean':
+			return EvidenceType.BOOLEAN
+		case 'tinyint':
+		case 'smallint':
+		case 'integer':
+		case 'bigint':
+		case 'real':
+    case 'double':
+			return EvidenceType.NUMBER
+		case typeLower.match(/^decimal/)?.input: // TODO: treat decimal as a number too?
+		case 'varchar':
+		case typeLower.match(/^char/)?.input:
+		case 'varbinary':
+		case 'json':
+			return EvidenceType.STRING
+		case 'date':
+		case 'time':
+		case 'time with time zone':
+		case 'timestamp':
+		case 'timestamp with time zone':
+			return EvidenceType.DATE
+		case 'interval year to month':
+		case 'interval day to second':
+		case typeLower.match(/^array/)?.input:
+		case typeLower.match(/^map/)?.input:
+		case typeLower.match(/^row/)?.input:
+		case 'ipaddress':
+		case 'uuid':
+		case 'hyperloglog':
+		case 'p4hyperloglog':
+		case typeLower.match(/^qdigest/)?.input:
+		case 'geometry':
+		case 'sphericalgeography':
+			return EvidenceType.STRING
+		default:
+			return undefined
+	}
+}
+
+module.exports = runQuery;

--- a/packages/trino/package.json
+++ b/packages/trino/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@evidence-dev/trino",
+	"version": "0.1.0",
+	"description": "Trino driver for Evidence projects",
+	"main": "index.cjs",
+	"author": "evidence.dev",
+	"license": "MIT",
+	"scripts": {
+		"test": "uvu test test.js"
+	},
+	"dependencies": {
+		"@evidence-dev/db-commons": "workspace:^",
+		"presto-client": "^0.13.0"
+	},
+	"type": "module"
+}

--- a/packages/trino/test/test.js
+++ b/packages/trino/test/test.js
@@ -1,7 +1,7 @@
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
-import runQuery from '../index.cjs'
-import { TypeFidelity } from '@evidence-dev/db-commons'
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import runQuery from '../index.cjs';
+import { TypeFidelity } from '@evidence-dev/db-commons';
 
 const query = `
 SELECT
@@ -36,29 +36,92 @@ ST_Point(0, 0) AS geometry_col,
 to_spherical_geography(ST_Point(0, 0)) AS spherical_geography_col,
 bing_tile_at(40.7492, 73.9675, 1) AS bing_tile_col,
 1 AS "whitespace col"
-`
+`;
 
 test('query runs', async () => {
-	const result = await runQuery(query)
+	const result = await runQuery(query);
 
-	assert.instance(result.rows, Array)
-	assert.instance(result.columnTypes, Array)
-	assert.type(result.rows[0], 'object')
-	assert.equal(result.rows[0].boolean_col, true)
-	assert.equal(result.rows[0].tinyint_col, 1)
+	assert.instance(result.rows, Array);
+	assert.instance(result.columnTypes, Array);
+	assert.type(result.rows[0], 'object');
+	assert.equal(result.rows[0].boolean_col, true);
+	assert.equal(result.rows[0].tinyint_col, 1);
 
-	const actualColumnTypes = result.columnTypes.map((columnType) => columnType.evidenceType)
-	const actualColumnNames = result.columnTypes.map((columnType) => columnType.name)
-	const actualTypePrecisions = result.columnTypes.map((columnType) => columnType.typeFidelity)
+	const actualColumnTypes = result.columnTypes.map((columnType) => columnType.evidenceType);
+	const actualColumnNames = result.columnTypes.map((columnType) => columnType.name);
+	const actualTypePrecisions = result.columnTypes.map((columnType) => columnType.typeFidelity);
 
-	const expectedColumnTypes = ['boolean', 'number', 'number', 'number', 'number', 'number', 'number', 'string', 'string', 'string', 'string', 'string', 'date', 'date', 'date', 'date', 'date', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', undefined, 'number']
-	const expectedColumnNames = ['boolean_col', 'tinyint_col', 'smallint_col', 'integer_col', 'bigint_col', 'real_col', 'double_col', 'decimal_col', 'varchar_col', 'char_col', 'varbinary_col', 'json_col', 'date_col', 'time_col', 'time_with_timezone_col', 'timestamp_col', 'timestamp_with_timezone_col', 'interval_year_to_month_col', 'interval_day_to_second_col', 'array_col', 'map_col', 'row_col', 'ipaddress_col', 'uuid_col', 'hyper_log_log_col', 'p4_hyper_log_log_col', 'q_digest_col', 'geometry_col', 'spherical_geography_col', 'bing_tile_col', 'whitespace_col']
-	const expectedTypePrecisions = Array(result.columnTypes.length).fill(TypeFidelity.PRECISE)
+	const expectedColumnTypes = [
+		'boolean',
+		'number',
+		'number',
+		'number',
+		'number',
+		'number',
+		'number',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'date',
+		'date',
+		'date',
+		'date',
+		'date',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		'string',
+		undefined,
+		'number'
+	];
+	const expectedColumnNames = [
+		'boolean_col',
+		'tinyint_col',
+		'smallint_col',
+		'integer_col',
+		'bigint_col',
+		'real_col',
+		'double_col',
+		'decimal_col',
+		'varchar_col',
+		'char_col',
+		'varbinary_col',
+		'json_col',
+		'date_col',
+		'time_col',
+		'time_with_timezone_col',
+		'timestamp_col',
+		'timestamp_with_timezone_col',
+		'interval_year_to_month_col',
+		'interval_day_to_second_col',
+		'array_col',
+		'map_col',
+		'row_col',
+		'ipaddress_col',
+		'uuid_col',
+		'hyper_log_log_col',
+		'p4_hyper_log_log_col',
+		'q_digest_col',
+		'geometry_col',
+		'spherical_geography_col',
+		'bing_tile_col',
+		'whitespace_col'
+	];
+	const expectedTypePrecisions = Array(result.columnTypes.length).fill(TypeFidelity.PRECISE);
 
-	assert.equal(actualColumnTypes, expectedColumnTypes)
-	assert.equal(actualColumnNames, expectedColumnNames)
-	assert.equal(actualTypePrecisions, expectedTypePrecisions)
+	assert.equal(actualColumnTypes, expectedColumnTypes);
+	assert.equal(actualColumnNames, expectedColumnNames);
+	assert.equal(actualTypePrecisions, expectedTypePrecisions);
+});
 
-})
-
-test.run()
+test.run();

--- a/packages/trino/test/test.js
+++ b/packages/trino/test/test.js
@@ -1,0 +1,64 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import runQuery from '../index.cjs'
+import { TypeFidelity } from '@evidence-dev/db-commons'
+
+const query = `
+SELECT
+CAST(true AS BOOLEAN) AS boolean_col,
+CAST(1 AS TINYINT) AS tinyint_col,
+CAST(1 AS SMALLINT) AS smallint_col,
+CAST(1 AS INTEGER) AS integer_col,
+CAST(1 AS BIGINT) AS bigint_col,
+CAST(1.1 AS REAL) AS real_col,
+CAST(1.1 AS DOUBLE) AS double_col,
+CAST(1.1 AS DECIMAL) AS decimal_col,
+CAST('a' AS VARCHAR) AS varchar_col,
+CAST('a' AS CHAR) AS char_col,
+X'65683F' AS varbinary_col,
+CAST(json_object('a': 1, 'b': true) AS JSON) AS json_col,
+DATE '2001-08-22' AS date_col,
+TIME '10:00:00' AS time_col,
+TIME '10:00:00 -08:00' AS time_with_timezone_col,
+TIMESTAMP '2001-08-22 10:00:00' AS timestamp_col,
+TIMESTAMP '2001-08-22 10:00:00 -08:00' AS timestamp_with_timezone_col,
+INTERVAL '3' MONTH AS interval_year_to_month_col,
+INTERVAL '2' DAY AS interval_day_to_second_col,
+ARRAY[1, 2, 3] AS array_col,
+MAP(ARRAY['foo', 'bar'], ARRAY[1, 2]) AS map_col,
+CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE)) AS row_col,
+IPADDRESS '2001:db8::1' AS ipaddress_col,
+UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59' AS uuid_col,
+approx_set(1) AS hyper_log_log_col,
+CAST(approx_set(1) AS P4HyperLogLog) AS p4_hyper_log_log_col,
+qdigest_agg(1) AS q_digest_col,
+ST_Point(0, 0) AS geometry_col,
+to_spherical_geography(ST_Point(0, 0)) AS spherical_geography_col,
+bing_tile_at(40.7492, 73.9675, 1) AS bing_tile_col,
+1 AS "whitespace col"
+`
+
+test('query runs', async () => {
+	const result = await runQuery(query)
+
+	assert.instance(result.rows, Array)
+	assert.instance(result.columnTypes, Array)
+	assert.type(result.rows[0], 'object')
+	assert.equal(result.rows[0].boolean_col, true)
+	assert.equal(result.rows[0].tinyint_col, 1)
+
+	const actualColumnTypes = result.columnTypes.map((columnType) => columnType.evidenceType)
+	const actualColumnNames = result.columnTypes.map((columnType) => columnType.name)
+	const actualTypePrecisions = result.columnTypes.map((columnType) => columnType.typeFidelity)
+
+	const expectedColumnTypes = ['boolean', 'number', 'number', 'number', 'number', 'number', 'number', 'string', 'string', 'string', 'string', 'string', 'date', 'date', 'date', 'date', 'date', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', 'string', undefined, 'number']
+	const expectedColumnNames = ['boolean_col', 'tinyint_col', 'smallint_col', 'integer_col', 'bigint_col', 'real_col', 'double_col', 'decimal_col', 'varchar_col', 'char_col', 'varbinary_col', 'json_col', 'date_col', 'time_col', 'time_with_timezone_col', 'timestamp_col', 'timestamp_with_timezone_col', 'interval_year_to_month_col', 'interval_day_to_second_col', 'array_col', 'map_col', 'row_col', 'ipaddress_col', 'uuid_col', 'hyper_log_log_col', 'p4_hyper_log_log_col', 'q_digest_col', 'geometry_col', 'spherical_geography_col', 'bing_tile_col', 'whitespace_col']
+	const expectedTypePrecisions = Array(result.columnTypes.length).fill(TypeFidelity.PRECISE)
+
+	assert.equal(actualColumnTypes, expectedColumnTypes)
+	assert.equal(actualColumnNames, expectedColumnNames)
+	assert.equal(actualTypePrecisions, expectedTypePrecisions)
+
+})
+
+test.run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       '@evidence-dev/telemetry':
         specifier: workspace:^
         version: link:../telemetry
+      '@evidence-dev/trino':
+        specifier: workspace:^
+        version: link:../trino
       blueimp-md5:
         specifier: 2.18.0
         version: 2.18.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   got@<11.8.5: '>=11.8.5'
   jsonwebtoken@<=8.5.1: '>=9.0.0'
@@ -113,7 +109,7 @@ importers:
         version: 2.1.0
       svelte-preprocess:
         specifier: 5.0.3
-        version: 5.0.3(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.55.0)(typescript@4.9.5)
+        version: 5.0.3(@babel/core@7.22.15)(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.59.1)(typescript@5.0.4)
       svelte-tiny-linked-charts:
         specifier: 1.1.5
         version: 1.1.5
@@ -449,7 +445,7 @@ importers:
         version: 1.8.1
       svelte-preprocess:
         specifier: 5.0.3
-        version: 5.0.3(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.55.0)(typescript@4.9.5)
+        version: 5.0.3(@babel/core@7.22.15)(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.59.1)(typescript@5.0.4)
       svelte-tiny-linked-charts:
         specifier: 1.1.5
         version: 1.1.5
@@ -579,7 +575,7 @@ importers:
         version: 3.55.0
       svelte-preprocess:
         specifier: ^5.0.3
-        version: 5.0.3(svelte@3.55.0)(typescript@5.0.4)
+        version: 5.0.3(@babel/core@7.22.15)(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.59.1)(typescript@5.0.4)
       sveltekit-autoimport:
         specifier: ^1.7.0
         version: 1.7.0
@@ -652,7 +648,7 @@ importers:
         version: 3.55.0
       svelte-preprocess:
         specifier: 5.0.3
-        version: 5.0.3(svelte@3.55.0)(typescript@5.1.6)
+        version: 5.0.3(@babel/core@7.22.15)(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.59.1)(typescript@5.0.4)
       unified:
         specifier: ^9.1.0
         version: 9.1.0
@@ -759,6 +755,15 @@ importers:
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
+
+  packages/trino:
+    dependencies:
+      '@evidence-dev/db-commons':
+        specifier: workspace:^
+        version: link:../db-commons
+      presto-client:
+        specifier: ^0.13.0
+        version: 0.13.0
 
   sites/docs:
     dependencies:
@@ -19990,6 +19995,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  /presto-client@0.13.0:
+    resolution: {integrity: sha512-EL+oiqnMnGF8iPzAOiuZi5Ja7D2zIQkYZ9iJy+Ddwjapw3SZ6AzP71gN4KhqbM/9WLCFW8WxexqbWc//4L5kpg==}
+    dev: false
+
   /prettier-plugin-svelte@2.10.0(prettier@2.8.7)(svelte@3.55.0):
     resolution: {integrity: sha512-GXMY6t86thctyCvQq+jqElO+MKdB09BkL3hexyGP3Oi8XLKRFaJP1ud/xlWCZ9ZIa2BxHka32zhHfcuU+XsRQg==}
     peerDependencies:
@@ -22366,149 +22375,6 @@ packages:
       strip-indent: 3.0.0
       svelte: 3.59.1
       typescript: 5.0.4
-    dev: true
-
-  /svelte-preprocess@5.0.3(postcss-load-config@4.0.1)(postcss@8.4.23)(svelte@3.55.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==}
-    engines: {node: '>= 14.10.0'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.27.0
-      postcss: 8.4.23
-      postcss-load-config: 4.0.1(postcss@8.4.23)
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 3.55.0
-      typescript: 4.9.5
-
-  /svelte-preprocess@5.0.3(svelte@3.55.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==}
-    engines: {node: '>= 14.10.0'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.27.0
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 3.55.0
-      typescript: 5.0.4
-    dev: false
-
-  /svelte-preprocess@5.0.3(svelte@3.55.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==}
-    engines: {node: '>= 14.10.0'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.27.0
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 3.55.0
-      typescript: 5.1.6
-    dev: false
 
   /svelte-tiny-linked-charts@1.1.5:
     resolution: {integrity: sha512-27AlRKnz82GfswxoLkNjFtn1+C10bkpZb4kRH7d3qQVbgLLgNJY2ICSuWa+49Qh6jDFn6e/+qx3wWIz8kMmMkA==}
@@ -23228,6 +23094,7 @@ packages:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /ua-parser-js@0.7.34:
     resolution: {integrity: sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ==}
@@ -24756,3 +24623,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/sites/docs/docs/cli/index.md
+++ b/sites/docs/docs/cli/index.md
@@ -40,40 +40,47 @@ Evidence does not currently support a `.env` file, but you can set environment v
 
 All Redshift environment variables are set using the PostgreSQL variables.
 
-| Variable                            | Description                                                     | Options (if applicable)                                                               |
-| ----------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| EVIDENCE_DATABASE                   | The database to use.                                            | `bigquery` , `snowflake` , `redshift`, `postgres`, `mssql`, `mysql`, `sqlite`, `duckdb`, `csv` |
-| EVIDENCE_BIGQUERY_PROJECT_ID        | BigQuery Project ID                                             |                                                                                       |
-| EVIDENCE_BIGQUERY_CLIENT_EMAIL      | BigQuery Client Email                                           |                                                                                       |
-| EVIDENCE_BIGQUERY_PRIVATE_KEY       | BigQuery Private Key                                            |                                                                                       |
-| EVIDENCE_BIGQUERY_AUTHENTICATOR     | BigQuery Authenticator                                          | `oauth`, `gcloud-cli`, `service-account`                                              |
-| EVIDENCE_BIGQUERY_TOKEN             | BigQuery OAuth Token                                            |                                                                                       |
-| EVIDENCE_SNOWFLAKE_ACCOUNT          | Snowflake Account ID                                            |                                                                                       |
-| EVIDENCE_SNOWFLAKE_USERNAME         | Snowflake Username                                              |                                                                                       |
-| EVIDENCE_SNOWFLAKE_PASSWORD         | Snowflake Password                                              |                                                                                       |
-| EVIDENCE_SNOWFLAKE_DATABASE         | Snowflake Database                                              |                                                                                       |
-| EVIDENCE_SNOWFLAKE_WAREHOUSE        | Snowflake Warehouse                                             |                                                                                       |
-| EVIDENCE_SNOWFLAKE_ROLE             | Snowflake Role                                                  |                                                                                       |
-| EVIDENCE_SNOWFLAKE_SCHEMA           | Snowflake Schema                                                |                                                                                       |
-| EVIDENCE_SNOWFLAKE_AUTHENTICATOR    | Snowflake Authenticator                                         | `snowflake_jwt`, `externalbrowser`, `okta`, `snowflake`                               |
-| EVIDENCE_SNOWFLAKE_PRIVATE_KEY      | Snowflake Private Key                                           |                                                                                       |
-| EVIDENCE_SNOWFLAKE_PASSPHRASE       | Snowflake Passphrase                                            |                                                                                       |
-| EVIDENCE_SNOWFLAKE_OKTA_URL         | Snowflake Okta URL                                              |                                                                                       |
-| EVIDENCE_POSTGRES_USER              | Postgres Username                                               |                                                                                       |
-| EVIDENCE_POSTGRES_HOST              | Postgres Host                                                   |                                                                                       |
-| EVIDENCE_POSTGRES_DATABASE          | Postgres Database                                               |                                                                                       |
-| EVIDENCE_POSTGRES_PASSWORD          | Postgres Password                                               |                                                                                       |
-| EVIDENCE_POSTGRES_PORT              | Postgres Port                                                   |                                                                                       |
-| EVIDENCE_POSTGRES_SCHEMA            | Postgres Schema                                                 |                                                                                       |
-| EVIDENCE_POSTGRES_SSL               | Postgres SSL                                                    | `true` , `false`, `no-verify`                                                         |
-| EVIDENCE_POSTGRES_CONNECTIONSTRING  | Postgres Connection String                                      |                                                                                       |
-| EVIDENCE_MYSQL_USER                 | MySQL Username                                                  |                                                                                       |
-| EVIDENCE_MYSQL_HOST                 | MySQL Host                                                      |                                                                                       |
-| EVIDENCE_MYSQL_DATABASE             | MySQL Database                                                  |                                                                                       |
-| EVIDENCE_MYSQL_PASSWORD             | MySQL Password                                                  |                                                                                       |
-| EVIDENCE_MYSQL_PORT                 | MySQL Port                                                      |                                                                                       |
-| EVIDENCE_MYSQL_SOCKETPATH           | MySQL Socket Path                                               |                                                                                       |
-| EVIDENCE_MYSQL_SSL                  | MySQL SSL                                                       | `true` , `false`, `no-verify`                                                         |
-| EVIDENCE_SQLITE_FILENAME            | SQLite Filename                                                 |                                                                                       |
-| EVIDENCE_DUCKDB_FILENAME            | DuckDB Filename                                                 |                                                                                       |
-| SEND_ANONYMOUS_USAGE_STATS          | Send [anonymous usage stats](localhost:3000/settings#telemetry) | `yes` , `no`                                                                          |
+| Variable                            | Description                                                     | Options (if applicable)                                                                                 |
+| ----------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| EVIDENCE_DATABASE                   | The database to use.                                            | `bigquery` , `snowflake` , `redshift`, `postgres`, `trino`, `mssql`, `mysql`, `sqlite`, `duckdb`, `csv` |
+| EVIDENCE_BIGQUERY_PROJECT_ID        | BigQuery Project ID                                             |                                                                                                         |
+| EVIDENCE_BIGQUERY_CLIENT_EMAIL      | BigQuery Client Email                                           |                                                                                                         |
+| EVIDENCE_BIGQUERY_PRIVATE_KEY       | BigQuery Private Key                                            |                                                                                                         |
+| EVIDENCE_BIGQUERY_AUTHENTICATOR     | BigQuery Authenticator                                          | `oauth`, `gcloud-cli`, `service-account`                                                                |
+| EVIDENCE_BIGQUERY_TOKEN             | BigQuery OAuth Token                                            |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_ACCOUNT          | Snowflake Account ID                                            |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_USERNAME         | Snowflake Username                                              |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_PASSWORD         | Snowflake Password                                              |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_DATABASE         | Snowflake Database                                              |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_WAREHOUSE        | Snowflake Warehouse                                             |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_ROLE             | Snowflake Role                                                  |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_SCHEMA           | Snowflake Schema                                                |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_AUTHENTICATOR    | Snowflake Authenticator                                         | `snowflake_jwt`, `externalbrowser`, `okta`, `snowflake`                                                 |
+| EVIDENCE_SNOWFLAKE_PRIVATE_KEY      | Snowflake Private Key                                           |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_PASSPHRASE       | Snowflake Passphrase                                            |                                                                                                         |
+| EVIDENCE_SNOWFLAKE_OKTA_URL         | Snowflake Okta URL                                              |                                                                                                         |
+| EVIDENCE_POSTGRES_USER              | Postgres Username                                               |                                                                                                         |
+| EVIDENCE_POSTGRES_HOST              | Postgres Host                                                   |                                                                                                         |
+| EVIDENCE_POSTGRES_DATABASE          | Postgres Database                                               |                                                                                                         |
+| EVIDENCE_POSTGRES_PASSWORD          | Postgres Password                                               |                                                                                                         |
+| EVIDENCE_POSTGRES_PORT              | Postgres Port                                                   |                                                                                                         |
+| EVIDENCE_POSTGRES_SCHEMA            | Postgres Schema                                                 |                                                                                                         |
+| EVIDENCE_POSTGRES_SSL               | Postgres SSL                                                    | `true` , `false`, `no-verify`                                                                           |
+| EVIDENCE_POSTGRES_CONNECTIONSTRING  | Postgres Connection String                                      |                                                                                                         |
+| EVIDENCE_TRINO_HOST                 | Trino Host                                                      |                                                                                                         |
+| EVIDENCE_TRINO_SSL                  | Trino SSL                                                       |                                                                                                         |
+| EVIDENCE_TRINO_PORT                 | Trino Port                                                      |                                                                                                         |
+| EVIDENCE_TRINO_USER                 | Trino User                                                      |                                                                                                         |
+| EVIDENCE_TRINO_PASSWORD             | Trino Password                                                  |                                                                                                         |
+| EVIDENCE_TRINO_CATALOG              | Trino Catalog                                                   |                                                                                                         |
+| EVIDENCE_TRINO_SCHEMA               | Trino Schema                                                    |                                                                                                         |
+| EVIDENCE_MYSQL_USER                 | MySQL Username                                                  |                                                                                                         |
+| EVIDENCE_MYSQL_HOST                 | MySQL Host                                                      |                                                                                                         |
+| EVIDENCE_MYSQL_DATABASE             | MySQL Database                                                  |                                                                                                         |
+| EVIDENCE_MYSQL_PASSWORD             | MySQL Password                                                  |                                                                                                         |
+| EVIDENCE_MYSQL_PORT                 | MySQL Port                                                      |                                                                                                         |
+| EVIDENCE_MYSQL_SOCKETPATH           | MySQL Socket Path                                               |                                                                                                         |
+| EVIDENCE_MYSQL_SSL                  | MySQL SSL                                                       | `true` , `false`, `no-verify`                                                                           |
+| EVIDENCE_SQLITE_FILENAME            | SQLite Filename                                                 |                                                                                                         |
+| EVIDENCE_DUCKDB_FILENAME            | DuckDB Filename                                                 |                                                                                                         |
+| SEND_ANONYMOUS_USAGE_STATS          | Send [anonymous usage stats](localhost:3000/settings#telemetry) | `yes` , `no`                                                                                            |

--- a/sites/docs/docs/core-concepts/data-sources/index.md
+++ b/sites/docs/docs/core-concepts/data-sources/index.md
@@ -26,6 +26,7 @@ Evidence supports:
 - [Snowflake](#snowflake)
 - [Redshift](#redshift)
 - [PostgreSQL](#postgresql)
+- [Trino](#trino)
 - [Microsoft SQL Server](#mssql)
 - [MySQL](#mysql)
 - [SQLite](#sqlite)
@@ -102,8 +103,8 @@ The Browser-Based SSO method uses a browser-based SSO flow to authenticate. To u
 The Native SSO through Okta method uses Okta to authenticate. To use this method, you will need to have an Okta account with MFA disabled connected to your Snowflake account.
 
 ### Redshift
-
 The Redshift connector uses the Postgres connector under the hood, so configuration options are similar.
+
 ### PostgreSQL
 
 #### SSL
@@ -122,6 +123,8 @@ postgresql://{user}:{password}@{host}:{port}/{database}?sslmode=require&sslrootc
 ```
 
 Replace the various `{properties}` as needed, and replace `/path/to/file/ca-certificate.crt` with the path and filename of your certificate.
+
+### Trino
 
 ### Microsoft SQL Server {#mssql}
 

--- a/sites/docs/docs/core-concepts/data-sources/index.md
+++ b/sites/docs/docs/core-concepts/data-sources/index.md
@@ -126,6 +126,30 @@ Replace the various `{properties}` as needed, and replace `/path/to/file/ca-cert
 
 ### Trino
 
+#### Supported Authentication Types
+
+While Trino supports multiple [authentication types](https://trino.io/docs/current/security/authentication-types.html), the connector does currently only support the password based ones. Behind the scenes, the connector is using [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) for communicating with Trino.
+
+#### HTTPS
+
+To connect to a Trino installation that is accessible via HTTPS, you need to set the SSL option to `true` and the port to `443`/`8443` (unless you are using a non standard port for HTTPS, in which case you should use that instead).
+
+#### Starburst Quickstart
+
+[Starburst](https://www.starburst.io/), the company behind Trino, offers a SAAS solution where they run Trino for you. Once you have signed up and created a Trino cluster, you should be able to connect Evidence with the following configuration:
+
+Host: `<YOUR_DOMAIN>-<YOUR_CLUSTER_NAME>.galaxy.starburst.io`
+
+Port: `443`
+
+User: `<YOUR_EMAIL>/accountadmin`
+
+SSL: `true`
+
+Password: The password you use to login to you Starburst account
+
+Alternatively, you can also create a service account at `https://<YOUR_DOMAIN>.galaxy.starburst.io/service-accounts` and use this to connect.
+
 ### Microsoft SQL Server {#mssql}
 
 #### Trust Server Certificate

--- a/sites/docs/docs/core-concepts/data-sources/index.md
+++ b/sites/docs/docs/core-concepts/data-sources/index.md
@@ -146,7 +146,7 @@ User: `<YOUR_EMAIL>/accountadmin`
 
 SSL: `true`
 
-Password: The password you use to login to you Starburst account
+Password: The password you use to login to your Starburst account
 
 Alternatively, you can also create a service account at `https://<YOUR_DOMAIN>.galaxy.starburst.io/service-accounts` and use this to connect.
 


### PR DESCRIPTION
### Description

This PR adds a data source for [Trino](https://trino.io/)/[Presto](https://prestodb.io/).

Resolves #1095.

Adding Trino/Presto significantly increases the number of data sources supported by Evidence, as they function as data source aggregators.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

### Screenshots

#### The new connection form with a valid connection

![image](https://github.com/evidence-dev/evidence/assets/22156776/4982c00c-4a87-489a-806f-f7da8a6a2a42)

#### The new connection form with an invalid connection

![image](https://github.com/evidence-dev/evidence/assets/22156776/17c434ac-fd1e-4975-b99d-93212c5e9da1)

#### A query running against the new data source

![image](https://github.com/evidence-dev/evidence/assets/22156776/8040e2d4-0da6-4caa-89a4-831e3206aa93)
