### PR TITLE
feat: add option param for postgres pool

### DIFF
--- a/.changeset/happy-games-wink.md
+++ b/.changeset/happy-games-wink.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/postgres': patch
+---
+
+adds options parameter to postgres connection settings

--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -51,7 +51,11 @@ const envMap = {
 		{ key: 'POSTGRES_SCHEMA', deprecated: true },
 		{ key: 'schema', deprecated: true },
 		{ key: 'SCHEMA', deprecated: true }
-	]
+	],
+	options: [
+		{ key: 'EVIDENCE_POSTGRES_OPTIONS', deprecated: false },
+		{ key: 'POSTGRES_OPTIONS', deprecated: false },
+	],
 };
 
 /**
@@ -163,7 +167,8 @@ const runQuery = async (queryString, database, batchSize = 100000) => {
 			password: database ? database.password : getEnv(envMap, 'password'),
 			port: database ? database.port : getEnv(envMap, 'port'),
 			ssl: database ? database.ssl : getEnv(envMap, 'ssl'),
-			connectionString: database ? database.connectionString : getEnv(envMap, 'connString')
+			connectionString: database ? database.connectionString : getEnv(envMap, 'connString'),
+			options: database ? database.options : getEnv(envMap, 'options'),
 		};
 
 		// Override types returned by pg package. The package will return some numbers as strings
@@ -248,6 +253,7 @@ module.exports = runQuery;
  * @property {Object | undefined} ssl
  * @property {string} connectionString
  * @property {string} schema
+ * @property {string} options
  */
 
 /** @type {import('@evidence-dev/db-commons').GetRunner<PostgresOptions>} */
@@ -333,5 +339,11 @@ module.exports.options = {
 		type: 'string',
 		secret: false,
 		description: 'Default schema'
+	},
+	options: {
+		title: 'Options',
+		type: 'string',
+		secret: false,
+		description: 'Connection options'
 	}
 };

--- a/packages/postgres/index.cjs
+++ b/packages/postgres/index.cjs
@@ -54,8 +54,8 @@ const envMap = {
 	],
 	options: [
 		{ key: 'EVIDENCE_POSTGRES_OPTIONS', deprecated: false },
-		{ key: 'POSTGRES_OPTIONS', deprecated: false },
-	],
+		{ key: 'POSTGRES_OPTIONS', deprecated: false }
+	]
 };
 
 /**
@@ -168,7 +168,7 @@ const runQuery = async (queryString, database, batchSize = 100000) => {
 			port: database ? database.port : getEnv(envMap, 'port'),
 			ssl: database ? database.ssl : getEnv(envMap, 'ssl'),
 			connectionString: database ? database.connectionString : getEnv(envMap, 'connString'),
-			options: database ? database.options : getEnv(envMap, 'options'),
+			options: database ? database.options : getEnv(envMap, 'options')
 		};
 
 		// Override types returned by pg package. The package will return some numbers as strings


### PR DESCRIPTION
### Description

Hi, this PR if merged would close #1358 by adding `options` to the postgres settings options.

I did a bit of manual testing, and could see the option pass though certainly happy to update to make things robust.

<img width="494" alt="image" src="https://github.com/evidence-dev/evidence/assets/421839/df00968e-6813-493e-a1a5-70eae653c096">

This is what the UI looks like with the new field.

<img width="698" alt="image" src="https://github.com/evidence-dev/evidence/assets/421839/ebe6f9ea-622a-4bd8-939b-b47bdba3c907">

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
Thanks!
