### PR TITLE
Add x and y sort to heatmap

### DIFF
--- a/.changeset/lazy-boxes-brake.md
+++ b/.changeset/lazy-boxes-brake.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': patch
+'@evidence-dev/core-components': patch
+---
+
+Add x and y sort to Heatmap

--- a/packages/component-utilities/src/getDistinctValues.js
+++ b/packages/component-utilities/src/getDistinctValues.js
@@ -1,3 +1,14 @@
+/**
+ * Extracts an array of distinct values from a specified column in a dataset.
+ *
+ * This function iterates over the dataset, collecting values from the specified
+ * column into a Set to ensure uniqueness. It then converts the Set into an array
+ * of distinct values and returns this array.
+ *
+ * @param {Object[]} data - The dataset to process, represented as an array of objects.
+ * @param {string} column - The name of the column from which to extract distinct values.
+ * @returns {any[]} An array containing distinct values from the specified column of the dataset.
+ */
 export default function getDistinctValues(data, column) {
 	const set = new Set(data.map((val) => val[column]));
 	return Array.from(set);

--- a/packages/component-utilities/src/getSortedDistinctValues.js
+++ b/packages/component-utilities/src/getSortedDistinctValues.js
@@ -1,0 +1,44 @@
+/**
+ * Gets an array of distinct values from a specified column in a dataset. If sorting by the same column,
+ * sorts the distinct values directly. If sorting by a different column, sorts the entire dataset by that column
+ * first, then extracts distinct values, ensuring the order reflects the sorted dataset.
+ *
+ * @param {Object[]} data - The dataset to process, represented as an array of objects.
+ * @param {string} sortColumn - The name of the column from which to extract distinct values.
+ * @param {string} [sortByColumn] - The name of the column by which to sort. If not specified or the same as sortColumn,
+ *                                   the distinct values of sortColumn are sorted directly. If different, the entire dataset
+ *                                   is sorted by this column before extracting distinct sortColumn values.
+ * @param {string} [sortOrder='asc'] - The order in which to sort ('asc' for ascending, 'desc' for descending). Defaults to 'asc'.
+ * @returns {any[]} An array of distinct values from the `sortColumn`, sorted according to the specified criteria.
+ */
+export default function getSortedDistinctValues(data, sortColumn, sortByColumn, sortOrder = 'asc') {
+	let sortedData = [...data]; // Make a shallow copy of the dataset
+
+	if (sortColumn !== sortByColumn && sortByColumn) {
+		// If sortByColumn is different, sort the full dataset first
+		sortedData.sort((a, b) => {
+			const valueA = a[sortByColumn],
+				valueB = b[sortByColumn];
+			// Handling undefined values explicitly for sorting
+			if (valueA === undefined) return 1;
+			if (valueB === undefined) return -1;
+			// Apply the specified sortOrder
+			return (valueA < valueB ? -1 : valueA > valueB ? 1 : 0) * (sortOrder === 'asc' ? 1 : -1);
+		});
+	}
+
+	// Extract distinct values of sortColumn from the (possibly) sorted dataset, excluding undefined
+	let distinctValues = [
+		...new Set(sortedData.map((item) => item[sortColumn]).filter((value) => value !== undefined))
+	];
+
+	// If sortColumn equals sortByColumn, sort the distinct values directly
+	if (sortColumn === sortByColumn) {
+		distinctValues.sort((a, b) => {
+			// Direct comparison since undefined values are already filtered out
+			return (a < b ? -1 : a > b ? 1 : 0) * (sortOrder === 'asc' ? 1 : -1);
+		});
+	}
+
+	return distinctValues;
+}

--- a/packages/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
@@ -14,11 +14,18 @@
 	} from '@evidence-dev/component-utilities/formatting';
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { uiColours } from '@evidence-dev/component-utilities/colours';
+	import getDistinctValues from '@evidence-dev/component-utilities/getDistinctValues';
+	import getSortedDistinctValues from '@evidence-dev/component-utilities/getSortedDistinctValues';
+	import getCompletedData from '@evidence-dev/component-utilities/getCompletedData';
 
 	export let data;
 	export let queryID;
 	export let x;
 	export let y;
+	export let xSort = undefined;
+	export let xSortOrder = 'asc';
+	export let ySort = undefined;
+	export let ySortOrder = 'asc';
 	export let value;
 	export let valueFmt;
 	export let valueLabels = true;
@@ -70,24 +77,16 @@
 
 	export let renderer = undefined;
 
