### PR TITLE
Adjust chart print width to fix Chrome print issue

### DIFF
--- a/.changeset/nervous-keys-yell.md
+++ b/.changeset/nervous-keys-yell.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Update print settings

--- a/packages/core-components/src/lib/unsorted/ui/QueryToast.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/QueryToast.svelte
@@ -56,4 +56,10 @@
 	span.status {
 		@apply font-medium;
 	}
+
+	@media print {
+		#toast {
+			display: none;
+		}
+	}
 </style>

--- a/packages/core-components/src/lib/unsorted/viz/EchartsCopyTarget.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/EchartsCopyTarget.svelte
@@ -31,7 +31,7 @@
 		class="chart"
 		style="
 		height: {height};
-		width: 645px;
+		width: 606px;
 		margin-left: 0;
 		margin-top: 15px;
 		margin-bottom: 10px;

--- a/packages/core-components/src/lib/unsorted/viz/EchartsCopyTarget.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/EchartsCopyTarget.svelte
@@ -31,7 +31,7 @@
 		class="chart"
 		style="
 		height: {height};
-		width: 606px;
+		width: 590px;
 		margin-left: 0;
 		margin-top: 15px;
 		margin-bottom: 10px;


### PR DESCRIPTION
### Description
Noticed that charts in Chrome are getting cut off when I try to export to PDF.

@mcrascal you might already know what's going on here - let me know what you think

<img width="400" alt="chrome-print-old" src="https://github.com/evidence-dev/evidence/assets/12602440/cae9287f-7a38-4c04-86bc-a939d7c02fb9">

But the same issue doesn't happen in Safari:

<img width="232" alt="safari-print-old" src="https://github.com/evidence-dev/evidence/assets/12602440/ca96fbc6-80a5-43c5-9a00-4a50c5233565">

I think there are 2 options here, but I don't totally understand why some things are working and others aren't, so maybe there are better ways:

### 1. Bring print width down from 645px to 606px
I took a look at the print width which was set to `645px` and adjusted it until it would fit on my page in Chrome. `606px` was the max I could do without it overflowing the margins of the page.

#### Chrome
<img width="400" alt="chrome-print-606" src="https://github.com/evidence-dev/evidence/assets/12602440/c654d251-d273-41ba-8448-7b11e52d52d0">

#### Safari
<img width="253" alt="safari-print-606" src="https://github.com/evidence-dev/evidence/assets/12602440/526b0af3-6694-40de-a9e9-3096f6d7cb45">

### 2. Use 100% as the chart width
This works for bringing the charts onto the page fully, but it causes the spacing above/below the charts to be bigger than it appears on the webpage, which isn't great.

#### Chrome
<img width="400" alt="chrome-print-100p" src="https://github.com/evidence-dev/evidence/assets/12602440/6bfcafe0-c428-4b3b-806e-51acbdcd9ee7">

#### Safari
<img width="245" alt="safari-print-100p" src="https://github.com/evidence-dev/evidence/assets/12602440/6f326925-18fb-42a9-824b-52c1847e753a">


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
