### PR TITLE
Speed up tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"release:next": "VERSION=$(git rev-parse --short HEAD) && pnpm -r exec npm pkg set version=0.0.0-\"$VERSION\" && pnpm install --frozen-lockfile && pnpm -r publish --tag next --no-git-checks",
 		"test": "pnpm -r test",
 		"test:ui": "pnpm -r test:ui",
-		"postinstall": "run-s build:plugin-connector build:preprocess build:tailwind build:query-store package:core-components build:evidence && pnpm install --ignore-scripts",
+		"postinstall": "run-s build:plugin-connector build:preprocess build:tailwind build:query-store package:core-components build:evidence",
 		"docs": "pnpm --filter ./sites/docs start",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"serve:docs": "pnpm --filter ./sites/docs serve",
 		"release": "run-s package:core-components build:tailwind build:evidence build:plugin-connector && pnpm changeset publish",
 		"release:next": "VERSION=$(git rev-parse --short HEAD) && pnpm -r exec npm pkg set version=0.0.0-\"$VERSION\" && pnpm install --frozen-lockfile && pnpm -r publish --tag next --no-git-checks",
-		"test": "run-s package:core-components build:tailwind build:evidence && pnpm i --frozen-lockfile && pnpm -r test",
+		"test": "pnpm -r test",
 		"test:ui": "pnpm -r test:ui",
 		"postinstall": "run-s build:plugin-connector build:preprocess build:tailwind build:query-store package:core-components build:evidence && pnpm install --ignore-scripts",
 		"docs": "pnpm --filter ./sites/docs start",

--- a/sites/test-env/evidence.plugins.yaml
+++ b/sites/test-env/evidence.plugins.yaml
@@ -6,5 +6,4 @@ datasources:
     @evidence-dev/csv: { }
     @evidence-dev/postgres: { }
     @evidence-dev/sqlite: { }
-    @evidence-dev/connector-gsheets: { }
     @evidence-dev/snowflake: { }

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -6,7 +6,6 @@
 		"build": "evidence build",
 		"build:strict": "evidence build:strict",
 		"dev": "evidence dev",
-		"test": "evidence sources && cross-env NODE_OPTIONS=--max-old-space-size=8192 evidence build",
 		"sources": "evidence sources",
 		"preview": "evidence preview"
 	},

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -3,8 +3,8 @@
 	"version": "3.0.22",
 	"private": true,
 	"scripts": {
-		"build": "evidence build",
-		"build:strict": "evidence build:strict",
+		"build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 evidence build",
+		"build:strict": "cross-env NODE_OPTIONS=--max-old-space-size=8192 evidence build:strict",
 		"dev": "evidence dev",
 		"sources": "evidence sources",
 		"preview": "evidence preview"


### PR DESCRIPTION
### Description

This PR aims to reduce the time it takes for our test suite to run.

It seems to cut test times to 25-30% of the original times.

Notable changes:
- Remove the pre `pnpm test` bundling (since this already happens in postinstall)
- Removes the post install rerun of `npm i`
- Removes the test env build completely (this was over 50% of our test time)



### Results

[Pre optimization test run](https://github.com/evidence-dev/evidence/actions/runs/8398470151/job/23003750927?pr=1780) 

**Ubuntu 18:** 6:44 -> 1:33
**Ubuntu 20:** 6:21 -> 1:34
**Mac 18:** 12mins -> 4mins
**Mac 20:** 10mins -> 4mins
**Windows 18:** 19mins -> 6min
**Windows 20:** 19mins -> 6min