### PR TITLE
Universal SQL: Fixes to options handling

### DIFF
--- a/.changeset/fast-cars-end.md
+++ b/.changeset/fast-cars-end.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+- connection.options.yaml values are now b64 encoded
+- children that do not have a key for all child values no longer break - e.g. when ssl is disabled for postgres, there are no children. This was breaking previously

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -10,6 +10,7 @@ import {
 } from './schemas/datasource-spec.schema';
 import { cleanZodErrors } from '../lib/clean-zod-errors.js';
 import { createHash } from 'node:crypto';
+import { decodeBase64Deep } from '../lib/b64-deep';
 
 /**
  * Returns the path to the sources directory, if it exists in the current directory.
@@ -227,7 +228,7 @@ async function loadConnectionOptions(sourceDir) {
 	if (!optionsFileExists) return {};
 	const optionsFile = await fs.readFile(optionsFilePath).then((r) => r.toString());
 	try {
-		return yaml.parse(optionsFile);
+		return decodeBase64Deep(yaml.parse(optionsFile));
 	} catch (e) {
 		throw new Error(`Error parsing connection.options.yaml file; ${sourceDir}`, { cause: e });
 	}

--- a/packages/plugin-connector/src/lib/b64-deep.js
+++ b/packages/plugin-connector/src/lib/b64-deep.js
@@ -1,0 +1,55 @@
+/**
+ * Encodes a value or an array of values into Base64 recursively.
+ * @param {*} v - The value or array of values to encode.
+ * @returns {*} - The encoded value or array of values.
+ */
+export const encodeBase64Deep = (v) => {
+	if (Array.isArray(v)) {
+		const mapped = v.map(encodeBase64Deep);
+		return mapped;
+	} else if (typeof v === 'string') {
+		return btoa(v);
+	} else if (v && v.constructor === Object) {
+		// bare object
+		return Object.fromEntries(
+			Object.entries(v).map(
+				/**
+				 * Maps each key-value pair of the object.
+				 * @param {[string, object]} entry - The key-value pair.
+				 * @returns {[string, object|string]} - The encoded key-value pair.
+				 */
+				([k, v]) => [k, encodeBase64Deep(v)]
+			)
+		);
+	} else {
+		return v;
+	}
+};
+
+/**
+ * Dencodes a value or an array of values from Base64 recursively.
+ * @param {*} v - The value or array of values to encode.
+ * @returns {*} - The encoded value or array of values.
+ */
+export const decodeBase64Deep = (v) => {
+	if (Array.isArray(v)) {
+		const mapped = v.map(decodeBase64Deep);
+		return mapped;
+	} else if (typeof v === 'string') {
+		return atob(v);
+	} else if (v && v.constructor === Object) {
+		// bare object
+		return Object.fromEntries(
+			Object.entries(v).map(
+				/**
+				 * Maps each key-value pair of the object.
+				 * @param {[string, object]} entry - The key-value pair.
+				 * @returns {[string, object|string]} - The encoded key-value pair.
+				 */
+				([k, v]) => [k, decodeBase64Deep(v)]
+			)
+		);
+	} else {
+		return v;
+	}
+};


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

- `connection.options.yaml` now has values b64 encoded
- Options where `children` is not exhaustive no longer break

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
