### PR TITLE
Remove redundant log message that pollutes build sources (via telemetry)

### DIFF
--- a/.changeset/few-forks-begin.md
+++ b/.changeset/few-forks-begin.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/telemetry': patch
+---
+
+Remove unnecessary file missing message that appears during build sources due to telemetry"

--- a/packages/telemetry/index.cjs
+++ b/packages/telemetry/index.cjs
@@ -149,7 +149,7 @@ function loadSettings() {
 	try {
 		settings = readJSONSync('evidence.settings.json');
 	} catch (e) {
-		console.error('Error reading evidence.settings.json', e);
+		//do nothing
 	}
 	return settings;
 }


### PR DESCRIPTION
### Description
If the evidence.settings.json file is not available (which happens to be the case with out of box USQL projects), this ugly error message can show up during `npm run sources`
The file not existing has no impact on the project - so this is just noise from a user point of view
![CleanShot 2023-12-27 at 12 01 33@2x](https://github.com/evidence-dev/evidence/assets/1594000/61242037-31ec-41e9-914f-02f165a6f39d)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