+	export let nullsZero = true; // if nulls or missing records should display as zero or missing values (blank grey squares)
+	export let zeroDisplay = '—'; // what to display in place of zeros
+
 	$: height = undefined;
 	$: gridHeight = undefined;
-
-	function getDistinctValues(data, column) {
-		let distinctValues = [];
-		const distinctValueSet = new Set();
-		data.forEach((d) => {
-			distinctValueSet.add(d[column]);
-		});
-		distinctValues = [...distinctValueSet];
-		return distinctValues;
-	}
 
 	function mapColumnsToArray(arrayOfObjects, col1, col2, col3) {
 		// x and y must be converted to strings, otherwise echarts will interpret them as index positions
 		return arrayOfObjects.map((obj) => [`${obj[col1]}`, `${obj[col2]}`, obj[col3]]);
 	}
-
 	let xDistinct;
 	let yDistinct;
 	let arrayOfArrays;
@@ -104,6 +103,8 @@
 
 	$: try {
 		checkInputs(data, [x, y, value]);
+
+		data = getCompletedData(data, x, value, y, nullsZero); // works slightly differently than regular chart - requires y column to be treated as series for this function
 
 		if (min) {
 			// if min was user-supplied
@@ -126,8 +127,12 @@
 		minValue = min ?? Math.min(...data.map((d) => d[value]));
 		maxValue = max ?? Math.max(...data.map((d) => d[value]));
 
-		xDistinct = getDistinctValues(data, x);
-		yDistinct = getDistinctValues(data, y);
+		xDistinct = xSort
+			? getSortedDistinctValues(data, x, xSort, xSortOrder)
+			: getDistinctValues(data, x);
+		yDistinct = ySort
+			? getSortedDistinctValues(data, y, ySort, ySortOrder)
+			: getDistinctValues(data, y);
 
 		arrayOfArrays = mapColumnsToArray(data, x, y, value);
 
@@ -227,10 +232,14 @@
 					<span id="tooltip" style='font-weight: 600;'>${params.name}</span>
 						<br/>
 						<span>${formatTitle(value, value_format_object)}: </span>
-							<span style='float:right; margin-left: 10px;'>${formatValue(
-								Number.isNaN(params.value[2]) ? 0 : params.value[2],
-								value_format_object
-							)}</span>`;
+							<span style='float:right; margin-left: 10px;'>${
+								params.value[2] === 0
+									? zeroDisplay
+									: formatValue(
+											Number.isNaN(params.value[2]) ? 0 : params.value[2],
+											value_format_object
+									  )
+							}</span>`;
 
 					return tooltipOutput;
 				},
@@ -280,7 +289,9 @@
 					label: {
 						show: valueLabels,
 						formatter: function (params) {
-							return formatValue(params.value[2], value_format_object);
+							return params.value[2] === 0
+								? zeroDisplay
+								: formatValue(params.value[2], value_format_object);
 						}
 					},
 					labelLayout: {

--- a/sites/docs/docs/components/heatmap.md
+++ b/sites/docs/docs/components/heatmap.md
@@ -142,6 +142,8 @@ Heatmap currently only works with string columns. If you would like to use a dat
 
 <table>						 
 <tr>	<th class='tleft'>Name</th>	<th class='tleft'>Description</th>	<th>Required?</th>	<th>Options</th>	<th>Default</th>	</tr>
+<tr>	<td>nullsZero</td>	<td>Whether to treats nulls or missing values as zero</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>true</td>	</tr>
+<tr>	<td>zeroDisplay</td>	<td>String to display in place of zeros</td>	<td class='tcenter'>-</td>	<td class='tcenter'>string</td>	<td class='tcenter'>—</td>	</tr>
 <tr>	<td>colorPalette</td>	<td>Array of colors to form the gradient for the heatmap. Remember to wrap your array in curly braces.</td>	<td class='tcenter'>-</td>	<td class='tcenter'>array of color codes - e.g., <code>{`colorPalette={['navy', 'white', '#c9c9c9']}`}</code></td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>valueFmt</td>	<td>Format to use for value column (<a href='/core-concepts/formatting'>see available formats</a>)</td>	<td class='tcenter'>-</td>	<td class='tcenter'>Excel-style format | built-in format name | custom format name</td>	<td class='tcenter'>-</td>	</tr>
 <tr>	<td>cellHeight</td>	<td>Number representing the height of cells in the heatmap</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>30</td>	</tr>
@@ -159,7 +161,10 @@ Heatmap currently only works with string columns. If you would like to use a dat
 <tr>	<td>yTickMarks</td>	<td>Turns on/off tick marks for the y-axis labels</td>	<td class='tcenter'>-</td>	<td class='tcenter'>true | false</td>	<td class='tcenter'>false</td>	</tr>
 <tr>	<td>xLabelRotation</td>	<td>Degrees to rotate the labels on the x-axis. Can be negative number to reverse direction. <code>45</code> and <code>-45</code> are common options</td>	<td class='tcenter'>-</td>	<td class='tcenter'>number</td>	<td class='tcenter'>0</td>	</tr>
 <tr>	<td>xAxisPosition</td>	<td>Position of x-axis and labels. Can be top or bottom. top recommended for longer charts</td>	<td class='tcenter'>-</td>	<td class='tcenter'>top | bottom</td>	<td class='tcenter'>top</td>	</tr>
-
+<tr>	<td>xSort</td>	<td>Column to sort x values by</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>xSortOrder</td>	<td>Sets direction of sort</td>	<td class='tcenter'>-</td>	<td class='tcenter'>asc | desc</td>	<td class='tcenter'>asc</td>	</tr>
+<tr>	<td>ySort</td>	<td>Column to sort y values by</td>	<td class='tcenter'>-</td>	<td class='tcenter'>column name</td>	<td class='tcenter'>-</td>	</tr>
+<tr>	<td>ySortOrder</td>	<td>Sets direction of sort</td>	<td class='tcenter'>-</td>	<td class='tcenter'>asc | desc</td>	<td class='tcenter'>asc</td>	</tr>
 </table>
 
 ### Chart

--- a/sites/example-project/src/pages/charts/heatmap/+page.md
+++ b/sites/example-project/src/pages/charts/heatmap/+page.md
@@ -1,5 +1,29 @@
 # Heatmap
 
+```missing
+select 'A' as cat, 'Mon' as day_name, 1 as day_num, 100 as sales union all
+select 'A' as cat, 'Thu' as day_name, 4 as day_num, 200 as sales union all
+select 'A' as cat, 'Sat' as day_name, 6 as day_num, 400 as sales union all
+select 'A' as cat, 'Tue' as day_name, 2 as day_num, 300 as sales union all
+select 'A' as cat, 'Wed' as day_name, 3 as day_num, 200 as sales union all
+select 'A' as cat, 'Fri' as day_name, 5 as day_num, 500 as sales union all
+select 'B' as cat, 'Mon' as day_name, 1 as day_num, 700 as sales union all
+select 'B' as cat, 'Thu' as day_name, 4 as day_num, 200 as sales union all
+select 'B' as cat, 'Sat' as day_name, 6 as day_num, 400 as sales union all
+select 'B' as cat, 'Tue' as day_name, 2 as day_num, 100 as sales union all
+select 'B' as cat, 'Wed' as day_name, 3 as day_num, 700 as sales union all
+select 'B' as cat, 'Fri' as day_name, 5 as day_num, 400 as sales union all
+select 'B' as cat, 'Sun' as day_name, 0 as day_num, 300 as sales
+```
+
+<Heatmap
+    data={missing}
+    x=day_name
+    y=cat
+    value=sales
+    xSort=day_num
+/>
+
 ```orders
 select category, dayname(order_datetime) as day, dayofweek(order_datetime) as day_num, count(*) as order_count from needful_things.orders
 group by all
@@ -107,4 +131,5 @@ order by state asc, item asc
     subtitle="By State"
     rightPadding=40
     cellHeight=25
+    nullsZero=false
 />


### PR DESCRIPTION
### Description
Adds x and y axis sorting ability to Heatmap.

#### New props:
`xSort` and `ySort`: column to sort the axis by - can be the same column or another column
`xSortOrder` and `ySortOrder`: 'asc' (default) or 'desc'
`nullsZero`: whether to treat missing/null data as zeros or not (true - default | false)
`zeroDisplay`: string to display in place of zeros ('-' is default)

### Examples

#### Before - sorted by SQL query
![CleanShot 2024-03-07 at 10 00 52@2x](https://github.com/evidence-dev/evidence/assets/12602440/79577d2c-4879-4ae5-a9ca-57a7b208a877)

#### After - `xSort=day_num`
![CleanShot 2024-03-07 at 10 03 30@2x](https://github.com/evidence-dev/evidence/assets/12602440/94a11310-a10b-471c-a3d8-8a6a805288db)

#### `ySort=orders` + `ySortOrder=desc`
![CleanShot 2024-03-07 at 10 05 00@2x](https://github.com/evidence-dev/evidence/assets/12602440/7434a9f0-faf5-4d16-a0d1-05dac9d17c21)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable