### PR TITLE
Fix format object retrieval in Chart and Value components

### DIFF
--- a/.changeset/cyan-suits-fry.md
+++ b/.changeset/cyan-suits-fry.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix errors caused by formatting null values

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -452,7 +452,7 @@
 			// Get format codes for axes
 			// ---------------------------------------------------------------------------------------
 			if (xFmt) {
-				xFormat = getFormatObjectFromString(xFmt, columnSummary[x].format.valueType);
+				xFormat = getFormatObjectFromString(xFmt, columnSummary[x].format?.valueType);
 			} else {
 				xFormat = columnSummary[x].format;
 			}
@@ -462,9 +462,9 @@
 			} else {
 				if (yFmt) {
 					if (typeof y === 'object') {
-						yFormat = getFormatObjectFromString(yFmt, columnSummary[y[0]].format.valueType);
+						yFormat = getFormatObjectFromString(yFmt, columnSummary[y[0]].format?.valueType);
 					} else {
-						yFormat = getFormatObjectFromString(yFmt, columnSummary[y].format.valueType);
+						yFormat = getFormatObjectFromString(yFmt, columnSummary[y].format?.valueType);
 					}
 				} else {
 					if (typeof y === 'object') {
@@ -478,9 +478,9 @@
 			if (y2) {
 				if (y2Fmt) {
 					if (typeof y2 === 'object') {
-						y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2[0]].format.valueType);
+						y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2[0]].format?.valueType);
 					} else {
-						y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2].format.valueType);
+						y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2].format?.valueType);
 					}
 				} else {
 					if (typeof y2 === 'object') {
@@ -493,7 +493,7 @@
 
 			if (size) {
 				if (sizeFmt) {
-					sizeFormat = getFormatObjectFromString(sizeFmt, columnSummary[size].format.valueType);
+					sizeFormat = getFormatObjectFromString(sizeFmt, columnSummary[size].format?.valueType);
 				} else {
 					sizeFormat = columnSummary[size].format;
 				}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
@@ -75,7 +75,7 @@
 					selected_value = data[row][column];
 					columnSummary = columnSummary.filter((d) => d.id === column);
 					if (fmt) {
-						format_object = getFormatObjectFromString(fmt, columnSummary[0].format.valueType);
+						format_object = getFormatObjectFromString(fmt, columnSummary[0].format?.valueType);
 					} else {
 						format_object = columnSummary[0].format;
 					}

--- a/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
@@ -89,7 +89,7 @@
 		if (valueFmt) {
 			valueColFormat = getFormatObjectFromString(
 				valueFmt,
-				columnSummary[valueCol].format.valueType
+				columnSummary[valueCol].format?.valueType
 			);
 		} else {
 			valueColFormat = columnSummary[valueCol].format;


### PR DESCRIPTION
### Description
In Value and BigValue, when `fmt` was applied to nulls, it threw an error. This PR removes the error and passes the value through as "-"

### Notes
I think we can simplify the flow for value formatting. When we set it up, the only way to format values was with format tags in column names, but now the primary method of formatting is using `fmt` props. Creating a format object gets a bit confusing when `fmt` is the method, as we need the value type for the column, which comes from `columnSummary`.

Once we fix the date/timezone issue and rip out the date parsing logic (which also requires `columnSummary`, it would be a good time to reconsider the default formatting approach inside components.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)