### PR TITLE
Fix links for vscode browser

### DIFF
--- a/.changeset/clean-dancers-love.md
+++ b/.changeset/clean-dancers-love.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix links to work in VS Code browser

--- a/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Deployment/EvidenceDeploy.svelte
@@ -6,15 +6,16 @@
 	<li>Schedule updates to your data</li>
 	<li>Re-build when you push changes to your project</li>
 </ul>
-<p>Evidence Cloud is in private beta. Request early access below.</p>
-<div class="new-format-buttons">
-	<button
-		type="button"
-		on:click={() =>
-			window.open(
-				'https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel'
-			)}>Request Early Access</button
-	>
+<p>Evidence Cloud is invite-only. Request an invite below.</p>
+
+<div class="new-format-buttons mb-3">
+	<button type="button">
+		<a
+			class="text-white no-underline hover:no-underline"
+			href="https://du3tapwtcbi.typeform.com/to/kwp7ZD3q?utm_source=product&utm_campaign=deploy_panel"
+			>Request an Invite</a
+		>
+	</button>
 </div>
 
 <style>

--- a/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
@@ -77,7 +77,6 @@ from table`;
 			<p>
 				Add new formats to your project. Custom formats use <a
 					class="docs-link"
-					target="none"
 					href="https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68"
 					>excel-style format codes.</a
 				>
@@ -89,7 +88,6 @@ from table`;
 		<span
 			>Learn more about <a
 				class="docs-link"
-				target="none"
 				href="https://docs.evidence.dev/core-concepts/formatting/"
 			>
 				formatting in Evidence &rarr;</a

--- a/packages/core-components/src/lib/unsorted/ui/Header.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/Header.svelte
@@ -166,7 +166,6 @@
 								<MenuItem let:active>
 									<a
 										href="https://docs.evidence.dev"
-										target="_blank"
 										rel="noreferrer"
 										class:active
 										class="w-full block text-left py-1 px-2 hover:bg-gray-100 rounded-[0.25rem]"


### PR DESCRIPTION
### Description
Opens settings links in same browser so they work in VS Code's simple browser.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
