### PR TITLE
fix QueryViewer open state

### DIFF
--- a/.changeset/green-suns-dress.md
+++ b/.changeset/green-suns-dress.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Ensure QueryViewer SQL not open by default

--- a/packages/core-components/src/lib/unsorted/ui/QueryViewer.svelte
+++ b/packages/core-components/src/lib/unsorted/ui/QueryViewer.svelte
@@ -18,7 +18,7 @@
 	$: pageQueries = $page.data.evidencemeta.queries;
 
 	// Title & Query Toggle
-	let showSQL = localStorageStore('showSQL_'.concat(queryID), true);
+	let showSQL = localStorageStore('showSQL_'.concat(queryID), false);
 	// Query text & Compiler Toggle
 	let showResults = localStorageStore(`showResults_${queryID}`);
 


### PR DESCRIPTION
### Description

Query viewer SQL should not be visible by default

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
