### PR TITLE
Add options to layout

### DIFF
--- a/.changeset/violet-scissors-walk.md
+++ b/.changeset/violet-scissors-walk.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Add options to Evidence layout

--- a/packages/ui/core-components/src/lib/organisms/layout/BreadCrumbs.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/BreadCrumbs.svelte
@@ -55,7 +55,7 @@
 	$: crumbs = buildCrumbs(pathArray);
 </script>
 
-<div class="flex items-start mt-8 sm:mt-12 whitespace-nowrap overflow-auto">
+<div class="flex items-start mt-[6px] whitespace-nowrap overflow-auto">
 	<div class="inline-flex items-center text-sm capitalize gap-1 text-gray-500 mb-2 sm:mb-4">
 		{#each crumbs as crumb, i}
 			{#if i > 0}

--- a/packages/ui/core-components/src/lib/organisms/layout/BreadCrumbs.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/BreadCrumbs.svelte
@@ -55,7 +55,7 @@
 	$: crumbs = buildCrumbs(pathArray);
 </script>
 
-<div class="flex items-start mt-[6px] whitespace-nowrap overflow-auto">
+<div class="flex items-start mt-0 whitespace-nowrap overflow-auto">
 	<div class="inline-flex items-center text-sm capitalize gap-1 text-gray-500 mb-2 sm:mb-4">
 		{#each crumbs as crumb, i}
 			{#if i > 0}

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -35,6 +35,13 @@
 	/** @type {string}*/
 	export let maxWidth = undefined;
 
+	/** @type {boolean} */
+	export let hideBreadcrumbs = false;
+	/** @type {boolean} */
+	export let hideHeader = false;
+	/** @type {boolean} */
+	export let hideTOC = false;
+
 	const prefetchStrategy = dev ? 'tap' : 'hover';
 
 	let mobileSidebarOpen = false;
@@ -52,19 +59,21 @@
 
 <div data-sveltekit-preload-data={prefetchStrategy} class="antialiased text-gray-900">
 	<ErrorOverlay />
-	<Header
-		bind:mobileSidebarOpen
-		{title}
-		{logo}
-		{neverShowQueries}
-		{fullWidth}
-		{maxWidth}
-		{hideSidebar}
-		{githubRepo}
-		{slackCommunity}
-		{xProfile}
-		{algolia}
-	/>
+	{#if !hideHeader}
+		<Header
+			bind:mobileSidebarOpen
+			{title}
+			{logo}
+			{neverShowQueries}
+			{fullWidth}
+			{maxWidth}
+			{hideSidebar}
+			{githubRepo}
+			{slackCommunity}
+			{xProfile}
+			{algolia}
+		/>
+	{/if}
 	<div
 		class={(fullWidth ? 'max-w-full ' : maxWidth ? '' : ' max-w-7xl ') +
 			'print:w-[650px] mx-auto print:md:px-0 print:px-0 px-6 sm:px-8 md:px-12 flex justify-start'}
@@ -72,18 +81,29 @@
 	>
 		{#if !hideSidebar}
 			<div class="print:hidden">
-				<Sidebar {fileTree} bind:mobileSidebarOpen {title} {logo} {builtWithEvidence} />
+				<Sidebar
+					{fileTree}
+					bind:mobileSidebarOpen
+					{title}
+					{logo}
+					{builtWithEvidence}
+					{hideHeader}
+				/>
 			</div>
 		{/if}
 		<main
-			class={(!hideSidebar ? 'md:px-8 ' : '') +
-				'flex-grow overflow-x-hidden print:px-0 print:md:px-0 py-8'}
+			class={(!hideSidebar ? 'md:pl-8 ' : '') +
+				(!hideTOC ? 'md:pr-8 ' : '') +
+				(!hideHeader ? 'mt-[74px] ' : 'mt-[26px] ') +
+				'flex-grow overflow-x-hidden print:px-0 print:mt-8'}
 		>
-			<div class="print:hidden">
-				{#if $page.route.id !== '/settings'}
-					<BreadCrumbs {fileTree} />
-				{/if}
-			</div>
+			{#if !hideBreadcrumbs}
+				<div class="print:hidden">
+					{#if $page.route.id !== '/settings'}
+						<BreadCrumbs {fileTree} />
+					{/if}
+				</div>
+			{/if}
 			{#if !$navigating}
 				<article id="evidence-main-article" class="select-text markdown">
 					<slot name="content" />
@@ -92,9 +112,11 @@
 				<LoadingSkeleton />
 			{/if}
 		</main>
-		<div class="print:hidden">
-			<TableOfContents />
-		</div>
+		{#if !hideTOC}
+			<div class="print:hidden">
+				<TableOfContents />
+			</div>
+		{/if}
 	</div>
 </div>
 {#if !$navigating && dev && !$page.url.pathname.startsWith('/settings')}

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -94,7 +94,13 @@
 		<main
 			class={(!hideSidebar ? 'md:pl-8 ' : '') +
 				(!hideTOC ? 'md:pr-8 ' : '') +
-				(!hideHeader ? 'mt-[74px] ' : 'mt-[26px] ') +
+				(!hideHeader
+					? !hideBreadcrumbs
+						? ' mt-16 sm:mt-20 '
+						: ' mt-16 sm:mt-[74px] '
+					: !hideBreadcrumbs
+						? ' mt-4 sm:mt-8 '
+						: ' mt-4 sm:mt-[26px] ') +
 				'flex-grow overflow-x-hidden print:px-0 print:mt-8'}
 		>
 			{#if !hideBreadcrumbs}
@@ -114,7 +120,7 @@
 		</main>
 		{#if !hideTOC}
 			<div class="print:hidden">
-				<TableOfContents />
+				<TableOfContents {hideHeader} />
 			</div>
 		{/if}
 	</div>

--- a/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
@@ -107,10 +107,3 @@
 		</div>
 	</div>
 </header>
-
-<style>
-	.active {
-		--tw-bg-opacity: 1;
-		background-color: rgb(243 244 246 / var(--tw-bg-opacity));
-	}
-</style>

--- a/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
@@ -7,20 +7,20 @@
 	import AlgoliaDocSearch from './AlgoliaDocSearch.svelte';
 	import KebabMenu from './KebabMenu.svelte';
 
-	export let mobileSidebarOpen;
-	export let title;
-	export let logo;
-	export let neverShowQueries;
-	export let fullWidth;
-	export let maxWidth;
-	export let hideSidebar;
+	export let mobileSidebarOpen = undefined;
+	export let title = undefined;
+	export let logo = undefined;
+	export let neverShowQueries = undefined;
+	export let fullWidth = undefined;
+	export let maxWidth = undefined;
+	export let hideSidebar = undefined;
 
-	export let algolia;
+	export let algolia = undefined;
 
 	// Social links
-	export let githubRepo;
-	export let xProfile;
-	export let slackCommunity;
+	export let githubRepo = undefined;
+	export let xProfile = undefined;
+	export let slackCommunity = undefined;
 </script>
 
 <header
@@ -110,6 +110,7 @@
 
 <style>
 	.active {
-		@apply bg-gray-100;
+		--tw-bg-opacity: 1;
+		background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 	}
 </style>

--- a/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
@@ -4,13 +4,14 @@
 	import { fly, fade } from 'svelte/transition';
 	import { lock, unlock } from 'tua-body-scroll-lock';
 	import { afterUpdate } from 'svelte';
-	import Badge from '$lib/organisms/layout/sidebar/Badge.svelte';
+	import Badge from './Badge.svelte';
 	import Logo from '../Logo.svelte';
 
-	export let fileTree;
-	export let title;
-	export let logo;
-	export let builtWithEvidence;
+	export let fileTree = undefined;
+	export let title = undefined;
+	export let logo = undefined;
+	export let builtWithEvidence = undefined;
+	export let hideHeader = false;
 
 	// sort children arrays by sidebar_position
 	function sortChildrenBySidebarPosition(node) {
@@ -194,6 +195,7 @@
 	{#if !mobileSidebarOpen}
 		<div
 			class="hidden: md:block fixed w-48 top-20 bottom-8 overflow-y-auto flex-1 text-sm text-gray-500 pretty-scrollbar"
+			class:top-8={hideHeader}
 		>
 			<div class="flex flex-col pb-6">
 				<a

--- a/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/TableOfContents.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/TableOfContents.svelte
@@ -1,11 +1,16 @@
 <script>
 	import ContentsList from './ContentsList.svelte';
 	import { page, navigating } from '$app/stores';
+
+	export let hideHeader = false;
 </script>
 
 <aside class="hidden lg:block w-48">
 	{#if !$navigating && $page.data.isUserPage}
-		<div class="fixed w-48 top-20 bottom-20 pl-4 px-3 overflow-auto pretty-scrollbar">
+		<div
+			class="fixed w-48 top-20 bottom-20 pl-4 px-3 overflow-auto pretty-scrollbar"
+			class:top-8={hideHeader}
+		>
 			<ContentsList />
 		</div>
 	{/if}


### PR DESCRIPTION
### Description
Adds options to layout:
- `hideHeader`
- `hideBreadcrumbs`
- `hideTOC`

Also modifies some margin/padding to make this possible, but likely needs a good look to make sure the changes are not brittle.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
