### PR TITLE
Semi-fix SQLConsole bug

### DIFF
--- a/.changeset/gentle-berries-teach.md
+++ b/.changeset/gentle-berries-teach.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix sqlconsole bug that crashed on navigation

--- a/packages/core-components/src/lib/molecules/sql-console/SqlConsole.svelte
+++ b/packages/core-components/src/lib/molecules/sql-console/SqlConsole.svelte
@@ -8,7 +8,6 @@
 	import { sqlConsole, buildAutoCompletes } from './sqlConsole.action.js';
 
 	import { onMount } from 'svelte';
-	import { slide } from 'svelte/transition';
 
 	import { Button } from '../../atoms/button';
 	import DataTable from '../../unsorted/viz/table/DataTable.svelte';
@@ -122,7 +121,7 @@
 
 	<!-- Result View -->
 	{#if showResults}
-		<div transition:slide>
+		<div>
 			<DataTable data={$data} />
 		</div>
 	{/if}


### PR DESCRIPTION
### Description

Fixes `SQLConsole` crashing page on navigation, but only fixes the symptom of some greater bug that has something to do with on-page queries + transitions?

To reproduce the bigger bug:
1. Clone & run https://github.com/csjh/sqlconsole-transition-repro
2. Click on link to test
3. Click on link back to home
4. Witness error in dev console

Suspect it might be a Svelte bug, since I can't figure out anything we would be doing that would make Svelte complain

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
