### PR TITLE
Slugified Anchor Links

### DIFF
--- a/.changeset/sharp-years-film.md
+++ b/.changeset/sharp-years-film.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/preprocess': patch
+'@evidence-dev/core-components': patch
+---
+
+Add automatic links to headers

--- a/packages/lib/preprocess/index.cjs
+++ b/packages/lib/preprocess/index.cjs
@@ -6,7 +6,7 @@ const addClasses = require('./src/add-classes.cjs');
 // This is includes future proofing to add support for Prism highlighting
 const processFrontmatter = require('./src/frontmatter/process-frontmatter.cjs');
 const injectPartials = require('./src/partials/inject-partials.cjs');
-const remarkSlug = require('remark-slug');
+const rehypeSlug = require('rehype-slug');
 const rehypeAutolinkHeadings = require('rehype-autolink-headings');
 
 module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
@@ -25,14 +25,11 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 			highlight: {
 				highlighter
 			},
-			remarkPlugins: [remarkSlug],
 			rehypePlugins: [
-				[
-					addClasses,
-					{
+				[addClasses, {
 						'*': 'markdown'
-					}
-				],
+					}],
+				[rehypeSlug],
 				[rehypeAutolinkHeadings, {
 					behavior: 'wrap',
 					properties: {}

--- a/packages/lib/preprocess/index.cjs
+++ b/packages/lib/preprocess/index.cjs
@@ -7,6 +7,7 @@ const addClasses = require('./src/add-classes.cjs');
 const processFrontmatter = require('./src/frontmatter/process-frontmatter.cjs');
 const injectPartials = require('./src/partials/inject-partials.cjs');
 const remarkSlug = require('remark-slug');
+const rehypeAutolinkHeadings = require('rehype-autolink-headings');
 
 module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 	return [
@@ -31,7 +32,11 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 					{
 						'*': 'markdown'
 					}
-				]
+				],
+				[rehypeAutolinkHeadings, {
+					behavior: 'wrap',
+					properties: {}
+				  }],
 			]
 		}),
 

--- a/packages/lib/preprocess/index.cjs
+++ b/packages/lib/preprocess/index.cjs
@@ -26,14 +26,20 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 				highlighter
 			},
 			rehypePlugins: [
-				[addClasses, {
+				[
+					addClasses,
+					{
 						'*': 'markdown'
-					}],
+					}
+				],
 				[rehypeSlug],
-				[rehypeAutolinkHeadings, {
-					behavior: 'wrap',
-					properties: {}
-				  }],
+				[
+					rehypeAutolinkHeadings,
+					{
+						behavior: 'wrap',
+						properties: {}
+					}
+				]
 			]
 		}),
 

--- a/packages/lib/preprocess/index.cjs
+++ b/packages/lib/preprocess/index.cjs
@@ -6,6 +6,7 @@ const addClasses = require('./src/add-classes.cjs');
 // This is includes future proofing to add support for Prism highlighting
 const processFrontmatter = require('./src/frontmatter/process-frontmatter.cjs');
 const injectPartials = require('./src/partials/inject-partials.cjs');
