### PR TITLE
Add error handling to custom format retrieval

### DIFF
--- a/.changeset/light-poets-return.md
+++ b/.changeset/light-poets-return.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': patch
+'@evidence-dev/core-components': patch
+---
+
+Fix custom formatting retrieval for custom components

--- a/packages/component-utilities/src/formatting.js
+++ b/packages/component-utilities/src/formatting.js
@@ -10,7 +10,11 @@ const AXIS_FORMATTING_CONTEXT = 'axis';
 const VALUE_FORMATTING_CONTEXT = 'value';
 
 export const getCustomFormats = () => {
-	return getContext(CUSTOM_FORMATTING_SETTINGS_CONTEXT_KEY)?.getCustomFormats() || [];
+	try {
+		return getContext(CUSTOM_FORMATTING_SETTINGS_CONTEXT_KEY)?.getCustomFormats() || [];
+	} catch (error) {
+		return [];
+	}
 };
 
 /**


### PR DESCRIPTION
### Description
If you are building a custom component in an Evidence project and you use a formatting function from `component-utilities`, there can be problems when these functions try to retrieve custom formats from the project settings.

This happened most recently to me when my custom component was loaded in an `onMount()` call and the error I received was `Function called outside component initialization`

I traced this through to the `getCustomFormats` function, which was throwing an error. Adding a try-catch solves the problem.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
