### PR TITLE
Use `-` instead of `{column.linkLabel}` for nullish linkLabel values

### DIFF
--- a/.changeset/thin-pens-care.md
+++ b/.changeset/thin-pens-care.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+display null instead of linkLabel column name when row[column.linkLabel] is null

--- a/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
@@ -422,35 +422,33 @@
                         "
 										/>
 									{:else if column.contentType === 'link' && row[column.id] !== undefined}
-										<a href={row[column.id]} target={column.openInNewTab ? '_blank' : ''}>
-											{#if column.linkLabel != undefined}
-												{#if row[column.linkLabel] != undefined}
-													{formatValue(
+										{#if column.linkLabel != undefined}
+											{#if row[column.linkLabel] != undefined}
+												{@const labelSummary = safeExtractColumn({ id: column.linkLabel })}
+												<a href={row[column.id]} target={column.openInNewTab ? '_blank' : ''}
+													>{formatValue(
 														row[column.linkLabel],
 														column.fmt
-															? getFormatObjectFromString(
-																	column.fmt,
-																	safeExtractColumn(column).format.valueType
-															  )
-															: safeExtractColumn(column).format,
-														safeExtractColumn(column).columnUnitSummary
-													)}
-												{:else}
-													-
-												{/if}
+															? getFormatObjectFromString(column.fmt, labelSummary.format.valueType)
+															: labelSummary.format,
+														labelSummary.columnUnitSummary
+													)}</a
+												>
 											{:else}
-												{formatValue(
-													row[column.id],
-													column.fmt
-														? getFormatObjectFromString(
-																column.fmt,
-																safeExtractColumn(column).format.valueType
-														  )
-														: safeExtractColumn(column).format,
-													safeExtractColumn(column).columnUnitSummary
-												)}
+												-
 											{/if}
-										</a>
+										{:else}
+											{formatValue(
+												row[column.id],
+												column.fmt
+													? getFormatObjectFromString(
+															column.fmt,
+															safeExtractColumn(column).format.valueType
+													  )
+													: safeExtractColumn(column).format,
+												safeExtractColumn(column).columnUnitSummary
+											)}
+										{/if}
 									{:else if column.contentType === 'delta' && row[column.id] !== undefined}
 										<div
 											class="m-0 text-xs font-medium font-ui"

--- a/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/DataTable.svelte
@@ -436,7 +436,7 @@
 														safeExtractColumn(column).columnUnitSummary
 													)}
 												{:else}
-													{column.linkLabel}
+													-
 												{/if}
 											{:else}
 												{formatValue(

--- a/sites/test-env/pages/null-datatable.md
+++ b/sites/test-env/pages/null-datatable.md
@@ -1,0 +1,8 @@
+```datum
+SELECT '1' AS id, null AS username UNION ALL SELECT '2' as id, 'johndoe' AS username UNION ALL SELECT '3' as id, 'janedoe' as username;
+```
+
+<DataTable data={datum}>
+	<Column id=username />
+	<Column id=id linkLabel=username contentType=link />
+</DataTable>


### PR DESCRIPTION
### Description

Before:
<img width="577" alt="image" src="https://github.com/evidence-dev/evidence/assets/61282104/97def86b-66a1-4ec4-bd99-434377048811">

After:
<img width="576" alt="image" src="https://github.com/evidence-dev/evidence/assets/61282104/1202085b-2f9e-44db-bc46-da16187301df">

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
