### PR TITLE
support for algolia docsearch

### DIFF
--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -37,6 +37,8 @@
 		"@codemirror/lint": "^6.4.2",
 		"@codemirror/search": "^6.5.5",
 		"@codemirror/view": "^6.23.0",
+		"@docsearch/css": "^3.5.2",
+		"@docsearch/js": "^3.5.2",
 		"@evidence-dev/component-utilities": "workspace:*",
 		"@evidence-dev/query-store": "workspace:*",
 		"@evidence-dev/tailwind": "workspace:*",

--- a/packages/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -10,18 +10,27 @@
 	import { ToastWrapper } from '../../molecules/toast';
 
 	export let data;
+
+	// Layout options
+	/** @type {string} */
 	export let title = undefined;
+	/** @type {string} */
 	export let logo = undefined;
+	/** @type {boolean} */
 	export let neverShowQueries = false;
+	/** @type {boolean} */
 	export let fullWidth = false;
+	/** @type {boolean} */
 	export let hideSidebar = false;
+	/** @type {boolean} */
 	export let builtWithEvidence = false;
-
+	/** @type {{appId: string, apiKey: string, indexName: string}} */
 	export let algolia;
-
-	// Social links
+	/** @type {string} */
 	export let githubRepo;
+	/** @type {string} */
 	export let xProfile;
+	/** @type {string} */
 	export let slackCommunity;
 
 	const prefetchStrategy = dev ? 'tap' : 'hover';

--- a/packages/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -17,6 +17,8 @@
 	export let hideSidebar = false;
 	export let builtWithEvidence = false;
 
+	export let algolia;
+
 	// Social links
 	export let githubRepo;
 	export let xProfile;
@@ -47,6 +49,7 @@
 		{githubRepo}
 		{slackCommunity}
 		{xProfile}
+		{algolia}
 	/>
 	<div
 		class={(fullWidth ? 'max-w-full ' : 'max-w-7xl ') +

--- a/packages/core-components/src/lib/organisms/layout/header/AlgoliaDocSearch.svelte
+++ b/packages/core-components/src/lib/organisms/layout/header/AlgoliaDocSearch.svelte
@@ -1,0 +1,20 @@
+<script>
+	import '@docsearch/css/dist/_variables.css';
+	import '@docsearch/css/dist/modal.css';
+	import './SearchButton.css';
+	import { onMount } from 'svelte';
+	import docsearch from '@docsearch/js';
+
+	export let algolia;
+
+	onMount(() => {
+		docsearch({
+			container: '#docsearch',
+			appid: algolia?.appId,
+			apiKey: algolia?.apiKey,
+			indexName: algolia?.indexName
+		});
+	});
+</script>
+
+<div id="docsearch" />

--- a/packages/core-components/src/lib/organisms/layout/header/Header.svelte
+++ b/packages/core-components/src/lib/organisms/layout/header/Header.svelte
@@ -15,12 +15,15 @@
 	} from '@steeze-ui/tabler-icons';
 	import { Github as GithubLogo, Slack as SlackLogo } from '@steeze-ui/simple-icons';
 	import Logo from '../Logo.svelte';
+	import AlgoliaDocSearch from './AlgoliaDocSearch.svelte';
 
 	export let mobileSidebarOpen;
 	export let title;
 	export let logo;
 	export let neverShowQueries;
 	export let fullWidth;
+
+	export let algolia;
 
 	// Social links
 	export let githubRepo;
@@ -67,44 +70,49 @@
 			{/if}
 		</button>
 		<div class="flex gap-2 text-sm items-center pr-6">
