### PR TITLE
fix boolean config option parsing

### DIFF
--- a/.changeset/olive-frogs-rescue.md
+++ b/.changeset/olive-frogs-rescue.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/mssql': patch
+'@evidence-dev/trino': patch
+---
+
+Fix boolean config options for MSSQL and Trino

--- a/packages/mssql/index.cjs
+++ b/packages/mssql/index.cjs
@@ -95,7 +95,8 @@ const runQuery = async (queryString, database = {}, batchSize = 100000) => {
 			password: database.password,
 			port: parseInt(database.port ?? 1433),
 			options: {
-				trustServerCertificate: trust_server_certificate === 'true' || trust_server_certificate === true,
+				trustServerCertificate:
+					trust_server_certificate === 'true' || trust_server_certificate === true,
 				encrypt: encrypt === 'true' || encrypt === true
 			}
 		};

--- a/packages/mssql/index.cjs
+++ b/packages/mssql/index.cjs
@@ -95,8 +95,8 @@ const runQuery = async (queryString, database = {}, batchSize = 100000) => {
 			password: database.password,
 			port: parseInt(database.port ?? 1433),
 			options: {
-				trustServerCertificate: trust_server_certificate === 'true',
-				encrypt: encrypt === 'true'
+				trustServerCertificate: trust_server_certificate === 'true' || trust_server_certificate === true,
+				encrypt: encrypt === 'true' || encrypt === true
 			}
 		};
 
@@ -156,7 +156,7 @@ module.exports.getRunner = async (opts) => {
 
 /** @type {import('@evidence-dev/db-commons').ConnectionTester<MsSQLOptions>} */
 module.exports.testConnection = async (opts) => {
-	return await runQuery('SELECT 1;', opts)
+	return await runQuery('SELECT 1 AS TEST;', opts) //
 		.then(exhaustStream)
 		.then(() => true)
 		.catch((e) => ({ reason: e.message ?? (e.toString() || 'Invalid Credentials') }));

--- a/packages/trino/index.cjs
+++ b/packages/trino/index.cjs
@@ -9,7 +9,7 @@ const runQuery = async (queryString, database) => {
 
 		const client = new trino.Client({
 			host: database.host,
-			ssl: (ssl === 'true' || ssl === true) ? {} : undefined,
+			ssl: ssl === 'true' || ssl === true ? {} : undefined,
 			port: database.port,
 			user: database.user,
 			source: 'evidence',

--- a/packages/trino/index.cjs
+++ b/packages/trino/index.cjs
@@ -9,7 +9,7 @@ const runQuery = async (queryString, database) => {
 
 		const client = new trino.Client({
 			host: database.host,
-			ssl: ssl === 'true' ? {} : undefined,
+			ssl: (ssl === 'true' || ssl === true) ? {} : undefined,
 			port: database.port,
 			user: database.user,
 			source: 'evidence',


### PR DESCRIPTION
### Description

Boolean config options were returning booleans but we were comparing them to strings during parsing

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
