### PR TITLE
Fix bug navigating away from settings page

### DIFF
--- a/.changeset/happy-ads-serve.md
+++ b/.changeset/happy-ads-serve.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix bug caused by navigating away from settings page

--- a/packages/core-components/src/lib/organisms/source-config/SourceConfig.svelte
+++ b/packages/core-components/src/lib/organisms/source-config/SourceConfig.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <section class="w-full mt-8">
-	<div class="p-3 rounded-t w-full border-gray-200 border">
+	<div class="p-3 rounded-t w-full border-gray-200 border-t border-l border-r">
 		<h2 class="font-semibold text-lg mb-2">Data Sources</h2>
 
 		<div
@@ -118,7 +118,7 @@
 
 		<div />
 	</div>
-	<div class="p-4 rounded-b w-full bg-gray-100 text-sm border-b border-r border-l">
+	<div class="p-4 rounded-b w-full bg-gray-100 text-sm border-[1px] border-gray-200">
 		<!-- TODO: Update this when we have docs -->
 		Learn more about
 		<a

--- a/packages/core-components/src/lib/organisms/source-config/SourceConfigRow.svelte
+++ b/packages/core-components/src/lib/organisms/source-config/SourceConfigRow.svelte
@@ -59,7 +59,7 @@
 </div>
 
 {#if open}
-	<div class="col-span-4" transition:slide>
+	<div class="col-span-4" transition:slide|local>
 		<SourceConfigForm
 			{sources}
 			{source}


### PR DESCRIPTION
### Description
There was a bug that would crash the page if you opened a connection's settings in the Settings page, then attempted to navigate back to a normal page.

This was cause by svelte's animation attempting to close the connection settings pane before navigating.

This PR adds `|local` to the animation, which solves the issue.

Also adds a border to the db settings panel

#### Before
![CleanShot 2024-03-06 at 15 58 10](https://github.com/evidence-dev/evidence/assets/12602440/9f6d1bc2-aead-4de8-9964-002edb05dfd9)

#### After
![CleanShot 2024-03-06 at 15 59 23](https://github.com/evidence-dev/evidence/assets/12602440/2c886c68-084f-43d5-b52e-338eef7e1f20)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)