### PR TITLE
Less verbose error messages for charts

### DIFF
--- a/.changeset/green-ducks-allow.md
+++ b/.changeset/green-ducks-allow.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Output less verbose errors for charts

--- a/packages/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -992,7 +992,7 @@
 			});
 		} catch (e) {
 			error = e.message;
-			console.error(e);
+			console.error('\x1b[31m%s\x1b[0m', `Error in ${chartType}: ${e.message}`);
 			// if the build is in production fail instead of sending the error to the chart
 			if (strictBuild) {
 				throw error;


### PR DESCRIPTION
### Description
Currently if you have errors in a chart on your page, you will see large error messages printed to the terminal. 

This PR shortens the error message, adds the chart type, and adds red font formatting to terminal output.

If we need the additional info, it may be worth adding a `logLevel` flag to components to allow larger messages to be posted.

#### Before
![CleanShot 2024-01-28 at 16 37 28@21x](https://github.com/evidence-dev/evidence/assets/12602440/514f5c58-125c-4da9-9bd2-de0abf0f4ad0)

#### After
<img width="1193" alt="CleanShot 2024-01-28 at 16 45 17@2x" src="https://github.com/evidence-dev/evidence/assets/12602440/88b22ca9-412e-4970-b389-21c42c0917b0">

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
