### PR TITLE
Exclude page source code from pagesManifest

### DIFF
--- a/.changeset/late-mails-grin.md
+++ b/.changeset/late-mails-grin.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Reduces the amount of data returned in the pages manifest

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -54,16 +54,8 @@ export async function GET() {
 					let absolutePath = path.join(process.cwd(), 'src', 'pages', pagePath);
 					let pageContent = fs.readFileSync(absolutePath, 'utf-8');
 					let frontMatter = preprocess.parseFrontmatter(pageContent);
-					let queries = preprocess.extractQueries(
-						preprocess.injectPartials(pageContent),
-						absolutePath
-					);
-					return (
-						(r['href'] = href),
-						(r['frontMatter'] = frontMatter),
-						(r['queries'] = queries),
-						(r['content'] = pageContent)
-					);
+
+					return (r['href'] = href), (r['frontMatter'] = frontMatter);
 				} else {
 					let label = e.includes('[') ? undefined : e.replace(/_/g, ' ').replace(/-/g, ' ');
 					r.isTemplated = e.includes('[');


### PR DESCRIPTION
Stops the pages manifest from returning source code for each page, which is currently unused. 