### PR TITLE
Fix hard refresh on initial project boot

### DIFF
--- a/.changeset/yellow-cows-perform.md
+++ b/.changeset/yellow-cows-perform.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+fix hard refresh on first project boot

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -43,7 +43,7 @@ fsExtra.outputFileSync(
     {
         plugins: [sveltekit()],
         optimizeDeps: {
-            include: ['echarts-stat', 'echarts'],
+            include: ['echarts-stat', 'echarts', '@evidence-dev/core-components', '@evidence-dev/component-utilities/stores', '@evidence-dev/component-utilities/formatting', '@evidence-dev/component-utilities/globalContexts'],
             exclude: ['svelte-icons', 'svelte-tiny-linked-charts']
         },
         ssr: {


### PR DESCRIPTION
### Description

Adds dependencies that vite can't find (plugin-connector inserted `@evidence-dev/core-components` imports, imports added in preprocess)

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
