### PR TITLE
Add `noDefault` option, allow `defaultValue`s to be array in `Dropdown`

### DIFF
--- a/.changeset/lazy-hornets-call.md
+++ b/.changeset/lazy-hornets-call.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': minor
+---
+
+add `noDefault` prop to `Dropdown`, support for multi-defaultValue

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -60,7 +60,7 @@
 		_defaultValue.length = 0;
 	}
 
-	const hasDefault = noDefault || _defaultValue.length >= 0;
+	const hasDefault = noDefault || _defaultValue.length > 0;
 
 	const ctx = {
 		hasBeenSet: hasDefault,

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -48,14 +48,13 @@
 
 	export let hideDuringPrint = true;
 
+	export let disableSelectAll = false;
+
 	/** @type {string | string[]} */
 	export let defaultValue = [];
 	const _defaultValue = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
 
-	/** @type {boolean} */
 	export let noDefault = false;
-	noDefault = noDefault === true || noDefault === 'true';
-
 	if (noDefault) {
 		_defaultValue.length = 0;
 	}
@@ -267,16 +266,18 @@
 								{/if}
 							</Command.Group>
 							{#if multiple}
-								<Command.Separator />
-								<Command.Item
-									class="justify-center text-center"
-									onSelect={() => {
-										$selectedValues = $items.map((x) => ({ label: x.label, value: x.value }));
-										selectedValuesToInput();
-									}}
-								>
-									Select all
-								</Command.Item>
+								{#if !disableSelectAll}
+									<Command.Separator />
+									<Command.Item
+										class="justify-center text-center"
+										onSelect={() => {
+											$selectedValues = $items.map((x) => ({ label: x.label, value: x.value }));
+											selectedValuesToInput();
+										}}
+									>
+										Select all
+									</Command.Item>
+								{/if}
 								<Command.Separator />
 								<Command.Item
 									disabled={$selectedValues.length === 0}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -51,6 +51,15 @@
 	/** @type {string} */
 	export let defaultValue = undefined;
 
+	/** @type {boolean} */
+	export let noDefault = false;
+	noDefault = noDefault === true || noDefault === 'true';
+
+	if (noDefault) {
+		// `Symbol()` so it isn't == to anything else
+		defaultValue = Symbol();
+	}
+
 	const ctx = {
 		hasBeenSet: defaultValue !== undefined,
 		handleSelect,
@@ -150,7 +159,7 @@
 	function useNewQuery(query) {
 		items = query;
 
-		if (hasQuery && defaultValue) {
+		if (hasQuery && defaultValue !== undefined) {
 			ctx.hasBeenSet = true;
 			if (browser) {
 				(async () => {

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -60,14 +60,10 @@
 		_defaultValue.length = 0;
 	}
 
-	const defaultStatus = noDefault
-		? 'no_default'
-		: _defaultValue.length > 0
-			? 'manual_default'
-			: 'auto_default';
+	const hasDefault = noDefault || _defaultValue.length >= 0;
 
 	const ctx = {
-		hasBeenSet: defaultStatus !== 'auto_default',
+		hasBeenSet: hasDefault,
 		handleSelect,
 		multiple
 	};
@@ -165,7 +161,7 @@
 	function useNewQuery(query) {
 		items = query;
 
-		if (hasQuery && defaultStatus !== 'auto_default') {
+		if (hasQuery && hasDefault) {
 			ctx.hasBeenSet = true;
 			if (browser) {
 				(async () => {

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -48,20 +48,26 @@
 
 	export let hideDuringPrint = true;
 
-	/** @type {string} */
-	export let defaultValue = undefined;
+	/** @type {string | string[]} */
+	export let defaultValue = [];
+	const _defaultValue = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
 
 	/** @type {boolean} */
 	export let noDefault = false;
 	noDefault = noDefault === true || noDefault === 'true';
 
 	if (noDefault) {
-		// `Symbol()` so it isn't == to anything else
-		defaultValue = Symbol();
+		_defaultValue.length = 0;
 	}
 
+	const defaultStatus = noDefault
+		? 'no_default'
+		: _defaultValue.length > 0
+			? 'manual_default'
+			: 'auto_default';
+
 	const ctx = {
-		hasBeenSet: defaultValue !== undefined,
+		hasBeenSet: defaultStatus !== 'auto_default',
 		handleSelect,
 		multiple
 	};
@@ -159,16 +165,16 @@
 	function useNewQuery(query) {
 		items = query;
 
-		if (hasQuery && defaultValue !== undefined) {
+		if (hasQuery && defaultStatus !== 'auto_default') {
 			ctx.hasBeenSet = true;
 			if (browser) {
 				(async () => {
 					await query.fetch();
-					$selectedValues = query.filter((x) => x.value == defaultValue);
+					$selectedValues = query.filter((x) => _defaultValue.find((d) => x.value == d));
 					selectedValuesToInput();
 				})();
 			} else {
-				$selectedValues = query.filter((x) => x.value == defaultValue);
+				$selectedValues = query.filter((x) => _defaultValue.find((d) => x.value == d));
 				selectedValuesToInput();
 			}
 		} else {

--- a/sites/docs/docs/components/dropdown.md
+++ b/sites/docs/docs/components/dropdown.md
@@ -163,6 +163,13 @@ where column_name like '${inputs.name_of_dropdown.value}'
         <td class='tcenter'>-</td>
         <td class='tcenter'>First value in dropdown</td>
     </tr>
+	<tr>
+        <td>noDefault</td>
+        <td>Stops any default from being selected. Overrides any set `defaultValue`.</td>
+        <td class='tcenter'>No</td>
+        <td class='tcenter'>true | false</td>
+        <td class='tcenter'>false</td>
+    </tr>
     <tr>    
         <td>multiple</td>
         <td>Enables multi-select which returns a list</td>
@@ -197,6 +204,13 @@ where column_name like '${inputs.name_of_dropdown.value}'
         <td class='tcenter'>No</td>
         <td class='tcenter'>SQL where clause</td>
         <td class='tcenter'>-</td>
+    </tr>
+	<tr>	
+        <td>hideDuringPrint</td>
+        <td>Hide the component when the report is printed</td>
+        <td class='tcenter'>No</td>
+        <td class='tcenter'>true | false</td>
+        <td class='tcenter'>true</td>
     </tr>
 </table>
 

--- a/sites/docs/docs/components/dropdown.md
+++ b/sites/docs/docs/components/dropdown.md
@@ -123,6 +123,23 @@ where column_name like '${inputs.name_of_dropdown.value}'
 ```
 ````
 
+### Multiple defaultValues
+
+````markdown
+<Dropdown
+    data={query_name} 
+    name=name_of_dropdown
+    value=column_name
+	defaultValue={['value1', 'value2']}
+/>
+
+```sql filtered_query
+select *
+from source_name.table
+where column_name like '${inputs.name_of_dropdown.value}'
+```
+````
+
 ## Dropdown
 
 ### Options
@@ -150,15 +167,15 @@ where column_name like '${inputs.name_of_dropdown.value}'
         <td class='tcenter'>-</td>	
     </tr>
     <tr>	
-        <td>value</td>	
+        <td>value</td>
         <td>Column name from the query containing values to pick from</td>	
         <td class='tcenter'>No</td>	
         <td class='tcenter'>column name</td>	
         <td class='tcenter'>-</td>
     </tr>
-    <tr>	
+    <tr>
         <td>defaultValue</td>
-        <td>Value to use when the dropdown is first loaded. Must be one of the options in the dropdown.</td>
+        <td>Value(s) to use when the dropdown is first loaded. Must be options in the values of the dropdown. Note: for multiple values, the array must be formatted as `defaultValue={[]}`, not `defaultValue=[]`</td>
         <td class='tcenter'>No</td>
         <td class='tcenter'>-</td>
         <td class='tcenter'>First value in dropdown</td>

--- a/sites/docs/docs/components/dropdown.md
+++ b/sites/docs/docs/components/dropdown.md
@@ -187,11 +187,18 @@ where column_name like '${inputs.name_of_dropdown.value}'
         <td class='tcenter'>true | false</td>
         <td class='tcenter'>false</td>
     </tr>
+	<tr>
+        <td>disableSelectAll</td>
+        <td>Removes the `Select all` button. Recommended for large datasets.</td>
+        <td class='tcenter'>No</td>
+        <td class='tcenter'>true | false</td>
+        <td class='tcenter'>false</td>
+    </tr>
     <tr>    
         <td>multiple</td>
         <td>Enables multi-select which returns a list</td>
         <td class='tcenter'>No</td>
-        <td class='tcenter'>boolean</td>
+        <td class='tcenter'>true | false</td>
         <td class='tcenter'>false</td>
     </tr>
     <tr>	

--- a/sites/test-env/pages/dropdown.md
+++ b/sites/test-env/pages/dropdown.md
@@ -47,7 +47,7 @@ select * from orders
 select * from orders where id in ${inputs.multiple_selected_order_ids.value}
 ```
 
-<Dropdown multiple title="Selected Order ID" label="first_name || ' ' || last_name" value="order_id" data="named_reviews" where="nps_score > 7" order="first_name" name="multiple_selected_order_ids" defaultValue={[2772, 271]} />
+<Dropdown multiple title="Selected Order ID" label="first_name || ' ' || last_name" value="order_id" data="named_reviews" where="nps_score > 7" order="first_name" name="multiple_selected_order_ids" defaultValue={[2772, 271]} disableSelectAll />
 
 Orders of {inputs.multiple_selected_order_ids.label}
 

--- a/sites/test-env/pages/dropdown.md
+++ b/sites/test-env/pages/dropdown.md
@@ -71,7 +71,7 @@ Orders of {inputs.multiple_selected_order_ids.label}
 
 ## Small Demo
 
-<Dropdown multiple title="Item" name="item" value="item" data="orders" />
+<Dropdown multiple title="Item" name="item" value="item" data="orders" noDefault />
 <DateRange name="range" dates="order_datetime" data="orders" />
 
 ```selected_items

--- a/sites/test-env/pages/dropdown.md
+++ b/sites/test-env/pages/dropdown.md
@@ -47,7 +47,7 @@ select * from orders
 select * from orders where id in ${inputs.multiple_selected_order_ids.value}
 ```
 
-<Dropdown multiple title="Selected Order ID" label="first_name || ' ' || last_name" value="order_id" data="named_reviews" where="nps_score > 7" order="first_name" name="multiple_selected_order_ids" defaultValue={2772} />
+<Dropdown multiple title="Selected Order ID" label="first_name || ' ' || last_name" value="order_id" data="named_reviews" where="nps_score > 7" order="first_name" name="multiple_selected_order_ids" defaultValue={[2772, 271]} />
 
 Orders of {inputs.multiple_selected_order_ids.label}
 


### PR DESCRIPTION
### Description

Adds `noDefault` option to `Dropdown` component to allow for no default option to be selected

Adds support for multiple `defaultValue`s via an array being passed

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable