### PR TITLE
Fix: Arrays for Multiselect Dropdowns

### DIFF
--- a/.changeset/fast-hornets-mate.md
+++ b/.changeset/fast-hornets-mate.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adjusts multi-dropdowns to return ARRAY rather than LIST types

--- a/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -67,9 +67,8 @@
 		if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
 			return String(value);
 		if (value instanceof Date) return `'${value.toISOString()}'::TIMESTAMP_MS`;
-		if (Array.isArray(value)) 
-		return value.length === 0 ? `('')` :
-		`(${value.map((x) => jsToDuckDB(x)).join(',')})`;
+		if (Array.isArray(value))
+			return value.length === 0 ? `('')` : `(${value.map((x) => jsToDuckDB(x)).join(',')})`;
 		return JSON.stringify(value);
 	}
 

--- a/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -25,6 +25,7 @@
 	import { browser } from '$app/environment';
 	import debounce from 'lodash.debounce';
 	import { QueryStore } from '@evidence-dev/query-store';
+	import formatTitle from '@evidence-dev/component-utilities/formatTitle';
 
 	const inputs = getContext(INPUTS_CONTEXT_KEY);
 
@@ -214,7 +215,7 @@
 						{:else if $selectedValues.length > 0 && !multiple}
 							{$selectedValues[0].label}
 						{:else}
-							{title}
+							{title ?? formatTitle(name)}
 						{/if}
 						<!-- {$selectedValues.length > 0 && !multiple ? $selectedValues[0].label : title} -->
 						<Icon src={CaretSort} class="ml-2 h-4 w-4" />

--- a/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -67,8 +67,7 @@
 		if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
 			return String(value);
 		if (value instanceof Date) return `'${value.toISOString()}'::TIMESTAMP_MS`;
-		if (Array.isArray(value))
-			return value.length === 0 ? `('')` : `(${value.map((x) => jsToDuckDB(x)).join(',')})`;
+		if (Array.isArray(value)) return `[${value.map((x) => jsToDuckDB(x)).join(', ')}]`;
 		return JSON.stringify(value);
 	}
 
@@ -76,7 +75,10 @@
 		let values;
 		if (multiple) {
 			values = $selectedValues.map((x) => x.value);
-			values.toString = () => jsToDuckDB(values);
+			values.toString = () =>
+				values.length === 0
+					? `(select null where 0)`
+					: `(${values.map((x) => jsToDuckDB(x)).join(', ')})`;
 		} else {
 			values = $selectedValues[0]?.value ?? null;
 			// the default `toString` method for Dates aren't good for duckdb

--- a/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -66,7 +66,9 @@
 		if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean')
 			return String(value);
 		if (value instanceof Date) return `'${value.toISOString()}'::TIMESTAMP_MS`;
-		if (Array.isArray(value)) return `[${value.map((x) => jsToDuckDB(x)).join(',')}]`;
+		if (Array.isArray(value)) 
+		return value.length === 0 ? `('')` :
+		`(${value.map((x) => jsToDuckDB(x)).join(',')})`;
 		return JSON.stringify(value);
 	}
 

--- a/sites/docs/docs/components/dropdown.md
+++ b/sites/docs/docs/components/dropdown.md
@@ -99,6 +99,12 @@ Note that "%" is a wildcard character in SQL that can be used with `where column
     value=column_name
     multiple=true
 />
+
+```sql filtered_query
+select *
+from source_name.table
+where column_name in ${inputs.name_of_dropdown.value}
+```
 ````
 
 ### Filtering a Query
@@ -113,7 +119,7 @@ Note that "%" is a wildcard character in SQL that can be used with `where column
 ```sql filtered_query
 select *
 from source_name.table
-where column_name like '${inputs.name_of_dropdown}'
+where column_name like '${inputs.name_of_dropdown.value}'
 ```
 ````
 

--- a/sites/example-project/src/pages/input-components/dropdown/+page.md
+++ b/sites/example-project/src/pages/input-components/dropdown/+page.md
@@ -73,7 +73,16 @@ and date_part('year', order_datetime) = '${inputs.year.value}'
 
 ## Multi Select
 
-<Dropdown name=multi_select data={categories} value=category multiple title=Categories/>
+<Dropdown 
+    name=multi_select 
+    data={categories} 
+    value=category multiple 
+/>
+
+```sql orders_multi
+select * from needful_things.orders
+where category in ${inputs.multi_select.value}
+```
 
 ## A huge amount of options
 

--- a/sites/test-env/pages/dropdown.md
+++ b/sites/test-env/pages/dropdown.md
@@ -44,7 +44,7 @@ select * from orders
 ## Multi Dropdown
 
 ```selected_orders
-select * from orders where list_contains(${inputs.multiple_selected_order_ids.value}, id)
+select * from orders where id in ${inputs.multiple_selected_order_ids.value}
 ```
 
 <Dropdown multiple title="Selected Order ID" label="first_name || ' ' || last_name" value="order_id" data="named_reviews" where="nps_score > 7" order="first_name" name="multiple_selected_order_ids" defaultValue={2772} />
@@ -75,7 +75,7 @@ Orders of {inputs.multiple_selected_order_ids.label}
 <DateRange name="range" dates="order_datetime" data="orders" />
 
 ```selected_items
-SELECT * FROM orders WHERE list_contains(${inputs.item.value}, item) AND order_datetime BETWEEN '${inputs.range.start}' AND '${inputs.range.end}'
+SELECT * FROM orders WHERE item in ${inputs.item.value} AND order_datetime BETWEEN '${inputs.range.start}' AND '${inputs.range.end}'
 ```
 
 <DataTable data={selected_items} />


### PR DESCRIPTION
### Description

This allows you to use outputs from mutli-dropdowns as DuckDB arrays.

In the case where nothing is selected, it will return an empty array

## From 
causes multiple values to be returned as a LIST type

`${inputs.category.value} → ['Cursed Sporting Goods', 'Sinister Toys']`

which means to filter a query, you need to use

`where list_contains(${inputs.category.value}, category)`

## To 
use an ARRAY type

`${inputs.category.value} → ('Cursed Sporting Goods', 'Sinister Toys')`

which means you could filter with

`where category IN ${inputs.category.value}`

which I believe is the intended behaviour

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
