### PR TITLE
Docs: note that Snowflake columns will be lowercase

### DIFF
--- a/sites/docs/docs/core-concepts/data-sources/index.md
+++ b/sites/docs/docs/core-concepts/data-sources/index.md
@@ -89,7 +89,7 @@ Now you can copy the access token and use it in your Evidence project.
 
 ### Snowflake
 
-Evidence supports connecting to Snowflake using a [Snowflake Account](https://docs.snowflake.com/en/user-guide/api-authentication), [Key-Pair Authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth.html), [Browser-Based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#label-browser-based-sso), or [Native SSO through Okta](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#label-native-sso-okta).
+Evidence supports connecting to Snowflake using a [Snowflake Account](https://docs.snowflake.com/en/user-guide/api-authentication), [Key-Pair Authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth.html), [Browser-Based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#label-browser-based-sso), or [Native SSO through Okta](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#label-native-sso-okta).  All Snowflake column names will be converted to lowercase in Evidence.
 
 #### Snowflake Account
 The Snowflake Account authentication method uses your Snowflake username and password to authenticate. If you don't have access to these, you will need to use one of the other authentication methods.


### PR DESCRIPTION
### Description

Documentation update: in the Snowflake section of Data Sources, add a note that all column names will be converted to lowercase in Evidence.  This is significant because Snowflake has the (weird) convention of all table and column names being being uppercase.

It looks like this was design choice made when the Snowflake connector was written, with a comment saying that an issue should be opened to consider this further:
https://github.com/evidence-dev/evidence/blob/cafd4b1f6002a25873949c6c1b62cb72cc4eacd7/packages/snowflake/index.cjs#L158C5-L158C5
