### PR TITLE
Fix single row `Value` and `BigValue` regressions

### DIFF
--- a/.changeset/soft-candles-trade.md
+++ b/.changeset/soft-candles-trade.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix single row `Value` and `BigValue` regressions

--- a/packages/core-components/src/lib/atoms/query-load/QueryLoad.svelte
+++ b/packages/core-components/src/lib/atoms/query-load/QueryLoad.svelte
@@ -25,7 +25,7 @@
 	<slot loaded={data} />
 {:else if !data?.__isQueryStore}
 	<!-- data prop was provided, but it is not a query store -->
-	{#if !data?.__isQueryStore && isEmptyDataset(data) && $$slots.empty}
+	{#if (Array.isArray(data) || !data) && isEmptyDataset(data) && $$slots.empty}
 		<!-- handle case where data is not a query store but is also empty -->
 		<slot name="empty" />
 	{:else}

--- a/packages/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
+++ b/packages/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
@@ -40,9 +40,6 @@
 	$: try {
 		error = undefined;
 
-		// check if dataset exists
-		checkInputs(data);
-
 		if (!value) {
 			throw new Error('value is required');
 		}

--- a/sites/test-env/pages/single-value.md
+++ b/sites/test-env/pages/single-value.md
@@ -1,0 +1,28 @@
+<script>
+	const datas = [
+		{ price: 59.99 },
+		{ price: 10.99 },
+		{ price: 29.99 },
+		{ price: 99.99 }
+	];
+</script>
+
+## BigValues
+
+{#each datas as row}
+	<BigValue data={row} value="price" />
+{/each}
+
+## Values
+
+<ul>
+{#each datas as row, i}
+	<li>
+		{i+1}: <Value data={row} value="price" />
+	</li>
+{/each}
+</ul>
+
+## Random DataTable
+
+<DataTable data={datas} />


### PR DESCRIPTION
### Description

Closes #1745 

Re-enables `Value` and `BigValue`'s ability to render a single row

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
