### PR TITLE
fix: buildReactiveInputQuery

### DIFF
--- a/.changeset/proud-drinks-remember.md
+++ b/.changeset/proud-drinks-remember.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/component-utilities': patch
+---
+
+- buildReactiveInputQuery was accidentally setting the value of it's store to a Promise, which was not the intent. This ensures that the value is always the proper interface.

--- a/packages/component-utilities/src/buildQuery.js
+++ b/packages/component-utilities/src/buildQuery.js
@@ -41,6 +41,7 @@ export const getQueryFunction = () => getContext(QUERY_CONTEXT_KEY);
 export const buildReactiveInputQuery = (queryProps, id, initialData) => {
 	const internal = writable(buildInputQuery(queryProps, id, initialData));
 
+	let currentQuery;
 	return {
 		results: derived(internal, (v) => v),
 		update: async (queryProps) => {
@@ -48,13 +49,19 @@ export const buildReactiveInputQuery = (queryProps, id, initialData) => {
 			if (!hasQuery) {
 				internal.set({ hasQuery: false });
 			} else {
-				internal.update(async (currentQuery) => {
-					if (query.hash !== currentQuery) await query.fetch();
-					return { hasQuery, query };
-				});
+				if (query.hash !== currentQuery) {
+					const fetched = query.fetch()
+					if (fetched instanceof Promise) fetched.then(() => {
+						currentQuery = query
+						internal.set({ hasQuery, query });
+					})
+				} else {
+					currentQuery = query
+					internal.set({ hasQuery, query });
+				}
 			}
 		}
-	};
+	}
 };
 
 /**


### PR DESCRIPTION
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
