### PR TITLE
use `Date.now()` instead of `query.hash` for file path

### DIFF
--- a/.changeset/strong-eggs-pull.md
+++ b/.changeset/strong-eggs-pull.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+use `Date.now()` instead of `query.hash` for parquet filepath

--- a/packages/plugin-connector/src/data-sources/build-sources.js
+++ b/packages/plugin-connector/src/data-sources/build-sources.js
@@ -339,7 +339,13 @@ const flushSource = async (source, query, result, dataPath, metaPath, batchSize,
 	const logOut = /** @param {string} t **/ (t) => (spinner ? (spinner.text = t) : console.log(t));
 
 	// use `Date.now()` to ensure data is updated
-	const dataOutDir = path.join(dataPath, source.name, query.name, Date.now().toString());
+	const dataOutDir = path.join(
+		dataPath,
+		source.name,
+		query.name,
+		query.hash ?? '',
+		Date.now().toString()
+	);
 
 	const parquetFilename = path.join(dataOutDir, query.name + '.parquet');
 	const schemaFilename = path.join(dataOutDir, query.name + '.schema.json');

--- a/packages/plugin-connector/src/data-sources/build-sources.js
+++ b/packages/plugin-connector/src/data-sources/build-sources.js
@@ -338,7 +338,8 @@ export const buildSources = async (
 const flushSource = async (source, query, result, dataPath, metaPath, batchSize, spinner) => {
 	const logOut = /** @param {string} t **/ (t) => (spinner ? (spinner.text = t) : console.log(t));
 
-	const dataOutDir = path.join(dataPath, source.name, query.name, query.hash ?? '');
+	// use `Date.now()` to ensure data is updated
+	const dataOutDir = path.join(dataPath, source.name, query.name, Date.now().toString());
 
 	const parquetFilename = path.join(dataOutDir, query.name + '.parquet');
 	const schemaFilename = path.join(dataOutDir, query.name + '.schema.json');

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -111,7 +111,7 @@ export const getSources = async (sourcesDir) => {
 				// queries: queries
 			};
 		})
-	).then((r) => /** @type {Exclude<typeof r[number], false>[]} */ (r.filter(Boolean)));
+	).then((r) => /** @type {Exclude<typeof r[number], false>[]} */(r.filter(Boolean)));
 };
 
 /**
@@ -208,17 +208,19 @@ export async function cleanParquetFiles(dataDir, hashes) {
 			for (const resultHash of currentResults) {
 				if (resultHash !== sourceHashes[queryName]) {
 					await fs.rm(path.join(queryPath, resultHash), { recursive: true, force: true });
-				} else {
-					const timestamps = await fs.readdir(path.join(queryPath, resultHash));
-					const latest = timestamps.sort().reverse()[0];
-					for (const timestamp of timestamps) {
-						if (timestamp !== latest) {
-							await fs.rm(path.join(queryPath, resultHash, timestamp), {
-								recursive: true,
-								force: true
-							});
-						}
-					}
+				}
+			}
+
+			if (!sourceHashes[queryName]) continue;
+			const queryHashPath = path.join(queryPath, /** @type {string} */(sourceHashes[queryName]));
+			const timestamps = await fs.readdir(queryHashPath);
+			const latest = timestamps.sort().reverse()[0];
+			for (const timestamp of timestamps) {
+				if (timestamp !== latest) {
+					await fs.rm(path.join(queryHashPath, timestamp), {
+						recursive: true,
+						force: true
+					});
 				}
 			}
 		}

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -111,7 +111,7 @@ export const getSources = async (sourcesDir) => {
 				// queries: queries
 			};
 		})
-	).then((r) => /** @type {Exclude<typeof r[number], false>[]} */(r.filter(Boolean)));
+	).then((r) => /** @type {Exclude<typeof r[number], false>[]} */ (r.filter(Boolean)));
 };
 
 /**
@@ -212,7 +212,7 @@ export async function cleanParquetFiles(dataDir, hashes) {
 			}
 
 			if (!sourceHashes[queryName]) continue;
-			const queryHashPath = path.join(queryPath, /** @type {string} */(sourceHashes[queryName]));
+			const queryHashPath = path.join(queryPath, /** @type {string} */ (sourceHashes[queryName]));
 			const timestamps = await fs.readdir(queryHashPath);
 			const latest = Math.max(...timestamps.map((x) => Number(x))).toString();
 			for (const timestamp of timestamps) {

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -214,7 +214,7 @@ export async function cleanParquetFiles(dataDir, hashes) {
 			if (!sourceHashes[queryName]) continue;
 			const queryHashPath = path.join(queryPath, /** @type {string} */(sourceHashes[queryName]));
 			const timestamps = await fs.readdir(queryHashPath);
-			const latest = timestamps.sort().reverse()[0];
+			const latest = Math.max(...timestamps.map((x) => Number(x))).toString();
 			for (const timestamp of timestamps) {
 				if (timestamp !== latest) {
 					await fs.rm(path.join(queryHashPath, timestamp), {

--- a/packages/plugin-connector/src/data-sources/get-sources.js
+++ b/packages/plugin-connector/src/data-sources/get-sources.js
@@ -208,6 +208,17 @@ export async function cleanParquetFiles(dataDir, hashes) {
 			for (const resultHash of currentResults) {
 				if (resultHash !== sourceHashes[queryName]) {
 					await fs.rm(path.join(queryPath, resultHash), { recursive: true, force: true });
+				} else {
+					const timestamps = await fs.readdir(path.join(queryPath, resultHash));
+					const latest = timestamps.sort().reverse()[0];
+					for (const timestamp of timestamps) {
+						if (timestamp !== latest) {
+							await fs.rm(path.join(queryPath, resultHash, timestamp), {
+								recursive: true,
+								force: true
+							});
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description

Switches to `Date.now()` in an attempt to fix #1437, as leading theory for cause is faulty caching. Post-change, parquet file paths are now immutable, so caching shouldn't be an issue.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
