### PR TITLE
Fix multiple queries running on server start

### DIFF
--- a/.changeset/curly-foxes-battle.md
+++ b/.changeset/curly-foxes-battle.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+prevent multiple hits to the data API in the terminal

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -5,7 +5,7 @@ export const load = async ({ fetch, route, data: parentData }) => {
 
 		let data, json;
 		const res = await fetch(`/api/${routeHash}.json`);
-		
+
 		// don't clone the response if we're in dev mode as it causes multiple queries to fire
 		// but when building we do to bypass the proxy https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
 		if (dev) {

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,9 +1,7 @@
 export const load = async ({ fetch, route, data: parentData }) => {
 	if (route.id && route.id !== '/settings') {
 		const { customFormattingSettings, routeHash } = parentData;
-		const res = await fetch(`/api/${routeHash}.json`);
-		// has to be cloned to bypass the proxy https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
-		const { data } = await res.clone().json();
+		const { data } = await fetch(`/api/${routeHash}.json`).then(res=> res.json());
 
 		return {
 			data,

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,7 +1,7 @@
 export const load = async ({ fetch, route, data: parentData }) => {
 	if (route.id && route.id !== '/settings') {
 		const { customFormattingSettings, routeHash } = parentData;
-		const { data } = await fetch(`/api/${routeHash}.json`).then(res=> res.json());
+		const { data } = await fetch(`/api/${routeHash}.json`).then((res) => res.json());
 
 		return {
 			data,

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,7 +1,19 @@
+import { dev } from '$app/environment';
 export const load = async ({ fetch, route, data: parentData }) => {
 	if (route.id && route.id !== '/settings') {
 		const { customFormattingSettings, routeHash } = parentData;
-		const { data } = await fetch(`/api/${routeHash}.json`).then((res) => res.json());
+
+		let data, json;
+		const res = await fetch(`/api/${routeHash}.json`);
+		
+		// don't clone the response if we're in dev mode as it causes multiple queries to fire
+		// but when building we do to bypass the proxy https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
+		if (dev) {
+			json = await res.json();
+		} else {
+			json = await res.clone().json();
+		}
+		data = json.data;
 
 		return {
 			data,

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -3,17 +3,21 @@ export const load = async ({ fetch, route, data: parentData }) => {
 	if (route.id && route.id !== '/settings') {
 		const { customFormattingSettings, routeHash } = parentData;
 
-		let data, json;
 		const res = await fetch(`/api/${routeHash}.json`);
 
-		// don't clone the response if we're in dev mode as it causes multiple queries to fire
-		// but when building we do to bypass the proxy https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
-		if (dev) {
-			json = await res.json();
-		} else {
-			json = await res.clone().json();
-		}
-		data = json.data;
+		/*
+			Explanation of the below:
+			The SvelteKit `fetch` uses a proxy[0] to prevent a request happening on
+			both server and client execution of load functions
+			- This is good during dev, as it prevents the multiple queries from firing
+			- But bad during build, as it inlines the response into the SSR'd page,
+			  which blows up build folder/html size
+			So, we conditionally clone the response to bypass the proxy during build,
+			but not during dev
+
+			[0] - https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
+		*/
+		const { data } = dev? await res.json() : await res.clone().json();
 
 		return {
 			data,

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -17,7 +17,7 @@ export const load = async ({ fetch, route, data: parentData }) => {
 
 			[0] - https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/load_data.js#L297
 		*/
-		const { data } = dev? await res.json() : await res.clone().json();
+		const { data } = dev ? await res.json() : await res.clone().json();
 
 		return {
 			data,

--- a/sites/example-project/src/pages/templated-pages/[category]/[item]/+page.md
+++ b/sites/example-project/src/pages/templated-pages/[category]/[item]/+page.md
@@ -11,3 +11,8 @@ The most recent monthly sales of {$page.params.item}s was {fmt(orders_by_item.fi
 
 <LineChart data={orders_by_item.filter(d => d.item?.toLowerCase() === $page.params.item?.toLowerCase())} x=month y=sales_usd0k/>
 
+```sql orders
+select * from orders
+```
+
+{orders.length}


### PR DESCRIPTION
This prevents queries from executing twice when pages load in development.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
