### PR TITLE
Fix custom conditional formatting bug

### DIFF
--- a/.changeset/shaggy-ducks-unite.md
+++ b/.changeset/shaggy-ducks-unite.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix custom color conditional formatting bug

--- a/packages/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -392,6 +392,7 @@
 									column.colorMax ?? safeExtractColumn(column).columnUnitSummary.max}
 								{@const is_nonzero =
 									column_max - column_min !== 0 && !isNaN(column_max) && !isNaN(column_min)}
+								{@const percentage = (row[column.id] - column_min) / (column_max - column_min)}
 								<td
 									class={safeExtractColumn(column).type}
 									class:row-lines={rowLines && i !== displayedData.length - 1}
@@ -402,11 +403,9 @@
 									style:background-color={column.contentType === 'colorscale' && is_nonzero
 										? column.customColor
 											? `color-mix(in srgb, ${column.customColor} ${
-													((row[column.id] - column_min) / (column_max - column_min)) * 100
+													Math.max(0, Math.min(1, percentage)) * 100
 											  }%, transparent)`
-											: `${column.useColor} ${
-													(row[column.id] - column_min) / (column_max - column_min)
-											  })`
+											: `${column.useColor} ${Math.max(0, Math.min(1, percentage))})`
 										: // closing bracket needed to close unclosed color string from Column component
 										  ''}
 								>


### PR DESCRIPTION
### Description
Fixes a bug in DataTable when a custom color scale is used with `colorMin` or `colorMax`.

When dividing a cell against the range of values in a column, the percentage can become higher than 100% or lower than 0% depending on how `colorMin` and `colorMax` are set. These values weren't a problem with the built-in conditional formatting colors, but the color setting used for custom color scales can't handle them.

This PR adjusts the logic so the calculations must return a number between 0 and 1.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
