### PR TITLE
Add freeze column to datatable

### DIFF
--- a/.changeset/real-parents-smoke.md
+++ b/.changeset/real-parents-smoke.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/components': patch
+---
+
+Add freezeColumn to DataTable

--- a/packages/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -87,6 +87,9 @@
 	export let formatColumnTitles = true;
 	$: formatColumnTitles = formatColumnTitles === 'true' || formatColumnTitles === true;
 
+	export let freezeColumn = false;
+	$: freezeColumn = freezeColumn === 'true' || freezeColumn === true;
+
 	// ---------------------------------------------------------------------------------------
 	// DATA SETUP
 	// ---------------------------------------------------------------------------------------
@@ -307,15 +310,24 @@
 				<thead>
 					<tr>
 						{#if rowNumbers}
-							<th class="index w-[2%]" style:background-color={headerColor} />
+							<th
+								class="index w-[2%]"
+								style:background-color={headerColor}
+								class:sticky={freezeColumn}
+								class:left-0={freezeColumn}
+								class:bg-white={freezeColumn}
+							/>
 						{/if}
 						{#if $props.columns.length > 0}
-							{#each $props.columns as column}
+							{#each $props.columns as column, i}
 								<th
 									class={safeExtractColumn(column).type}
 									style:text-align={column.align}
 									style:color={headerFontColor}
 									style:background-color={headerColor}
+									class:sticky={freezeColumn && i == 0}
+									class:left-0={freezeColumn && i == 0}
+									class:bg-white={freezeColumn && i == 0}
 									style:cursor={sortable ? 'pointer' : 'auto'}
 									on:click={sortable ? sort(column.id) : ''}
 								>
@@ -330,12 +342,15 @@
 								</th>
 							{/each}
 						{:else}
-							{#each columnSummary.filter((d) => d.show === true) as column}
+							{#each columnSummary.filter((d) => d.show === true) as column, i}
 								<th
 									class={column.type}
 									style:color={headerFontColor}
 									style:background-color={headerColor}
 									style:cursor={sortable ? 'pointer' : 'auto'}
+									class:sticky={freezeColumn && i == 0}
+									class:left-0={freezeColumn && i == 0}
+									class:bg-white={freezeColumn && i == 0}
 									on:click={sortable ? sort(column.id) : ''}
 								>
 									<span class="col-header">
@@ -357,7 +372,13 @@
 						on:click={() => handleRowClick(row[link])}
 					>
 						{#if rowNumbers}
-							<td class="index w-[2%]" class:row-lines={rowLines}>
+							<td
+								class="index w-[2%]"
+								class:row-lines={rowLines}
+								class:sticky={freezeColumn}
+								class:left-0={freezeColumn}
+								class:bg-white={freezeColumn}
+							>
 								{#if i === 0}
 									{(index + i + 1).toLocaleString()}
 								{:else}
@@ -367,7 +388,7 @@
 						{/if}
 
 						{#if $props.columns.length > 0}
-							{#each $props.columns as column}
+							{#each $props.columns as column, j}
 								{@const column_min =
 									column.colorMin ?? safeExtractColumn(column).columnUnitSummary.min}
 								{@const column_max =
@@ -381,6 +402,9 @@
 									style:height={column.height}
 									style:width={column.width}
 									style:white-space={column.wrap ? 'normal' : 'nowrap'}
+									class:sticky={freezeColumn && j == 0}
+									class:left-0={freezeColumn && j == 0}
+									class:bg-white={freezeColumn && j == 0}
 									style={column.contentType === 'colorscale' && is_nonzero
 										? ` background-color: ${column.useColor} ${
 												(row[column.id] - column_min) / (column_max - column_min)
@@ -486,8 +510,13 @@
 								</td>
 							{/each}
 						{:else}
-							{#each columnSummary.filter((d) => d.show === true) as column}
-								<td class={column.type} class:row-lines={rowLines}
+							{#each columnSummary.filter((d) => d.show === true) as column, j}
+								<td
+									class={column.type}
+									class:row-lines={rowLines}
+									class:sticky={freezeColumn && j == 0}
+									class:left-0={freezeColumn && j == 0}
+									class:bg-white={freezeColumn && j == 0}
 									>{formatValue(row[column.id], column.format, column.columnUnitSummary)}</td
 								>
 							{/each}
@@ -635,6 +664,11 @@
 		padding: 2px 8px;
 		white-space: nowrap;
 		overflow: hidden;
+	}
+
+	th:first-child,
+	td:first-child {
+		padding-left: 4px;
 	}
 
 	th {

--- a/sites/example-project/src/pages/tables/data-table/+page.md
+++ b/sites/example-project/src/pages/tables/data-table/+page.md
@@ -31,3 +31,11 @@ Aliquam massa elit, egestas eget risus nec, rhoncus vehicula ante. Cras placerat
 ## Fuzzy Search
 
 <DataTable data={[{ thing: 'The world has many goodbyes and hellos.' }]} search=true />
+
+## Freeze First Column
+
+<DataTable data={orders_by_category} freezeColumn=true/>
+
+With row numbers (row numbers slide away when scrolled):
+
+<DataTable data={orders_by_category} freezeColumn=true rowNumbers=true/>


### PR DESCRIPTION
### Description
Minimal implementation of a `freezeColumn` prop for `DataTable`,  which freezes the first column on the left and allows you to scroll the other columns.

If `rowNumbers` are shown, these are not frozen - they will scroll away, leaving only the first column of the table frozen on the left.

![CleanShot 2024-01-23 at 15 33 01](https://github.com/evidence-dev/evidence/assets/12602440/bb13f8dd-701a-4c19-92fc-6db54e4bb282)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)


## To Do
- Fix issue with white background in Firefox - overrides the border of the cells
- Fix issue with edges of white background on mobile - interferes with header bottom border
- Test on Windows and multiple browsers