### PR TITLE
Explicitly set font family for chart theme

### DIFF
--- a/.changeset/chatty-pugs-sleep.md
+++ b/.changeset/chatty-pugs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/component-utilities': patch
+---
+
+Explicitly set font family for chart theme

--- a/packages/component-utilities/src/echartsThemes.js
+++ b/packages/component-utilities/src/echartsThemes.js
@@ -12,8 +12,8 @@ const light_legendPageTextColor = uiColours.grey500;
 const light_tooltipBorderColor = uiColours.grey400;
 const light_tooltipBackgroundColor = 'white';
 const light_tooltipTextColor = uiColours.grey900;
-const light_titleColor = uiColours.grey700;
-const light_subtitleColor = uiColours.grey600;
+const light_titleColor = uiColours.grey800;
+const light_subtitleColor = uiColours.grey700;
 
 // Dark Mode Theme
 const dark_axisBaselineColor = uiColours.grey500;

--- a/packages/component-utilities/src/echartsThemes.js
+++ b/packages/component-utilities/src/echartsThemes.js
@@ -34,6 +34,9 @@ const dark_subtitleColor = uiColours.grey400;
 
 export const evidenceThemeLight = {
 	darkMode: false, // if true, echarts will automatically update the font colour to work better on dark background
+	textStyle: {
+		fontFamily: 'sans-serif'
+	},
 	grid: {
 		left: '0%',
 		right: '4%',
@@ -445,6 +448,9 @@ export const evidenceThemeLight = {
 
 export const evidenceThemeDark = {
 	darkMode: true, // if true, echarts will automatically update the font colour to work better on dark background
+	textStyle: {
+		fontFamily: 'sans-serif'
+	},
 	grid: {
 		left: '0%',
 		right: '4%',


### PR DESCRIPTION
### Description
On some operating systems, the font shown in charts is inconsistent with the UI font. This PR explicitly sets the font family within the echarts theme so the font is more consistent across operating systems.

In the future, we should consider changing the font family from `sans-serif` to `inter`, but on trying it here I noticed spacing issues that would need to be worked out.

#### Windows Before
![windows-chartfont-before](https://github.com/evidence-dev/evidence/assets/12602440/6830c1ed-bc3a-4001-8dcb-4136d19fed7e)

#### Windows After
![windows-chartfont-after](https://github.com/evidence-dev/evidence/assets/12602440/b54eb642-55e6-430b-acea-6f5ca81ac223)

### Title colours
This also slightly darkens the default chart title and subtitle colour to fit better with the new project styling:

#### Before:
<img width="789" alt="CleanShot 2023-11-07 at 21 37 24@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/67583fa9-f7b0-4ad4-acea-7a079e1f4e36">

#### After:
<img width="782" alt="CleanShot 2023-11-07 at 21 37 36@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/d29c0345-b518-445b-b696-75a7b908b6ae">

Still might be a touch too light, but we can start here

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