-			{#if githubRepo}
-				<a
-					href={githubRepo}
-					class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
-					target="_blank"
-					rel="noreferrer"
-				>
-					<Icon src={GithubLogo} class="w-4 h-4 text-gray-800 " />
-				</a>
+			{#if algolia}
+				<AlgoliaDocSearch {algolia} />
 			{/if}
-			{#if xProfile}
-				<a
-					href={xProfile}
-					class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
-					target="_blank"
-					rel="noreferrer"
-				>
-					<svg
-						role="img"
-						viewBox="0 0 24 24"
-						xmlns="http://www.w3.org/2000/svg"
-						class="w-4 h-4 text-gray-800"
-						><path
-							d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"
-						/>
-					</svg>
-				</a>
-			{/if}
-			{#if slackCommunity}
-				<a
-					href={slackCommunity}
-					class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
-					target="_blank"
-					rel="noreferrer"
-				>
-					<Icon src={SlackLogo} class="w-4 h-4 text-gray-800 " />
-				</a>
-			{/if}
+			<div class="flex gap-2 items-center">
+				{#if githubRepo}
+					<a
+						href={githubRepo}
+						class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
+						target="_blank"
+						rel="noreferrer"
+					>
+						<Icon src={GithubLogo} class="w-4 h-4 text-gray-900 " />
+					</a>
+				{/if}
+				{#if xProfile}
+					<a
+						href={xProfile}
+						class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
+						target="_blank"
+						rel="noreferrer"
+					>
+						<svg
+							role="img"
+							viewBox="0 0 24 24"
+							xmlns="http://www.w3.org/2000/svg"
+							class="w-4 h-4 text-gray-900"
+							><path
+								d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"
+							/>
+						</svg>
+					</a>
+				{/if}
+				{#if slackCommunity}
+					<a
+						href={slackCommunity}
+						class="hover:bg-gray-50 rounded-lg p-2 transition-all duration-200"
+						target="_blank"
+						rel="noreferrer"
+					>
+						<Icon src={SlackLogo} class="w-4 h-4 text-gray-900 " />
+					</a>
+				{/if}
+			</div>
 			<div class="relative">
 				<Menu class="outline-none">
 					<MenuButton class="outline-none rounded-md focus:bg-gray-50 hover:bg-gray-100 px-1 py-1">

--- a/packages/core-components/src/lib/organisms/layout/header/SearchButton.css
+++ b/packages/core-components/src/lib/organisms/layout/header/SearchButton.css
@@ -1,0 +1,9 @@
+.DocSearch-Button {
+	@apply bg-white hover:bg-gray-50 transition-colors duration-200 hover:text-gray-800 rounded-md flex gap-16 cursor-pointer py-1 pl-2 pr-1 shadow-sm sm:text-xs text-gray-600 border font-sans font-medium  items-center;
+}
+.DocSearch-Search-Icon {
+	display: none;
+}
+.DocSearch-Button-Keys {
+	@apply flex gap-0.5 bg-gray-50 border rounded px-1 py-0.5 text-xs;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.23.0
         version: 6.23.0
+      '@docsearch/css':
+        specifier: '3'
+        version: 3.5.2
+      '@docsearch/js':
+        specifier: ^3.5.2
+        version: 3.5.2(@algolia/client-search@4.15.0)(react-dom@17.0.1)(react@17.0.1)(search-insights@2.13.0)
       '@evidence-dev/component-utilities':
         specifier: workspace:*
         version: link:../component-utilities
@@ -3996,6 +4002,19 @@ packages:
 
   /@docsearch/css@3.5.2:
     resolution: {integrity: sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==}
+    dev: false
+
+  /@docsearch/js@3.5.2(@algolia/client-search@4.15.0)(react-dom@17.0.1)(react@17.0.1)(search-insights@2.13.0):
+    resolution: {integrity: sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==}
+    dependencies:
+      '@docsearch/react': 3.5.2(@algolia/client-search@4.15.0)(react-dom@17.0.1)(react@17.0.1)(search-insights@2.13.0)
+      preact: 10.19.6
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - react
+      - react-dom
+      - search-insights
     dev: false
 
   /@docsearch/react@3.5.2(@algolia/client-search@4.15.0)(react-dom@17.0.1)(react@17.0.1)(search-insights@2.13.0):
@@ -20037,6 +20056,10 @@ packages:
       posthtml-parser: 0.11.0
       posthtml-render: 3.0.0
     dev: true
+
+  /preact@10.19.6:
+    resolution: {integrity: sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw==}
+    dev: false
 
   /preferred-pm@3.1.3:
     resolution: {integrity: sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
         specifier: ^6.23.0
         version: 6.23.0
       '@docsearch/css':
-        specifier: '3'
+        specifier: ^3.5.2
         version: 3.5.2
       '@docsearch/js':
         specifier: ^3.5.2


### PR DESCRIPTION
adds an algolia option to evidence default layout, which accepts the public info for the algolia docs search bar. Adds some custom styles on the actual search button. 


+layout.svelte 

```
<script>
	import '@evidence-dev/tailwind/fonts.css';
	import '../app.css';
	import { EvidenceDefaultLayout } from '@evidence-dev/core-components';
	export let data;
</script>

<EvidenceDefaultLayout
	{data}
	githubRepo="/"
	slackCommunity="/"
	xProfile="/"
	algolia={{
		appId: 'KHH9ANIISC',
		apiKey: 'd2bd44615d8d5f5464e54f06e82edd19',
		indexName: 'docs-evidence'
	}}
>
	<slot slot="content" />
</EvidenceDefaultLayout>

```

yields 

![CleanShot 2024-02-26 at 22 31 49@2x](https://github.com/evidence-dev/evidence/assets/6857673/4a298277-18d6-461f-8003-8ffef8001278)
