### PR TITLE
Add empty state to components

### DIFF
--- a/packages/component-utilities/src/checkInputs.js
+++ b/packages/component-utilities/src/checkInputs.js
@@ -17,9 +17,7 @@ export default function checkInputs(data, reqCols, optCols) {
 				'}'
 		);
 	} else if (data[0] === undefined || data.length === 0) {
-		throw Error(
-			'Dataset is empty: query ran successfully, but no data was returned from the database'
-		);
+		return;
 	}
 
 	// Check if data warehouse returned an error
@@ -27,7 +25,9 @@ export default function checkInputs(data, reqCols, optCols) {
 		throw Error('SQL Error: ' + data[0]?.error_object?.error?.message);
 	}
 
+	
 	if (reqCols != undefined) {
+		
 		if (!(reqCols instanceof Array)) {
 			throw Error('reqCols must be passed in as an array');
 		}
@@ -82,6 +82,7 @@ export default function checkInputs(data, reqCols, optCols) {
 			}
 		}
 	}
+
 	// IDEAS:
 	// Trigger a function call when error is caught - that function somehow sends us to the Error chart component
 	// rather than letting the rest of the current component file continue running?

--- a/packages/component-utilities/src/isEmptyDataset.js
+++ b/packages/component-utilities/src/isEmptyDataset.js
@@ -1,0 +1,14 @@
+export default function isEmptyDataset(data, emptySet) {
+    if (data[0] === undefined || data.length === 0) {
+        if(emptySet === 'error'){
+            throw Error(
+                'Dataset is empty: query ran successfully, but no data was returned from the database'
+            );    
+        } else if(emptySet === 'warn'){
+            console.warn('Dataset is empty: query ran successfully, but no data was returned from the database')
+            return true;
+        } else {
+            return true;
+        }
+	}
+}

--- a/packages/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
@@ -66,9 +66,12 @@
 
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{y}

--- a/packages/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
@@ -84,9 +84,12 @@
 
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{y}

--- a/packages/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
@@ -64,9 +64,12 @@
 		color,
 		confidenceInterval
 	);
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	x={name}
 	{xFmt}

--- a/packages/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
@@ -55,9 +55,12 @@
 	export let colorPalette = undefined;
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{y}

--- a/packages/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
@@ -34,9 +34,12 @@
 	export let colorPalette = undefined;
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{xFmt}

--- a/packages/core-components/src/lib/unsorted/viz/line/LineChart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/line/LineChart.svelte
@@ -81,9 +81,12 @@
 
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{y}

--- a/packages/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -54,9 +54,12 @@
 	export let colorPalette = undefined;
 	export let echartsOptions = undefined;
 	export let printEchartsConfig = false;
+
+	export let emptySet = 'error'; // error | warn | pass
 </script>
 
 <Chart
+	{emptySet}
 	{data}
 	{x}
 	{y}

--- a/sites/example-project/src/pages/empty-states/+page.md
+++ b/sites/example-project/src/pages/empty-states/+page.md
@@ -1,0 +1,80 @@
+# Empty Component States
+
+```empty_query
+select 1 as num
+where num > 1
+```
+
+## Value
+
+### `emptySet=error` (default)
+<Value data={empty_query} emptySet=error/>
+
+### `emptySet=warn`
+<Value data={empty_query} emptySet=warn/>
+
+### `emptySet=pass`
+<Value data={empty_query} emptySet=pass/>
+
+## BigValue
+
+### `emptySet=error` (default)
+<BigValue data={empty_query} value=num emptySet=error/>
+
+### `emptySet=warn`
+<BigValue data={empty_query} value=num emptySet=warn/>
+
+### `emptySet=pass`
+<BigValue data={empty_query} value=num emptySet=pass/>
+
+## Chart
+
+### `emptySet=error` (default)
+<LineChart data={empty_query} emptySet=error/>
+
+### `emptySet=warn`
+<LineChart data={empty_query} emptySet=warn/>
+
+### `emptySet=pass`
+<LineChart data={empty_query} emptySet=pass/>
+
+
+
+## DataTable
+
+### `emptySet=error` (default)
+<DataTable data={empty_query} emptySet=error/>
+
+### `emptySet=warn`
+<DataTable data={empty_query} emptySet=warn/>
+
+### `emptySet=pass`
+<DataTable data={empty_query} emptySet=pass/>
+
+## Filter Example
+
+```filter_query
+select 'a' as category, 100 as num
+union all 
+select 'b' as category, 200 as num
+union all 
+select 'c' as category, 300 as num
+union all 
+select 'd' as category, 400 as num
+```
+
+<Dropdown name=number>
+    <DropdownOption value=0/>
+    <DropdownOption value=100/>
+    <DropdownOption value=200/>
+    <DropdownOption value=300/>
+    <DropdownOption value=400/>
+    <DropdownOption value=500/>
+</Dropdown>
+
+```filtered
+select * from ${filter_query}
+where num >= '${inputs.number}'
+```
+
+<DataTable data={filtered} emptySet=warn/>


### PR DESCRIPTION
### Description
Proof of concept, but may be close to ready.

Adds an `emptySet` prop to components as described here: #1219 

`emptySet` can be:
- `error`: component renders on page as an error, error is thrown, build:strict will be blocked
- `warn`: component renders to new empty state (appearance TBD) and warning sent to console, builds not blocked
- `pass`: component renders to new empty state (appearance TBD) and no warnings sent

Breaks the empty dataset logic out of `checkInputs.js` and into `isEmptyDataset.js`

Also wraps most component script tag code in a `if(!isEmpty)` conditional.

### Notes
Similar approach to our current error handling in components.

I think checks and error handling in components might be easier if they accepted a string for query name rather than the data object, then used data loading components to retrieve the actual data.

### Work remaining if this approach works
- Create empty state design for each component type
- Add to:
   - FunnelChart
   - SankeyDiagram
   - USMap
   - ReferenceLine
   - ReferenceArea


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
