### PR TITLE
Bypass fully null bool column

### DIFF
--- a/.changeset/yellow-frogs-speak.md
+++ b/.changeset/yellow-frogs-speak.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/universal-sql': patch
+---
+
+fix fully null boolean column with float64 conversion

--- a/packages/universal-sql/src/build-parquet.js
+++ b/packages/universal-sql/src/build-parquet.js
@@ -23,12 +23,12 @@ import { columnsToScore } from './calculateScore.js';
 import chalk from 'chalk';
 
 /**
- * @param {string} type
+ * @param {{name: string, evidenceType: string}} column
  * @param {any[]} rawValues
  * @returns {import("apache-arrow").Vector}
  */
-function convertArrayToVector(type, rawValues) {
-	switch (type) {
+function convertArrayToVector(column, rawValues) {
+	switch (column.evidenceType) {
 		case 'number':
 			return vectorFromArray(rawValues, new Float64());
 		case 'string':
@@ -37,6 +37,16 @@ function convertArrayToVector(type, rawValues) {
 			// TODO: What gives with timezones
 			return vectorFromArray(rawValues, new TimestampMillisecond());
 		case 'boolean':
+			if (!rawValues.some((v) => v !== null)) {
+				// All null bool columns error out, so we have to do this
+				// https://github.com/evidence-dev/evidence/issues/1504
+				console.warn(
+					chalk.yellow(
+						`\nWarning: Column "${column.name}" (type Bool) contains only null values so it has been cast to Float64`
+					)
+				);
+				return vectorFromArray(rawValues, new Float64());
+			}
 			return vectorFromArray(rawValues, new Bool());
 		default:
 			throw new Error(
@@ -78,7 +88,7 @@ export async function buildMultipartParquet(
 			columns.map((c) => [
 				c.name,
 				convertArrayToVector(
-					c.evidenceType,
+					c,
 					results.map((i) => i[c.name] ?? null)
 				)
 			])

--- a/packages/universal-sql/src/build-parquet.js
+++ b/packages/universal-sql/src/build-parquet.js
@@ -51,7 +51,7 @@ function convertArrayToVector(column, rawValues) {
 		default:
 			throw new Error(
 				'Unrecognized EvidenceType: ' +
-					type +
+					column.evidenceType +
 					'\n This is likely an error in a datasource connector.'
 			);
 	}

--- a/sites/test-env/pages/nullish-bools.md
+++ b/sites/test-env/pages/nullish-bools.md
@@ -1,0 +1,14 @@
+<script>
+	$: if (nully.loaded) {
+		console.log([...nully])
+		if (nully[0].from_canada !== true) throw new Error('from_canada should be true');
+		if (nully[1].from_canada !== true) throw new Error('from_canada should be true');
+		if (nully[2].from_canada !== false) throw new Error('from_canada should be false');
+	}
+</script>
+
+```nully
+SELECT * FROM nullish_bool
+```
+
+<DataTable data={nully} />

--- a/sites/test-env/sources/needful_things/nullish_bool.sql
+++ b/sites/test-env/sources/needful_things/nullish_bool.sql
@@ -1,0 +1,6 @@
+select null::bool as country, 100 as sales, true as from_canada
+union all 
+select null::bool as country, 200 as sales, true as from_canada
+union all 
+select null::bool as country, 300 as sales, false as from_canada
+order by sales


### PR DESCRIPTION
### Description

Converts `Bool` columns to `Float64` columns if they're entirely null to bypass `apache-arrow` serialization bug

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
