### PR TITLE
Polish working with sources

### DIFF
--- a/.changeset/four-pigs-punch.md
+++ b/.changeset/four-pigs-punch.md
@@ -1,0 +1,7 @@
+---
+'@evidence-dev/evidence': patch
+'@evidence-dev/plugin-connector': patch
+'@evidence-dev/universal-sql': patch
+---
+
+polish working with sources

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -19,9 +19,14 @@ const populateTemplate = function () {
 	// - local settings
 	// - telemetry profile
 	// - static folder (mainly to preserve the data directory)
+	const keepers = new Set([
+		'evidence.settings.json',
+		'.profile.json',
+		'static',
+		'.evidence-queries'
+	]);
 	fs.readdirSync('./.evidence/template/').forEach((file) => {
-		if (file != 'evidence.settings.json' && file != '.profile.json' && file != 'static')
-			fs.removeSync(path.join('./.evidence/template/', file));
+		if (!keepers.has(file)) fs.removeSync(path.join('./.evidence/template/', file));
 	});
 
 	fs.copySync(path.join(__dirname, '/template'), './.evidence/template/');

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -212,7 +212,7 @@ prog
 	.action(async (opts) => {
 		const sources = opts.sources?.split(',') ?? null;
 		const queries = opts.queries?.split(',') ?? null;
-		updateDatasourceOutputs(`./static/data`, '/data', {
+		updateDatasourceOutputs('./.evidence/template', '/data', {
 			sources: sources ? new Set(sources) : sources,
 			queries: queries ? new Set(queries) : queries,
 			only_changed: opts.changed

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -15,9 +15,12 @@ const populateTemplate = function () {
 
 	fs.ensureDirSync('./.evidence/template/');
 
-	// empty the template directory, except any local settings, or telemetry profile that already exist.
+	// empty the template directory, except:
+	// - local settings
+	// - telemetry profile
+	// - static folder (mainly to preserve the data directory)
 	fs.readdirSync('./.evidence/template/').forEach((file) => {
-		if (file != 'evidence.settings.json' && file != '.profile.json')
+		if (file != 'evidence.settings.json' && file != '.profile.json' && file != 'static')
 			fs.removeSync(path.join('./.evidence/template/', file));
 	});
 

--- a/packages/plugin-connector/src/build-plugins/source-query-hmr.js
+++ b/packages/plugin-connector/src/build-plugins/source-query-hmr.js
@@ -31,20 +31,19 @@ if (process.env.NODE_ENV === 'development') {
 
 		build_watcher.emit('change', path);
 
-		// go in ../.. (root) vs. . (aka .evidence/template)
-		const error = await updateDatasourceOutputs(`../../static/data`, '/data', {
+		// go in . (aka .evidence/template)
+		const error = await updateDatasourceOutputs('.', '/data', {
 			sources: new Set([datasource.name]),
 			queries: source_path.endsWith('connection.yaml') ? null : new Set([query]),
 			only_changed: false
 		}).catch((e) => e);
 		await rm('./.evidence-queries', { recursive: true, force: true });
-		await cp('../../static/data', './static/data', { recursive: true });
 
 		if (error) {
 			console.error(`Error occured while reloading source: ${error}`);
 			build_watcher.emit('done', path, {}, error);
 		} else {
-			const manifest = await readFile('../../static/data/manifest.json', 'utf-8');
+			const manifest = await readFile('./static/data/manifest.json', 'utf-8');
 			build_watcher.emit('done', path, manifest, null);
 		}
 	});

--- a/packages/plugin-connector/src/cli.js
+++ b/packages/plugin-connector/src/cli.js
@@ -46,7 +46,7 @@ program
 		const datasources = await getSources(datasourceDir);
 		const plugins = await getDatasourcePlugins();
 		for (const source of datasources) {
-			await execSource(source, plugins, source.sourceDirectory);
+			await execSource(source, plugins, source.sourceDirectory, '/data');
 		}
 	});
 

--- a/packages/plugin-connector/src/data-sources/exec-source.js
+++ b/packages/plugin-connector/src/data-sources/exec-source.js
@@ -27,7 +27,7 @@ export const execSource = async (source, supportedDbs, outputDirectory, outputPr
 	// Can we somehow guess based on the number of columns?
 	// e.g. 1-10 columns -> 1m, 11+ -> 100k?
 
-	const batchSize = 1000 * 1000; // 1m
+	const batchSize = 100 * 1000; // 1m
 	const db = supportedDbs[source.type];
 	const runner = await db.factory(source.options, source.sourceDirectory);
 
@@ -111,6 +111,7 @@ export const execSource = async (source, supportedDbs, outputDirectory, outputPr
 			outputDirectory,
 			outputPrefix,
 			outputFilename,
+			result.expectedRowCount,
 			batchSize
 		);
 
@@ -133,7 +134,7 @@ export const execSource = async (source, supportedDbs, outputDirectory, outputPr
 		);
 
 		console.log(
-			` <| Finished ${filename} Returned ${writtenRows} rows. (took ${(
+			` <| Finished ${filename} Returned ${writtenRows.toLocaleString()} rows. (took ${(
 				performance.now() - beforeQuery
 			).toFixed(2)}ms)\n`
 		);

--- a/packages/plugin-connector/src/data-sources/index.js
+++ b/packages/plugin-connector/src/data-sources/index.js
@@ -98,7 +98,7 @@ export async function getDatasourceOptions() {
 }
 
 /**
- * @param {string} outDir
+ * @param {string} outDir The path to .evidence/template
  * @param {string} [prefix]
  * @param {{ sources: Set<string> | null, queries: Set<string> | null, only_changed: boolean }} [filters] `sources` or `queries` being null means no filter
  */
@@ -154,5 +154,5 @@ export async function updateDatasourceOutputs(
 		outputFiles[source.name].push(...newFiles.map((nf) => `${prefix}${nf}`));
 	}
 
-	await updateManifest(outputFiles, outDir, datasources);
+	await updateManifest(outputFiles, path.join(outDir, 'static', prefix), datasources);
 }

--- a/packages/plugin-connector/src/data-sources/index.js
+++ b/packages/plugin-connector/src/data-sources/index.js
@@ -130,11 +130,7 @@ export async function updateDatasourceOutputs(
 			});
 			return { ...source, queries };
 		})
-		.filter(
-			(source) =>
-				source.queries.length > 0 ||
-				console.log(`No queries left for source ${source.name} after filtration`)
-		);
+		.filter((source) => source.queries.length > 0);
 
 	for (const source of filteredDatasources) {
 		sourceHashes[source.name] = sourceHashes[source.name] ?? {};

--- a/packages/plugin-connector/src/data-sources/index.js
+++ b/packages/plugin-connector/src/data-sources/index.js
@@ -104,7 +104,7 @@ export async function getDatasourceOptions() {
  */
 export async function updateDatasourceOutputs(
 	outDir,
-	prefix,
+	prefix = '',
 	filters = { sources: null, queries: null, only_changed: false }
 ) {
 	const datasourceDir = await getSourcesDir();
@@ -150,12 +150,8 @@ export async function updateDatasourceOutputs(
 	const outputFiles = {};
 	for (const source of filteredDatasources) {
 		outputFiles[source.name] = [];
-		const newFiles = await execSource(source, plugins, outDir);
-		if (prefix) {
-			outputFiles[source.name].push(...newFiles.map((nf) => `${prefix}${nf}`));
-		} else {
-			outputFiles[source.name].push(...newFiles);
-		}
+		const newFiles = await execSource(source, plugins, outDir, prefix);
+		outputFiles[source.name].push(...newFiles.map((nf) => `${prefix}${nf}`));
 	}
 
 	await updateManifest(outputFiles, outDir, datasources);

--- a/packages/universal-sql/package.json
+++ b/packages/universal-sql/package.json
@@ -19,6 +19,7 @@
 		"@types/node": "^20.8.4",
 		"apache-arrow": "^11.0.0",
 		"chalk": "^5.2.0",
+		"cli-progress": "^3.12.0",
 		"duckdb": "^0.8.1",
 		"lodash.chunk": "^4.2.0",
 		"parquet-wasm": "0.3.1",

--- a/packages/universal-sql/src/build-parquet.d.ts
+++ b/packages/universal-sql/src/build-parquet.d.ts
@@ -12,6 +12,8 @@ export function buildParquetFromResultSet(
 export function buildMultipartParquet<T extends Record<string, any>>(
 	columns: { name: string; evidenceType: string }[],
 	data: Generator<T[]> | Promise<Generator<T[]>> | T[] | Promise<T[]>,
+	outputDirectory: string,
+	outputPrefix: string,
 	outputFilename: string,
 	batchSize?: number
 ): Promise<string | false>;

--- a/packages/universal-sql/src/build-parquet.d.ts
+++ b/packages/universal-sql/src/build-parquet.d.ts
@@ -15,5 +15,6 @@ export function buildMultipartParquet<T extends Record<string, any>>(
 	outputDirectory: string,
 	outputPrefix: string,
 	outputFilename: string,
+	expectedRowCount?: number,
 	batchSize?: number
 ): Promise<string | false>;

--- a/packages/universal-sql/src/build-parquet.js
+++ b/packages/universal-sql/src/build-parquet.js
@@ -137,16 +137,14 @@ export async function buildMultipartParquet(columns, data, outputFilename, batch
 
 	await initDB();
 
+	const outputFilepath = path.join('.', 'static', 'data', outputFilename);
+	await fs.mkdir(path.dirname(outputFilepath), { recursive: true });
+
 	const parquetFiles = tmpFilenames
 		.map((filename) => `'${filename.replaceAll('\\', '/')}'`)
 		.join(',');
 	const select = `SELECT * FROM read_parquet([${parquetFiles}])`;
-	const copy = `COPY (${select}) TO '${path.join(
-		'.',
-		'static',
-		'data',
-		outputFilename
-	)}' (FORMAT 'PARQUET', CODEC 'ZSTD');`;
+	const copy = `COPY (${select}) TO '${outputFilepath}' (FORMAT 'PARQUET', CODEC 'ZSTD');`;
 
 	await query(copy);
 

--- a/packages/universal-sql/src/build-parquet.js
+++ b/packages/universal-sql/src/build-parquet.js
@@ -14,6 +14,7 @@ import path from 'path';
 import { initDB, query } from './client-duckdb/node.js';
 import { isGeneratorObject } from 'util/types';
 import chunk from 'lodash.chunk';
+import { SingleBar, Presets } from 'cli-progress';
 
 /**
  * @param {string} type
@@ -47,6 +48,7 @@ function convertArrayToVector(type, rawValues) {
  * @param {string} outputDirectory - Path to the .evidence/template directory (or other output directory)
  * @param {string} outputPrefix - The prefix to use for the output directory - generally `data`
  * @param {string} outputFilename
+ * @param {number} [expectedRowCount]
  * @param {number} [batchSize]
  * @returns {Promise<number>} Number of rows
  */
@@ -56,12 +58,16 @@ export async function buildMultipartParquet(
 	outputDirectory,
 	outputPrefix,
 	outputFilename,
+	expectedRowCount,
 	batchSize = 1000000
 ) {
 	let batchNum = 0;
 	const outputSubpath = outputFilename.split('.parquet')[0];
 	let tmpFilenames = [];
 	let rowCount = 0;
+
+	const progressBar = new SingleBar({}, Presets.shades_classic);
+	if (expectedRowCount !== undefined) progressBar.start(expectedRowCount, 0);
 
 	const flush = async (results) => {
 		// Convert JS Objects -> Arrow
@@ -82,10 +88,8 @@ export async function buildMultipartParquet(
 		const writerProperties = new WriterPropertiesBuilder().setCompression(Compression.ZSTD).build();
 		// Converts the arrow buffer to a parquet buffer
 		// This can be slow; it includes the compression step
-		console.debug(` || Compressing batch ${batchNum}`);
 		const parquetBuffer = writeParquet(IPC, writerProperties);
 
-		console.debug(` || Writing batch ${batchNum} with ${results.length} rows.`);
 		const tempFilename = path.join(
 			outputDirectory,
 			'.evidence-queries',
@@ -95,10 +99,10 @@ export async function buildMultipartParquet(
 		await fs.mkdir(path.dirname(tempFilename), { recursive: true });
 		await fs.writeFile(tempFilename, parquetBuffer);
 
-		console.debug(` || Batch ${batchNum} written.`);
 		tmpFilenames.push(tempFilename);
 		rowCount += results.length;
 		batchNum++;
+		if (expectedRowCount !== undefined) progressBar.update(rowCount);
 	};
 
 	if (typeof data === 'function') data = data();
@@ -139,6 +143,8 @@ export async function buildMultipartParquet(
 		// Ensure nothing is left over
 		if (currentBatch.length) await flush(currentBatch);
 	}
+
+	if (expectedRowCount !== undefined) progressBar.stop();
 
 	if (!tmpFilenames.length) return 0;
 

--- a/packages/universal-sql/src/index.d.ts
+++ b/packages/universal-sql/src/index.d.ts
@@ -1,2 +1,2 @@
-export * from "./build-parquet.js";
-export * from "./cache-duckdb.js";
+export * from './build-parquet.js';
+export * from './cache-duckdb.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,7 +435,7 @@ importers:
   packages/evidence:
     dependencies:
       '@evidence-dev/plugin-connector':
-        specifier: workspace:2.0.0-usql.18
+        specifier: workspace:2.0.0-usql.19
         version: link:../plugin-connector
       '@evidence-dev/preprocess':
         specifier: workspace:4.0.0-usql.13
@@ -952,7 +952,7 @@ importers:
         specifier: workspace:1.0.0-usql.4
         version: link:../../packages/duckdb
       '@evidence-dev/plugin-connector':
-        specifier: workspace:2.0.0-usql.18
+        specifier: workspace:2.0.0-usql.19
         version: link:../../packages/plugin-connector
       '@evidence-dev/query-store':
         specifier: workspace:^2.0.0-usql.1
@@ -1073,7 +1073,7 @@ importers:
         specifier: workspace:1.0.0-usql.4
         version: link:../../packages/duckdb
       '@evidence-dev/evidence':
-        specifier: workspace:20.0.0-usql.28
+        specifier: workspace:20.0.0-usql.29
         version: link:../../packages/evidence
       '@evidence-dev/faker-datasource':
         specifier: workspace:2.0.0-usql.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,9 @@ importers:
       chalk:
         specifier: ^5.2.0
         version: 5.3.0
+      cli-progress:
+        specifier: ^3.12.0
+        version: 3.12.0
       duckdb:
         specifier: ^0.8.1
         version: 0.8.1

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -15,12 +15,7 @@ const loadDB = async () => {
 	if (!browser) {
 		const { readFile } = await import('fs/promises');
 		({ renderedFiles } = JSON.parse(
-			await readFile(
-				process.cwd().includes('.evidence')
-					? '../../static/data/manifest.json'
-					: './static/data/manifest.json',
-				'utf-8'
-			).catch(() => '{}')
+			await readFile('./static/data/manifest.json', 'utf-8').catch(() => '{}')
 		));
 	} else {
 		const res = await fetch('/data/manifest.json');

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -1,4 +1,4 @@
-import { browser, building } from '$app/environment';
+import { browser, building, dev } from '$app/environment';
 import {
 	tableFromIPC,
 	initDB,
@@ -9,7 +9,7 @@ import {
 } from '@evidence-dev/universal-sql/client-duckdb';
 import { profile } from '@evidence-dev/component-utilities/profile';
 
-const initDb = async () => {
+const loadDB = async () => {
 	let renderedFiles = {};
 
 	if (!browser) {
@@ -36,7 +36,7 @@ const initDb = async () => {
 	await profile(updateSearchPath, Object.keys(renderedFiles));
 };
 
-const database_initialization = profile(initDb);
+const database_initialization = profile(loadDB);
 
 /** @satisfies {import("./$types").LayoutLoad} */
 export const load = async ({
@@ -44,6 +44,8 @@ export const load = async ({
 	data: { customFormattingSettings, routeHash, isUserPage, evidencemeta }
 }) => {
 	if (!browser) await database_initialization;
+	// account for potential changes in manifest (source query hmr)
+	if (!browser && dev) await initDB();
 
 	const data = {};
 

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -3,8 +3,8 @@
 	"version": "3.0.0-usql.29",
 	"private": true,
 	"scripts": {
-		"build": "evidence build",
-		"dev": "evidence dev",
+		"build": "evidence build:sources --changed && evidence build",
+		"dev": "evidence build:sources --changed && evidence dev",
 		"test": "evidence build:sources && evidence build",
 		"build:sources": "evidence build:sources"
 	},


### PR DESCRIPTION
### Description

- Generates parquet into `.evidence/template/static/data` instead of user-facing `static` folder
- Adds progress bar for queries, replaces some of the previous output text
- Fix query by query basis source HMR
- Fix cancelled build sources erroring in the future
- Mute some vite warnings about `eval` and `fs/promises` externalization
- Adds `npx evidence build:sources --changed` to `test-env` dev and build scripts

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
