### PR TITLE
Update docs: Explain how to add static images to the Data Table component.

### DIFF
--- a/.changeset/good-goats-crash.md
+++ b/.changeset/good-goats-crash.md
@@ -1,0 +1,5 @@
+---
+'evidence-docs': patch
+---
+
+Explain how to add static images to the Data Table component

--- a/sites/docs/docs/components/data-table.md
+++ b/sites/docs/docs/components/data-table.md
@@ -85,6 +85,9 @@ hide_table_of_contents: false
 
 
 ### Including Images
+You can include images by indicating either an absolute path e.g. `https://www.example.com/images/image.png` or a relative path e.g. `/images/image.png`. For relative paths, see [storing static files in a static folder](/markdown/#storing-images-and-static-files). 
+
+In this example, `flag` is either an absolute path or a relative path to the image.
 
 ```html
 <DataTable data="{countries}">


### PR DESCRIPTION
### Description

Updated the docs on incorporating static images in the Data Table component. 
Added a link to the section explaining how to store static images in the `static` folder.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
