### PR TITLE
Add LastRefreshed component

### DIFF
--- a/.changeset/giant-lizards-help.md
+++ b/.changeset/giant-lizards-help.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/components': patch
+---
+
+Add LastRefreshed component

--- a/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
@@ -3,39 +3,42 @@
 </script>
 
 <script>
-    import { version } from '$app/environment';
-    const timestamp = Number(version);
+	import { version } from '$app/environment';
+	const timestamp = Number(version);
 
-    export let prefix = 'Last refreshed';
+	export let prefix = 'Last refreshed';
 
-    function timeAgo(startTimestamp, endTimestamp) {
-        const secondsAgo = Math.floor((endTimestamp - startTimestamp) / 1000);
+	function timeAgo(startTimestamp, endTimestamp) {
+		const secondsAgo = Math.floor((endTimestamp - startTimestamp) / 1000);
 
-        if (secondsAgo < 60) {
-            return secondsAgo === 1 ? '1 second ago' : `${secondsAgo} seconds ago`;
-        } else if (secondsAgo < 3600) {
-            const minutesAgo = Math.round(secondsAgo / 60);
-            return minutesAgo === 1 ? '1 min ago' : `${minutesAgo} mins ago`;
-        } else if (secondsAgo < 86400) {
-            const hoursAgo = (secondsAgo / 3600).toFixed(1);
-            return hoursAgo === '1' ? '1 hour ago' : `${hoursAgo} hours ago`;
-        } else if (secondsAgo < 604800) { 
-            const daysAgo = Math.round(secondsAgo / 86400); 
-            return daysAgo === 1 ? '1 day ago' : `${daysAgo} days ago`;
-        } else if (secondsAgo < 2592000) { 
-            const weeksAgo = Math.round(secondsAgo / 604800);
-            return weeksAgo === 1 ? '1 week ago' : `${weeksAgo} weeks ago`;
-        } else if (secondsAgo < 31536000) {
-            const monthsAgo = Math.round(secondsAgo / 2592000);
-            return monthsAgo === 1 ? '1 month ago' : `${monthsAgo} months ago`;
-        } else {
-            const yearsAgo = Math.round(secondsAgo / 31536000);
-            return yearsAgo === 1 ? '1 year ago' : `${yearsAgo} years ago`;
-        }
-    }
+		if (secondsAgo < 60) {
+			return secondsAgo === 1 ? '1 second ago' : `${secondsAgo} seconds ago`;
+		} else if (secondsAgo < 3600) {
+			const minutesAgo = Math.round(secondsAgo / 60);
+			return minutesAgo === 1 ? '1 min ago' : `${minutesAgo} mins ago`;
+		} else if (secondsAgo < 86400) {
+			const hoursAgo = (secondsAgo / 3600).toFixed(1);
+			return hoursAgo === '1' ? '1 hour ago' : `${hoursAgo} hours ago`;
+		} else if (secondsAgo < 604800) {
+			const daysAgo = Math.round(secondsAgo / 86400);
+			return daysAgo === 1 ? '1 day ago' : `${daysAgo} days ago`;
+		} else if (secondsAgo < 2592000) {
+			const weeksAgo = Math.round(secondsAgo / 604800);
+			return weeksAgo === 1 ? '1 week ago' : `${weeksAgo} weeks ago`;
+		} else if (secondsAgo < 31536000) {
+			const monthsAgo = Math.round(secondsAgo / 2592000);
+			return monthsAgo === 1 ? '1 month ago' : `${monthsAgo} months ago`;
+		} else {
+			const yearsAgo = Math.round(secondsAgo / 31536000);
+			return yearsAgo === 1 ? '1 year ago' : `${yearsAgo} years ago`;
+		}
+	}
 
-    const varTimeAgo = timeAgo(timestamp, Date.now())
-
+	const varTimeAgo = timeAgo(timestamp, Date.now());
 </script>
 
-<p class="text-sm py-1"><a href=" " class="cursor-text" title="{new Date(timestamp).toLocaleString()} ">{prefix} {varTimeAgo}</a> </p>
+<p class="text-sm py-1">
+	<a href=" " class="cursor-text" title="{new Date(timestamp).toLocaleString()} "
+		>{prefix} {varTimeAgo}</a
+	>
+</p>

