### PR TITLE
remove dummy page sql string collection

### DIFF
--- a/.changeset/fluffy-avocados-impress.md
+++ b/.changeset/fluffy-avocados-impress.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+remove dummy page sql string collection

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,7 +717,7 @@ importers:
         version: 3.22.4
     devDependencies:
       '@evidence-dev/component-utilities':
-        specifier: workspace:2.0.0-usql.30
+        specifier: workspace:2.0.0-usql.31
         version: link:../component-utilities
       '@parcel/core':
         specifier: ^2.8.3


### PR DESCRIPTION
### Description

Removes the sql string collecting part of the dummy page request, which wasn't really used yet, but would've been helpful for async SSR'd queries (i.e. motherduck integration, native duckdb). Worth looking at again in the future

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
