### PR TITLE
Align inputs to left side of page

### DIFF
--- a/.changeset/cold-bats-smash.md
+++ b/.changeset/cold-bats-smash.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adjust default margin on input components

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -47,7 +47,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="inline-flex flex-col mt-2 mb-4 mx-1">
+	<div class="inline-flex flex-col mt-2 mb-4 ml-0 mr-2">
 		{#if title}
 			<span class="text-gray-900 text-sm block mb-1">{title}</span>
 		{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
@@ -81,7 +81,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 mx-1 inline-block">
+	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
 		{#if title}
 			<span class="text-sm text-gray-500 block mb-1">{title}</span>
 		{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -185,7 +185,7 @@
 {/key}
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 mx-1 inline-block">
+	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
 		{#if hasQuery && $query.error}
 			<span
 				class="group inline-flex items-center relative cursor-help cursor-helpfont-sans px-1 border border-red-200 py-[1px] bg-red-50 rounded"

--- a/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
@@ -47,7 +47,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 mx-1 inline-block">
+	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
 		{#if title}
 			<span class="text-gray-900 text-sm block mb-1">{title}</span>
 		{/if}


### PR DESCRIPTION
### Description
Shift the margin on input components from `mx-1` to `ml-0 mr-2` so they align with the left edge of the page

#### Before
![CleanShot 2024-03-20 at 18 20 13@2x](https://github.com/evidence-dev/evidence/assets/12602440/52cdb090-0d37-4802-82b4-7a27da67b275)

#### After
![CleanShot 2024-03-20 at 18 27 42@2x](https://github.com/evidence-dev/evidence/assets/12602440/2cb694b4-f590-4176-8d85-bc99a901f190)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)