--- a/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
@@ -1,0 +1,41 @@
+<script context="module">
+	export const evidenceInclude = true;
+</script>
+
+<script>
+    import { version } from '$app/environment';
+    const timestamp = Number(version);
+
+    export let prefix = 'Last refreshed';
+
+    function timeAgo(startTimestamp, endTimestamp) {
+        const secondsAgo = Math.floor((endTimestamp - startTimestamp) / 1000);
+
+        if (secondsAgo < 60) {
+            return secondsAgo === 1 ? '1 second ago' : `${secondsAgo} seconds ago`;
+        } else if (secondsAgo < 3600) {
+            const minutesAgo = Math.round(secondsAgo / 60);
+            return minutesAgo === 1 ? '1 min ago' : `${minutesAgo} mins ago`;
+        } else if (secondsAgo < 86400) {
+            const hoursAgo = (secondsAgo / 3600).toFixed(1);
+            return hoursAgo === '1' ? '1 hour ago' : `${hoursAgo} hours ago`;
+        } else if (secondsAgo < 604800) { 
+            const daysAgo = Math.round(secondsAgo / 86400); 
+            return daysAgo === 1 ? '1 day ago' : `${daysAgo} days ago`;
+        } else if (secondsAgo < 2592000) { 
+            const weeksAgo = Math.round(secondsAgo / 604800);
+            return weeksAgo === 1 ? '1 week ago' : `${weeksAgo} weeks ago`;
+        } else if (secondsAgo < 31536000) {
+            const monthsAgo = Math.round(secondsAgo / 2592000);
+            return monthsAgo === 1 ? '1 month ago' : `${monthsAgo} months ago`;
+        } else {
+            const yearsAgo = Math.round(secondsAgo / 31536000);
+            return yearsAgo === 1 ? '1 year ago' : `${yearsAgo} years ago`;
+        }
+    }
+
+    const varTimeAgo = timeAgo(timestamp, Date.now())
+
+</script>
+
+<p class="text-sm py-1"><a href=" " class="cursor-text" title="{new Date(timestamp).toLocaleString()} ">{prefix} {varTimeAgo}</a> </p>

--- a/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
@@ -37,8 +37,6 @@
 	const varTimeAgo = timeAgo(timestamp, Date.now());
 </script>
 
-<p class="text-sm py-1">
-	<a href=" " class="cursor-text" title="{new Date(timestamp).toLocaleString()} "
-		>{prefix} {varTimeAgo}</a
-	>
+<p class="text-sm py-1 cursor-text" title="{new Date(timestamp).toLocaleString()}">
+	{prefix} {varTimeAgo}
 </p>

--- a/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/LastRefreshed.svelte
@@ -37,6 +37,7 @@
 	const varTimeAgo = timeAgo(timestamp, Date.now());
 </script>
 
-<p class="text-sm py-1 cursor-text" title="{new Date(timestamp).toLocaleString()}">
-	{prefix} {varTimeAgo}
+<p class="text-sm py-1 cursor-text" title={new Date(timestamp).toLocaleString()}>
+	{prefix}
+	{varTimeAgo}
 </p>

--- a/packages/core-components/src/lib/unsorted/ui/index.js
+++ b/packages/core-components/src/lib/unsorted/ui/index.js
@@ -9,6 +9,7 @@ export { default as Details } from './Details.svelte';
 export { default as DownloadData } from './DownloadData.svelte';
 export { default as EmailSignup } from './EmailSignup.svelte';
 export { default as Header } from './Header.svelte';
+export { default as LastRefreshed } from './LastRefreshed.svelte';
 export { default as LoadingIndicator } from './LoadingIndicator.svelte';
 export { default as LoadingSkeleton } from './LoadingSkeleton.svelte';
 export { default as Logo } from './Logo.svelte';

--- a/sites/example-project/src/pages/ui-components/last-refreshed/+page.md
+++ b/sites/example-project/src/pages/ui-components/last-refreshed/+page.md
@@ -1,0 +1,17 @@
+# Last Refreshed
+
+### Default
+
+```svelte
+<LastRefreshed/>
+```
+
+<LastRefreshed/>
+
+### Custom Prefix
+
+```svelte
+<LastRefreshed prefix="Updated"/>
+```
+
+<LastRefreshed prefix="Updated"/>


### PR DESCRIPTION
### Description
Adds `LastRefreshed` component, which shows the time since the last build took place.

Can see the full date/time by hovering over the text.

```html
<LastRefreshed/>
```

<img width="194" alt="CleanShot 2023-11-05 at 21 14 14@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/3392b442-6824-4847-ab48-3428f8dc06e2">

<img width="283" alt="CleanShot 2023-11-05 at 21 14 37@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/48e2c4cd-b02c-4369-9e92-558f39b1bd94">


#### Props
- `prefix`: allows you to set a custom prefix (e.g., "Updated" instead of the default "Last Refreshed")


```html
<LastRefreshed prefix="Updated"/>
```

<img width="189" alt="CleanShot 2023-11-05 at 21 16 10@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/26eee198-a6cd-46e7-b1f3-3fddfb864811">

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
