### PR TITLE
Fix axis overrides for multiple y axes

### DIFF
--- a/.changeset/cuddly-dancers-collect.md
+++ b/.changeset/cuddly-dancers-collect.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix for axis settings when secondary axis enabled

--- a/packages/core-components/src/lib/unsorted/viz/Area.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Area.svelte
@@ -185,7 +185,7 @@
 		config.update((d) => {
 			d.tooltip = { ...d.tooltip, order: 'seriesDesc' }; // Areas always stacked
 			if (swapXY) {
-				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
 				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };

--- a/packages/core-components/src/lib/unsorted/viz/Bar.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Bar.svelte
@@ -257,7 +257,7 @@
 					}
 				}
 				if (swapXY) {
-					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+					d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 				} else {
 					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };

--- a/packages/core-components/src/lib/unsorted/viz/Bubble.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Bubble.svelte
@@ -270,7 +270,7 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
 				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };

--- a/packages/core-components/src/lib/unsorted/viz/Line.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Line.svelte
@@ -207,7 +207,7 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
 				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };

--- a/packages/core-components/src/lib/unsorted/viz/ReferenceArea.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/ReferenceArea.svelte
@@ -219,7 +219,7 @@
 		if (chartOverrides) {
 			config.update((d) => {
 				if (swapXY) {
-					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+					d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 					d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 				} else {
 					d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };

--- a/packages/core-components/src/lib/unsorted/viz/Scatter.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/Scatter.svelte
@@ -218,7 +218,7 @@
 	beforeUpdate(() => {
 		config.update((d) => {
 			if (swapXY) {
-				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.xAxis };
+				d.yAxis = { ...d.yAxis, ...chartOverrides.xAxis };
 				d.xAxis = { ...d.xAxis, ...chartOverrides.yAxis };
 			} else {
 				d.yAxis[0] = { ...d.yAxis[0], ...chartOverrides.yAxis };


### PR DESCRIPTION
### Description
Secondary y-axis PR introduced a secondary axis that is included in all XY charts and hidden by default. Any axis overrides were updated to reference the correct axis (`[0]` for the primary axis and `[1]` for secondary). I had forgotten that the hidden secondary axis is only included in charts where `swapXY=false`, so anything that was referencing `yAxis[0]` in a `swapXY=true` chart was causing issues. This PR fixes the referencing of the yAxis from swapXY charts.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
