### PR TITLE
fix typo in docu

### DIFF
--- a/sites/docs/docs/markdown/index.md
+++ b/sites/docs/docs/markdown/index.md
@@ -159,7 +159,7 @@ You can put whatever data you would like here, and it uses a [yaml syntax](https
 | `og.description` | changes the body of the embed                                                                                                |
 | `og.image`       | will appear in the embed if specified, but it is not required.                                                               |
 | `queries`        | references SQL queries stored in the /queries directory.                                                                     |
-| `side_bar_position`        | changes the position of the page in the sidebar. When used in index.md pages, changes the position of their parent in the sidebar.                                                                     |
+| `sidebar_position`        | changes the position of the page in the sidebar. When used in index.md pages, changes the position of their parent in the sidebar.                                                                     |
 | `sidebar_link`        | when set to false, no link to the page appears in the sidebar. When used in index.md pages, the parent directory will still appear in the sidebar but it will not function as a link.                                                                    |
 
 


### PR DESCRIPTION
### Description

https://docs.evidence.dev/markdown/#frontmatter
suggests `side_bar_position` is the way to change the sidebar ordering. This does not work, the correct key is `sidebar_position`.

### Checklist

- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