+const remarkSlug = require('remark-slug');
 
 module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 	return [
@@ -23,6 +24,7 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 			highlight: {
 				highlighter
 			},
+			remarkPlugins: [remarkSlug],
 			rehypePlugins: [
 				[
 					addClasses,

--- a/packages/lib/preprocess/package.json
+++ b/packages/lib/preprocess/package.json
@@ -24,6 +24,7 @@
 		"prismjs": "^1.29.0",
 		"remark-parse": "8.0.2",
 		"remark-slug": "6.1.0",
+		"rehype-autolink-headings": "5.1.0",
 		"svelte": "4.2.12",
 		"svelte-preprocess": "5.1.3",
 		"unified": "^9.1.0",

--- a/packages/lib/preprocess/package.json
+++ b/packages/lib/preprocess/package.json
@@ -23,6 +23,7 @@
 		"mdsvex": "0.11.0",
 		"prismjs": "^1.29.0",
 		"remark-parse": "8.0.2",
+		"remark-slug": "6.1.0",
 		"svelte": "4.2.12",
 		"svelte-preprocess": "5.1.3",
 		"unified": "^9.1.0",

--- a/packages/lib/preprocess/package.json
+++ b/packages/lib/preprocess/package.json
@@ -23,7 +23,7 @@
 		"mdsvex": "0.11.0",
 		"prismjs": "^1.29.0",
 		"remark-parse": "8.0.2",
-		"remark-slug": "6.1.0",
+		"rehype-slug": "4.0.1",
 		"rehype-autolink-headings": "5.1.0",
 		"svelte": "4.2.12",
 		"svelte-preprocess": "5.1.3",

--- a/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
@@ -5,11 +5,7 @@
 	let observer;
 
 	function updateLinks() {
-		headers = Array.from(document.querySelectorAll('h1.markdown, h2.markdown'));
-		headers.forEach((header, i) => {
-			// Headers may contain values that change in response to user input, so we create our anchors as just the position on the page.
-			header.id = encodeURIComponent(i + 1);
-		});
+		headers = Array.from(document.querySelectorAll('h1.markdown, h2.markdown, h3.markdown'));
 	}
 
 	function observeDocumentChanges() {
@@ -38,11 +34,10 @@
 	<span class="block text-xs sticky top-0 mb-2 text-gray-950 bg-white shadow-white font-medium">
 		On this page
 	</span>
-	{#each headers as header, i}
+	{#each headers as header}
 		<a
-			href={'#' + encodeURIComponent(i + 1)}
+			href={'#' + header.id}
 			class={header.nodeName.toLowerCase()}
-			class:first={i === 0}
 		>
 			{header.innerText}
 		</a>
@@ -54,16 +49,16 @@
 		@apply block text-gray-600 text-xs transition-all duration-200 py-1;
 	}
 
-	/* a.h1.first {
-		@apply mt-0;
-	} */
-
 	a:hover {
 		@apply underline;
 	}
 
 	a.h2 {
 		@apply pl-0 text-gray-500;
+	}
+
+	a.h3 {
+		@apply pl-4 text-gray-500;
 	}
 
 	a.h1 {

--- a/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
@@ -35,10 +35,7 @@
 		On this page
 	</span>
 	{#each headers as header}
-		<a
-			href={'#' + header.id}
-			class={header.nodeName.toLowerCase()}
-		>
+		<a href={'#' + header.id} class={header.nodeName.toLowerCase()}>
 			{header.innerText}
 		</a>
 	{/each}

--- a/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/tableofcontents/ContentsList.svelte
@@ -35,7 +35,7 @@
 		On this page
 	</span>
 	{#each headers as header}
-		<a href={'#' + header.id} class={header.nodeName.toLowerCase()}>
+		<a href="#{header.id}" class={header.nodeName.toLowerCase()}>
 			{header.innerText}
 		</a>
 	{/each}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,9 @@ importers:
       prismjs:
         specifier: ^1.29.0
         version: 1.29.0
+      rehype-autolink-headings:
+        specifier: 5.1.0
+        version: 5.1.0
       remark-parse:
         specifier: 8.0.2
         version: 8.0.2
@@ -15467,8 +15470,16 @@ packages:
       web-namespaces: 1.1.4
     dev: false
 
+  /hast-util-has-property@1.0.4:
+    resolution: {integrity: sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==}
+    dev: false
+
   /hast-util-has-property@2.0.1:
     resolution: {integrity: sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==}
+    dev: false
+
+  /hast-util-heading-rank@1.0.1:
+    resolution: {integrity: sha512-P6Hq7RCky9syMevlrN90QWpqWDXCxwIVOfQR2rK6P4GpY4bqjKEuCzoWSRORZ7vz+VgRpLnXimh+mkwvVFjbyQ==}
     dev: false
 
   /hast-util-heading-rank@3.0.0:
@@ -21026,6 +21037,15 @@ packages:
     hasBin: true
     dependencies:
       jsesc: 0.5.0
+
+  /rehype-autolink-headings@5.1.0:
+    resolution: {integrity: sha512-ujU4/ALnWLJQubobQaMdC0h9nkzi7HlW9SOuCxZOkkJqhc/TrQ1cigIjMFQ2Tfc/es0KiFopKvwCUGw7Gw+mFw==}
+    dependencies:
+      extend: 3.0.2
+      hast-util-has-property: 1.0.4
+      hast-util-heading-rank: 1.0.1
+      unist-util-visit: 2.0.3
+    dev: false
 
   /rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,12 +697,12 @@ importers:
       rehype-autolink-headings:
         specifier: 5.1.0
         version: 5.1.0
+      rehype-slug:
+        specifier: 4.0.1
+        version: 4.0.1
       remark-parse:
         specifier: 8.0.2
         version: 8.0.2
-      remark-slug:
-        specifier: 6.1.0
-        version: 6.1.0
       svelte:
         specifier: 4.2.12
         version: 4.2.12
@@ -15547,6 +15547,10 @@ packages:
       zwitch: 1.0.5
     dev: false
 
+  /hast-util-to-string@1.0.4:
+    resolution: {integrity: sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==}
+    dev: false
+
   /hast-util-to-string@2.0.0:
     resolution: {integrity: sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==}
     dependencies:
@@ -18029,10 +18033,6 @@ packages:
       unist-util-generated: 1.1.6
       unist-util-position: 3.1.0
       unist-util-visit: 2.0.3
-    dev: false
-
-  /mdast-util-to-string@1.1.0:
-    resolution: {integrity: sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==}
     dev: false
 
   /mdast-util-to-string@2.0.0:
@@ -21076,6 +21076,16 @@ packages:
       parse5: 6.0.1
     dev: false
 
+  /rehype-slug@4.0.1:
+    resolution: {integrity: sha512-KIlJALf9WfHFF21icwTd2yI2IP+RQRweaxH9ChVGQwRYy36+hiomG4ZSe0yQRyCt+D/vE39LbAcOI/h4O4GPhA==}
+    dependencies:
+      github-slugger: 1.5.0
+      hast-util-has-property: 1.0.4
+      hast-util-heading-rank: 1.0.1
+      hast-util-to-string: 1.0.4
+      unist-util-visit: 2.0.3
+    dev: false
+
   /rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
     dependencies:
@@ -21161,14 +21171,6 @@ packages:
       unist-util-remove-position: 2.0.1
       vfile-location: 3.2.0
       xtend: 4.0.2
-    dev: false
-
-  /remark-slug@6.1.0:
-    resolution: {integrity: sha512-oGCxDF9deA8phWvxFuyr3oSJsdyUAxMFbA0mZ7Y1Sas+emILtO+e5WutF9564gDsEN4IXaQXm5pFo6MLH+YmwQ==}
-    dependencies:
-      github-slugger: 1.5.0
-      mdast-util-to-string: 1.1.0
-      unist-util-visit: 2.0.3
     dev: false
 
   /remark-squeeze-paragraphs@4.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,6 +697,9 @@ importers:
       remark-parse:
         specifier: 8.0.2
         version: 8.0.2
+      remark-slug:
+        specifier: 6.1.0
+        version: 6.1.0
       svelte:
         specifier: 4.2.12
         version: 4.2.12
@@ -18017,6 +18020,10 @@ packages:
       unist-util-visit: 2.0.3
     dev: false
 
+  /mdast-util-to-string@1.1.0:
+    resolution: {integrity: sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==}
+    dev: false
+
   /mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
     dev: false
@@ -19332,6 +19339,9 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(postcss@8.4.38)(typescript@5.4.2)
       '@parcel/core': 2.12.0
@@ -21133,6 +21143,14 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /remark-slug@6.1.0:
+    resolution: {integrity: sha512-oGCxDF9deA8phWvxFuyr3oSJsdyUAxMFbA0mZ7Y1Sas+emILtO+e5WutF9564gDsEN4IXaQXm5pFo6MLH+YmwQ==}
+    dependencies:
+      github-slugger: 1.5.0
+      mdast-util-to-string: 1.1.0
+      unist-util-visit: 2.0.3
+    dev: false
+
   /remark-squeeze-paragraphs@4.0.0:
     resolution: {integrity: sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==}
     dependencies:
@@ -21965,6 +21983,9 @@ packages:
   /sqlite3@5.1.6:
     resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       node-addon-api: 4.3.0

--- a/sites/example-project/src/pages/links-to-page-headers/+page.md
+++ b/sites/example-project/src/pages/links-to-page-headers/+page.md
@@ -1,0 +1,4 @@
+
+Doesn't currently work
+
+[Deep in the text](/text-and-metrics/text#more-nostra-non-parsque-talia-discussit)

--- a/sites/example-project/src/pages/links-to-page-headers/+page.md
+++ b/sites/example-project/src/pages/links-to-page-headers/+page.md
@@ -1,4 +1,0 @@
-
-Doesn't currently work
-
-[Deep in the text](/text-and-metrics/text#more-nostra-non-parsque-talia-discussit)


### PR DESCRIPTION
### Description

Addresses #1352

- Adds automatic anchor links to headings (H1-H6) in the preprocess stage.
- Puts H1-H3 in the TOC (rather than H1-H2)
- Links are based on slugified forms of the headers, but are made unique in the case of duplication by appending numbers
- Allows external links to navigate to the correct section of the page eg: `my-project.evidence.app/page-1/#heading-on-the-page`

### Issues
- [ ] Issue (svelte kit bug? https://github.com/sveltejs/kit/issues/11326) which prevents navigation between pages in Evidence from working correctly. **Open issue for this**
  - Appears to be client side nav only issue
  - This is not a regression as this did not work before.
- This uses outdated versions of rehype packages that still support CJS. I suspect the long term solution here is to convert this whole module to ESM, but then we need to rip out Prism (code highlighting) which is CJS only.

![CleanShot 2024-03-27 at 22 15 54](https://github.com/evidence-dev/evidence/assets/58074498/e82050b7-1416-4c3f-8306-7cda28af9cfe)



### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
