### PR TITLE
support URL parameters in getStatusAndExtractQueries

### DIFF
--- a/sites/example-project/src/pages/api/status/[...route]/+server.js
+++ b/sites/example-project/src/pages/api/status/[...route]/+server.js
@@ -1,9 +1,8 @@
 import { getStatusAndExtractQueries } from './extractQueries.server.js';
 import { json } from '@sveltejs/kit';
 
-export async function GET({ params }) {
-	const { route } = params;
-	const status = getStatusAndExtractQueries('/' + route);
+export async function GET(event) {
+	const status = getStatusAndExtractQueries(event);
 	if (status) {
 		return json({ status });
 	}


### PR DESCRIPTION
This is kind of a "big security vulnerability" so not sure if we even feel comfortable making it `dev mode only`.

Not sure if it could be done even better to support proper parameterization or what we'd consider "good enough".

It enables you to write queries like this in Markdown on pages:

````
```sql query1
select
    COUNT(*)
from quote_snapshots
WHERE scraped_at >= '{{expiration_date}}T13:30:00' AND scraped_at <= '{{expiration_date}}T20:00:00'
```
````

![image](https://github.com/evidence-dev/evidence/assets/8949910/51f16584-d17b-44a0-acb5-c12c8a21a4dc)

Then you visit it in the browser at `http://localhost:10000/test/2023-10-03/`, etc.

I think this addresses some part of https://github.com/evidence-dev/evidence/issues/728