### PR TITLE
Add default `ButtonGroup` selected item

### DIFF
--- a/.changeset/red-beans-cheat.md
+++ b/.changeset/red-beans-cheat.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': minor
+---
+
+adds `default` prop to `ButtonGroupItem`s allowing for a default selected item

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -4,7 +4,7 @@
 
 <script>
 	import { presets, setButtonGroupContext } from './lib.js';
-	import { derived, writable } from 'svelte/store';
+	import { writable, readonly } from 'svelte/store';
 	import { INPUTS_CONTEXT_KEY } from '@evidence-dev/component-utilities/globalContexts';
 	import { getContext } from 'svelte';
 	import { buildInputQuery } from '@evidence-dev/component-utilities/buildQuery';
@@ -23,15 +23,13 @@
 
 	const inputs = getContext(INPUTS_CONTEXT_KEY);
 
-	let currentValue = null;
 	const valueStore = writable(null);
-	$: $valueStore = currentValue;
-	$: $inputs[name] = currentValue?.value ?? null;
 
-	setButtonGroupContext(
-		(v) => (currentValue = v),
-		derived([valueStore], ([$v]) => $v)
-	);
+	setButtonGroupContext((v) => {
+		$valueStore = v;
+		// the assignment to $inputs is necessary to trigger the change on SSR
+		$inputs[name] = v?.value ?? null;
+	}, readonly(valueStore));
 
 	/////
 	// Query-Related Things

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
@@ -10,6 +10,14 @@
 	export let value;
 
 	const { update, value: currentValue } = getButtonGroupContext();
+
+	/** @type {boolean} */
+	let _default = false;
+	export { _default as default };
+
+	if (_default) {
+		update({ valueLabel, value });
+	}
 </script>
 
 <button

--- a/sites/docs/docs/components/button-group.md
+++ b/sites/docs/docs/components/button-group.md
@@ -56,7 +56,7 @@ To see how to filter a query using a Button Group, see [Filters](/core-concepts/
     value=column_name
     title="Select a Category"
 >
-    <ButtonGroupItem valueLabel="All Categories" value="%" />
+    <ButtonGroupItem valueLabel="All Categories" value="%" default />
 </ButtonGroup>
 ````
 

--- a/sites/example-project/src/pages/input-components/button-group/+page.md
+++ b/sites/example-project/src/pages/input-components/button-group/+page.md
@@ -7,28 +7,26 @@ queries:
 
 ## From a Query
 
-<ButtonGroup data={categories} name=category_name value=category />
+<ButtonGroup data={categories} name=first_category_name value=category />
 
-<Dropdown data={categories} name=category value=category/>
-
-{inputs.category_name}
+{inputs.first_category_name}
 
 ## With Title
 
 <ButtonGroup 
     data={categories} 
-    name=category_name 
+    name=second_category_name 
     value=category
     title="Select a Category"
 />
 
-{inputs.category_name}
+{inputs.second_category_name}
 
 ## Hardcoded Options
 
 <ButtonGroup name=option_name>
     <ButtonGroupItem valueLabel="Option One" value="1" />
-    <ButtonGroupItem valueLabel="Option Two" value="2" />
+    <ButtonGroupItem valueLabel="Option Two" value="2" default />
     <ButtonGroupItem valueLabel="Option Three" value="3" />
 </ButtonGroup>  
 
@@ -38,7 +36,7 @@ queries:
 ## With a Default Value
 
 <ButtonGroup data={categories} name=category_name_with_extras value=category title="Select a Category">
-    <ButtonGroupItem valueLabel="All Categories" value="%" />
+    <ButtonGroupItem valueLabel="All Categories" value="%" default/>
 </ButtonGroup>
 
 {inputs.category_name_with_extras}
@@ -51,8 +49,8 @@ queries:
 
 ## Setting a Default Value `defaultValue=1`
 
-<ButtonGroup name=default_value_input defaultValue=1>
-    <ButtonGroupItem valueLabel="Option One" value=1 />
+<ButtonGroup name=default_value_input>
+    <ButtonGroupItem valueLabel="Option One" value=1 default/>
     <ButtonGroupItem valueLabel="Option Two" value=2 />
     <ButtonGroupItem valueLabel="Option Three" value=3 />
 </ButtonGroup>

--- a/sites/test-env/pages/button-range.md
+++ b/sites/test-env/pages/button-range.md
@@ -35,7 +35,7 @@ select category from needful_things.orders group by category
 ## With a Default Value
 
 <ButtonGroup data={categories} name=category_name_with_extras value=category title="Select a Category">
-    <ButtonGroupItem valueLabel="All Categories" value="%" />
+    <ButtonGroupItem valueLabel="All Categories" value="%" default/>
 </ButtonGroup>
 
 {inputs.category_name_with_extras}
@@ -48,8 +48,8 @@ select category from needful_things.orders group by category
 
 ## Setting a Default Value `defaultValue=1`
 
-<ButtonGroup name=default_value_input defaultValue=1>
-    <ButtonGroupItem valueLabel="Option One" value=1 />
+<ButtonGroup name=default_value_input>
+    <ButtonGroupItem valueLabel="Option One" value=1 default/>
     <ButtonGroupItem valueLabel="Option Two" value=2 />
     <ButtonGroupItem valueLabel="Option Three" value=3 />
 </ButtonGroup>

--- a/sites/test-env/pages/button-range.md
+++ b/sites/test-env/pages/button-range.md
@@ -1,0 +1,75 @@
+```categories
+select category from needful_things.orders group by category
+```
+
+# Button Group
+
+## From a Query
+
+<ButtonGroup data={categories} name=first_category_name value=category />
+
+{inputs.first_category_name}
+
+## With Title
+
+<ButtonGroup 
+    data={categories} 
+    name=second_category_name 
+    value=category
+    title="Select a Category"
+/>
+
+{inputs.second_category_name}
+
+## Hardcoded Options
+
+<ButtonGroup name=option_name>
+    <ButtonGroupItem valueLabel="Option One" value="1" />
+    <ButtonGroupItem valueLabel="Option Two" value="2" default />
+    <ButtonGroupItem valueLabel="Option Three" value="3" />
+</ButtonGroup>  
+
+{inputs.option_name}
+
+
+## With a Default Value
+
+<ButtonGroup data={categories} name=category_name_with_extras value=category title="Select a Category">
+    <ButtonGroupItem valueLabel="All Categories" value="%" />
+</ButtonGroup>
+
+{inputs.category_name_with_extras}
+
+## Using a Preset `preset=dates`
+
+<ButtonGroup name=preset_input value=category preset=dates />
+
+{inputs.preset_input}
+
+## Setting a Default Value `defaultValue=1`
+
+<ButtonGroup name=default_value_input defaultValue=1>
+    <ButtonGroupItem valueLabel="Option One" value=1 />
+    <ButtonGroupItem valueLabel="Option Two" value=2 />
+    <ButtonGroupItem valueLabel="Option Three" value=3 />
+</ButtonGroup>
+
+{inputs.default_value_input}
+
+## Using Alternative Labels
+
+```sql category_lookup
+select 
+    category, 
+    upper(left(category,3)) as abbrev 
+from ${categories}
+```
+
+<ButtonGroup 
+    data={category_lookup} 
+    name=alternative_labels 
+    value=category
+    label=abbrev 
+/>
+
+{inputs.alternative_labels}


### PR DESCRIPTION
### Description

Adds a `default` prop to `ButtonGroupItem` for adding a default selected button

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
