### PR TITLE
Immediate hydration on page load

### DIFF
--- a/.changeset/hungry-moles-cry.md
+++ b/.changeset/hungry-moles-cry.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/preprocess': patch
+'@evidence-dev/query-store': patch
+---
+
+add longQueryNotifier and backgroundFetch to querystore

--- a/packages/preprocess/src/process-queries.cjs
+++ b/packages/preprocess/src/process-queries.cjs
@@ -130,6 +130,7 @@ const createDefaultProps = function (filename, componentDevelopmentMode, duckdbQ
 							'${id}',
 							{
 								scoreNotifier,
+								longQueryNotifier,
 								initialData,
 								initialError,
 								noResolve: false,
@@ -265,6 +266,15 @@ const createDefaultProps = function (filename, componentDevelopmentMode, duckdbQ
 				status: 'warning'
 			}, 5000);
 		};
+
+		const longQueryNotifier = (info) => {
+			toasts.add({
+				id: Math.random(),
+				title: info.id,
+				message: \`Query \${info.id} is loading...\`,
+				status: 'info'
+			}, 3000);
+		}
 
 		let __has_hmr_run = false
 	    if (import.meta?.hot) {

--- a/packages/preprocess/src/process-queries.cjs
+++ b/packages/preprocess/src/process-queries.cjs
@@ -142,6 +142,11 @@ const createDefaultProps = function (filename, componentDevelopmentMode, duckdbQ
 							fetch_maybepromise = query_store.fetch();
 						}
 
+						// if we have initial data, execute the query anyways in the background, ignoring results
+						// this helps fetch some parquet which can speed up future queries
+						if (initialData) {
+							query_store.backgroundFetch();
+						}
 
 						if (_${id}) {
 							// Query has already been created

--- a/packages/query-store/src/QueryStore.ts
+++ b/packages/query-store/src/QueryStore.ts
@@ -404,6 +404,19 @@ export class QueryStore extends AbstractStore<QueryStoreValue> {
 	/** Force the QueryStore to fetch data */
 	fetch = () => this.#fetchData();
 
+	/** 
+	 * Fetch data in the background,
+	 * likely meaning `initialData` was provided
+	 */
+	backgroundFetch = async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		handleMaybePromise(
+			() => {},
+			() => this.#exec(`--data\n${this.#query.toString()}`, this.id),
+			() => {}
+		);
+	}
+
 	/** Keep a copy of the promise so we can wait for loading in multiple places */
 	#dataFetchPromise: MaybePromise<unknown | void>;
 

--- a/packages/query-store/src/QueryStore.ts
+++ b/packages/query-store/src/QueryStore.ts
@@ -404,7 +404,7 @@ export class QueryStore extends AbstractStore<QueryStoreValue> {
 	/** Force the QueryStore to fetch data */
 	fetch = () => this.#fetchData();
 
-	/** 
+	/**
 	 * Fetch data in the background,
 	 * likely meaning `initialData` was provided
 	 */
@@ -415,7 +415,7 @@ export class QueryStore extends AbstractStore<QueryStoreValue> {
 			() => this.#exec(`--data\n${this.#query.toString()}`, this.id),
 			() => {}
 		);
-	}
+	};
 
 	/** Keep a copy of the promise so we can wait for loading in multiple places */
 	#dataFetchPromise: MaybePromise<unknown | void>;
@@ -439,8 +439,14 @@ export class QueryStore extends AbstractStore<QueryStoreValue> {
 
 		const queryWithComment = `--data\n${this.#query.toString()}`;
 
+		const longQueryTimeout = setTimeout(() => {
+			if (this.opts.longQueryNotifier) {
+				this.opts.longQueryNotifier({ id: this.id, query: this.#query.toString() });
+			}
+		}, 1000);
 		this.#dataFetchPromise = handleMaybePromise<QueryResult[], unknown>(
 			(result) => {
+				clearTimeout(longQueryTimeout);
 				this.#values = result;
 				this.#dataLoading = false;
 				this.#dataLoaded = true;

--- a/packages/query-store/src/types.ts
+++ b/packages/query-store/src/types.ts
@@ -23,6 +23,8 @@ export type QueryStoreOpts = {
 	errorNotifier?: (error: Error) => unknown;
 	/** Optional hook to enable custom query score behavior, can be used for toasts, alerts, etc. */
 	scoreNotifier?: (info: ScoreInformation) => void;
+	/** Optional hook to enable custom toast notifications for long-running queries */
+	longQueryNotifier?: (info: LongQueryInformation) => void;
 	/** If true, the store will never leave a loading state */
 	noResolve?: boolean;
 };
@@ -31,6 +33,11 @@ export type ScoreInformation = {
 	id: string;
 	query: string;
 	score: number;
+};
+
+export type LongQueryInformation = {
+	id: string;
+	query: string;
 };
 
 export type QueryStoreValue = QueryStore & QueryResult[];

--- a/packages/universal-sql/src/build-parquet.js
+++ b/packages/universal-sql/src/build-parquet.js
@@ -166,7 +166,7 @@ export async function buildMultipartParquet(
 				? `, PARTITION_BY (${partitionKeys.join(', ')}), OVERWRITE_OR_IGNORE 1`
 				: '';
 			const copy = `COPY (SELECT * FROM read_parquet([${c
-				.map((f) => `'${f}'`)
+				.map((f) => `'${f.replaceAll('\\', '/')}'`)
 				.join(',')}])) TO '${path.resolve(
 				outDir,
 				i.toString()

--- a/packages/universal-sql/src/build-parquet.spec.js
+++ b/packages/universal-sql/src/build-parquet.spec.js
@@ -70,7 +70,7 @@ describe('buildMultipartParquet', () => {
 		);
 		expect(r).toEqual({
 			writtenRows: 2,
-			filenames: ['.evidence/template/static/data/out.0.parquet']
+			filenames: ['.evidence/template/static/data/out.0.parquet'].map(adaptFilePath)
 		});
 		const stat = await fs.stat('.evidence/template/static/data/out.0.parquet');
 		expect(stat.isFile()).toBeTruthy();
@@ -107,7 +107,7 @@ describe('buildMultipartParquet', () => {
 		);
 		expect(r).toEqual({
 			writtenRows: 2,
-			filenames: ['.evidence/template/static/data/out.0.parquet']
+			filenames: ['.evidence/template/static/data/out.0.parquet'].map(adaptFilePath)
 		});
 		const stat = await fs.stat('.evidence/template/static/data/out.0.parquet');
 		expect(stat.isFile()).toBeTruthy();
@@ -173,7 +173,7 @@ describe('buildMultipartParquet', () => {
 		);
 		expect(r).toEqual({
 			writtenRows: 1000,
-			filenames: ['.evidence/template/static/data/out.0.parquet']
+			filenames: ['.evidence/template/static/data/out.0.parquet'].map(adaptFilePath)
 		});
 		const stat = await fs.stat('.evidence/template/static/data/out.0.parquet');
 		expect(stat.isFile()).toBeTruthy();

--- a/packages/universal-sql/src/client-duckdb/browser.js
+++ b/packages/universal-sql/src/client-duckdb/browser.js
@@ -96,11 +96,11 @@ export async function emptyDbFs(targetGlob) {
 
 /**
  * Adds a new view to the database, pointing to the provided parquet URL.
- * @param {Record<string, ({ partitions: string[], name: string, useHive: boolean })[]>} tablse
+ * @param {Record<string, ({ partitions: string[], name: string, useHive: boolean })[]>} tables
  * @param {boolean} [append]
  * @returns {Promise<void>}
  */
-export async function setParquetURLs(tablse, append = false) {
+export async function setParquetURLs(tables, append = false) {
 	if (!db) await initDB();
 	if (!append) await emptyDbFs('*');
 	if (import.meta.env.VITE_EVIDENCE_DEBUG) console.debug('Updating Parquet URLs');
@@ -120,9 +120,9 @@ export async function setParquetURLs(tablse, append = false) {
 	};
 
 	try {
-		for (const source in tablse) {
+		for (const source in tables) {
 			await connection.query(`CREATE SCHEMA IF NOT EXISTS "${source}";`);
-			for (const table of tablse[source]) {
+			for (const table of tables[source]) {
 				for (const file of table.partitions) {
 					const clean = cleanPath(file);
 					if (append) {

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -113,12 +113,12 @@ export async function setParquetURLs(tables, append = false) {
 		 */
 		const adaptForPlatform = (s) => s.split(/[\\/]/g).join(path.sep);
 		for (const table of tables[source]) {
+			table.partitions = table.partitions.map(adaptForPlatform);
 			for (const file of table.partitions) {
-				const platformPath = adaptForPlatform(file);
 				if (append) {
-					await emptyDbFs(platformPath);
+					await emptyDbFs(file);
 				}
-				db.registerFileURL(platformPath, platformPath, DuckDBDataProtocol.NODE_FS, false);
+				db.registerFileURL(file, file, DuckDBDataProtocol.NODE_FS, false);
 			}
 			connection.query(
 				`CREATE OR REPLACE VIEW "${source}"."${table.name}" AS (

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -123,7 +123,7 @@ export async function setParquetURLs(tables, append = false) {
 			connection.query(
 				`CREATE OR REPLACE VIEW "${source}"."${table.name}" AS (
 					SELECT * FROM read_parquet([${table.partitions
-						.map((p) => `'${p.replaceAll("'", "''")}'`)
+						.map((p) => `'${p.replaceAll("'", "''").replaceAll('\\', '\\\\')}'`)
 						.join(', ')}], hive_partitioning = ${table.useHive ? '1' : '0'})
 				);`
 			);

--- a/packages/universal-sql/src/client-duckdb/node.js
+++ b/packages/universal-sql/src/client-duckdb/node.js
@@ -7,12 +7,12 @@ import {
 	VoidLogger
 } from '@duckdb/duckdb-wasm/dist/duckdb-node-blocking';
 import { createRequire } from 'module';
-import path, { dirname, resolve } from 'path';
+import path from 'path';
 import { cache_for_hash, get_arrow_if_sql_already_run } from '../cache-duckdb.js';
 import { withTimeout } from './both.js';
 
 const require = createRequire(import.meta.url);
-const DUCKDB_DIST = dirname(require.resolve('@duckdb/duckdb-wasm'));
+const DUCKDB_DIST = path.dirname(require.resolve('@duckdb/duckdb-wasm'));
 
 export { tableFromIPC } from 'apache-arrow';
 
@@ -45,12 +45,12 @@ export async function initDB() {
 	try {
 		const DUCKDB_BUNDLES = {
 			mvp: {
-				mainModule: resolve(DUCKDB_DIST, './duckdb-mvp.wasm'),
-				mainWorker: resolve(DUCKDB_DIST, './duckdb-node-mvp.worker.cjs')
+				mainModule: path.resolve(DUCKDB_DIST, './duckdb-mvp.wasm'),
+				mainWorker: path.resolve(DUCKDB_DIST, './duckdb-node-mvp.worker.cjs')
 			},
 			eh: {
-				mainModule: resolve(DUCKDB_DIST, './duckdb-eh.wasm'),
-				mainWorker: resolve(DUCKDB_DIST, './duckdb-node-eh.worker.cjs')
+				mainModule: path.resolve(DUCKDB_DIST, './duckdb-eh.wasm'),
+				mainWorker: path.resolve(DUCKDB_DIST, './duckdb-node-eh.worker.cjs')
 			}
 		};
 		const logger = process.env.VITE_EVIDENCE_DEBUG ? new ConsoleLogger() : new VoidLogger();
@@ -111,7 +111,7 @@ export async function setParquetURLs(tables, append = false) {
 		 * @param {string} s
 		 * @returns {string}
 		 */
-		const adaptForPlatform = (s) => s.split(/[\\/]/g).join(path.delimiter);
+		const adaptForPlatform = (s) => s.split(/[\\/]/g).join(path.sep);
 		for (const table of tables[source]) {
 			for (const file of table.partitions) {
 				const platformPath = adaptForPlatform(file);


### PR DESCRIPTION
### Description

Adds a `backgroundFetch` function and `longQueryNotifier` to querystore

toast notification shows for 3 seconds after query takes longer than 1 second to execute:
<img width="341" alt="image" src="https://github.com/evidence-dev/evidence/assets/61282104/cb1088da-6a37-4823-8759-dc856ab25ece">


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
