### PR TITLE
add hour long timeout to bigquery type fetching

### DIFF
--- a/.changeset/breezy-tomatoes-pretend.md
+++ b/.changeset/breezy-tomatoes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/bigquery': patch
+---
+
+fix bigquery types timing out for large queries

--- a/packages/bigquery/index.cjs
+++ b/packages/bigquery/index.cjs
@@ -126,7 +126,8 @@ const runQuery = async (queryString, database, batchSize = 100000) => {
 		const [, , response] = await job.getQueryResults({
 			autoPaginate: false,
 			wrapIntegers: false,
-			maxResults: 0
+			maxResults: 0,
+			timeoutMs: 3_600_000
 		});
 		result.columnTypes = mapResultsToEvidenceColumnTypes(response);
 		result.expectedRowCount = response.totalRows && Number(response.totalRows);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,7 +394,7 @@ importers:
         specifier: ^1.5.0
         version: 1.6.1
       '@evidence-dev/db-commons':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../db-commons
     devDependencies:
       dotenv:
@@ -723,7 +723,7 @@ importers:
         version: 3.22.4
     devDependencies:
       '@evidence-dev/component-utilities':
-        specifier: workspace:2.0.0-usql.31
+        specifier: workspace:*
         version: link:../component-utilities
       '@parcel/core':
         specifier: ^2.8.3
@@ -936,7 +936,7 @@ importers:
   packages/trino:
     dependencies:
       '@evidence-dev/db-commons':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../db-commons
       presto-client:
         specifier: ^0.13.0


### PR DESCRIPTION
### Description

big bigquery queries were timing out before types were sent back

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
