### PR TITLE
Fix grid printing & add landscape print support

### DIFF
--- a/.changeset/chilled-students-deliver.md
+++ b/.changeset/chilled-students-deliver.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/components': patch
+---
+
+Fix printing of charts in grid component

--- a/packages/lib/component-utilities/src/echartsCopy.js
+++ b/packages/lib/component-utilities/src/echartsCopy.js
@@ -4,9 +4,20 @@ import { evidenceThemeLight } from './echartsThemes';
 export default (node, option) => {
 	registerTheme('evidence-light', evidenceThemeLight);
 
-	const { config, ratio, echartsOptions, seriesOptions, seriesColors } = option;
+	const { config, ratio, echartsOptions, seriesOptions, seriesColors, isMap, extraHeight, width } =
+		option;
 
-	const chart = init(node, 'evidence-light', { renderer: 'canvas' });
+	let initOpts = { renderer: 'canvas' };
+	if (isMap) {
+		initOpts.height = width * 0.5 + extraHeight;
+		if (node && node.parentNode) {
+			// node.parentNode refers to the chart's container
+			node.style.height = initOpts.height + 'px';
+			node.parentNode.style.height = initOpts.height + 'px';
+		}
+	}
+
+	const chart = init(node, 'evidence-light', initOpts);
 	config.animation = false; // disable animation
 
 	chart.setOption(config);

--- a/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
+++ b/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
@@ -11,11 +11,11 @@
 
 	const colClasses = Object.freeze({
 		[1]: 'grid-cols-1',
-		[2]: 'grid-cols-1 md:grid-cols-2',
-		[3]: 'grid-cols-1 md:grid-cols-3',
-		[4]: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
-		[5]: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-5',
-		[6]: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-6'
+		[2]: 'grid-cols-1 sm:grid-cols-2',
+		[3]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3',
+		[4]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4',
+		[5]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5',
+		[6]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
 	});
 	const gapClasses = Object.freeze({
 		none: 'gap-0',
@@ -23,6 +23,7 @@
 		md: 'gap-4',
 		lg: 'gap-8'
 	});
+
 </script>
 
 <div class="grid {colClasses[cols]} {gapClasses[gapSize]}">

--- a/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
+++ b/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
@@ -3,11 +3,11 @@
 </script>
 
 <script>
-    import { setContext } from 'svelte';
-	
+	import { setContext } from 'svelte';
+
 	/** @type {1|2|3|4|5|6}*/
 	export let cols = 2;
-	
+
 	/** @type {"none"|"sm"|"md"|"lg"}*/
 	export let gapSize = 'md';
 
@@ -37,11 +37,10 @@
 	// Create a simple unique identifier based on a timestamp and a random suffix
 	let gridId = `grid-${Date.now()}-${Math.round(Math.random() * 1000)}`;
 
-	let gapWidth = gapWidths[gapSize]
+	let gapWidth = gapWidths[gapSize];
 
 	// Setting grid context - used by charts during print to set appropriate width:
 	setContext('gridConfig', { gridId, cols, gapWidth });
-
 </script>
 
 <div class="grid {colClasses[cols]} {gapClasses[gapSize]}">

--- a/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
+++ b/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
@@ -3,9 +3,11 @@
 </script>
 
 <script>
+    import { setContext } from 'svelte';
+	
 	/** @type {1|2|3|4|5|6}*/
 	export let cols = 2;
-
+	
 	/** @type {"none"|"sm"|"md"|"lg"}*/
 	export let gapSize = 'md';
 
@@ -17,12 +19,29 @@
 		[5]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5',
 		[6]: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
 	});
+
 	const gapClasses = Object.freeze({
 		none: 'gap-0',
 		sm: 'gap-2',
 		md: 'gap-4',
 		lg: 'gap-8'
 	});
+
+	const gapWidths = Object.freeze({
+		none: 0,
+		sm: 8,
+		md: 16,
+		lg: 32
+	});
+
+	// Create a simple unique identifier based on a timestamp and a random suffix
+	let gridId = `grid-${Date.now()}-${Math.round(Math.random() * 1000)}`;
+
+	let gapWidth = gapWidths[gapSize]
+
+	// Setting grid context - used by charts during print to set appropriate width:
+	setContext('gridConfig', { gridId, cols, gapWidth });
+
 </script>
 
 <div class="grid {colClasses[cols]} {gapClasses[gapSize]}">

--- a/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
+++ b/packages/ui/core-components/src/lib/atoms/grid/Grid.svelte
@@ -23,7 +23,6 @@
 		md: 'gap-4',
 		lg: 'gap-8'
 	});
-
 </script>
 
 <div class="grid {colClasses[cols]} {gapClasses[gapSize]}">

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -67,7 +67,7 @@
 	/>
 	<div
 		class={(fullWidth ? 'max-w-full ' : maxWidth ? '' : ' max-w-7xl ') +
-			'print:w-[650px] mx-auto print:md:px-0 print:px-0 px-6 sm:px-8 md:px-12 flex justify-start'}
+			'print:w-[650px] print:md:w-[841px] mx-auto print:md:px-0 print:px-0 px-6 sm:px-8 md:px-12 flex justify-start'}
 		style="max-width:{maxWidth}px;"
 	>
 		{#if !hideSidebar}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script>
+	import { getContext } from 'svelte';
 	import eChartsCopy from '@evidence-dev/component-utilities/echartsCopy';
 
 	export let config = undefined;
@@ -13,7 +14,27 @@
 	export let echartsOptions = undefined;
 	export let seriesOptions = undefined;
 	export let seriesColors = undefined;
+
+	// Grid Context:
+	let inGrid = false;
+    let gridCols;
+	let gridId;
+	let gapWidth;
+
+    // Attempt to get the grid context
+    const gridConfig = getContext('gridConfig');
+
+    if (gridConfig) {
+        inGrid = true;
+        ({ gridId, cols: gridCols, gapWidth } = gridConfig);
+    }
+
+	$: portraitCols = Math.min(Number(gridCols), 2);
+	$: portraitWidth = `${(650 / portraitCols) - (Number(gapWidth) * (portraitCols - 1))}px`;
+	$: landscapeCols = Math.min(Number(gridCols), 3);
+	$: landscapeWidth = `${(650 / landscapeCols) - (Number(gapWidth) * (landscapeCols - 1))}px`;
 </script>
+
 
 {#if copying}
 	<div
@@ -30,17 +51,46 @@
 		use:eChartsCopy={{ config, ratio: 2, echartsOptions, seriesOptions, seriesColors }}
 	/>
 {:else if printing}
-	<div
-		class="chart"
-		style="
-		height: {height};
-		width: {width};
-		margin-left: 0;
-		margin-top: 15px;
-		margin-bottom: 10px;
-		overflow: visible;
-		break-inside: avoid;
-	"
-		use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
-	/>
+	{#if inGrid}
+		<div
+			class="chart md:hidden"
+			style="
+			height: {height};
+			width: {portraitWidth};
+			margin-left: 0;
+			margin-top: 15px;
+			margin-bottom: 10px;
+			overflow: visible;
+			break-inside: avoid;
+		"
+			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+		/>
+		<div
+			class="chart hidden md:block"
+			style="
+			height: {height};
+			width: {landscapeWidth};
+			margin-left: 0;
+			margin-top: 15px;
+			margin-bottom: 10px;
+			overflow: visible;
+			break-inside: avoid;
+		"
+			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+		/>
+	{:else}
+		<div
+			class="chart"
+			style="
+			height: {height};
+			width: 650px;
+			margin-left: 0;
+			margin-top: 15px;
+			margin-bottom: 10px;
+			overflow: visible;
+			break-inside: avoid;
+		"
+			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+		/>
+	{/if}
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -17,24 +17,22 @@
 
 	// Grid Context:
 	let inGrid = false;
-    let gridCols;
-	let gridId;
+	let gridCols;
 	let gapWidth;
 
-    // Attempt to get the grid context
-    const gridConfig = getContext('gridConfig');
+	// Attempt to get the grid context
+	const gridConfig = getContext('gridConfig');
 
-    if (gridConfig) {
-        inGrid = true;
-        ({ gridId, cols: gridCols, gapWidth } = gridConfig);
-    }
+	if (gridConfig) {
+		inGrid = true;
+		({ cols: gridCols, gapWidth } = gridConfig);
+	}
 
 	$: portraitCols = Math.min(Number(gridCols), 2);
-	$: portraitWidth = `${(650 / portraitCols) - (Number(gapWidth) * (portraitCols - 1))}px`;
+	$: portraitWidth = `${650 / portraitCols - Number(gapWidth) * (portraitCols - 1)}px`;
 	$: landscapeCols = Math.min(Number(gridCols), 3);
-	$: landscapeWidth = `${(650 / landscapeCols) - (Number(gapWidth) * (landscapeCols - 1))}px`;
+	$: landscapeWidth = `${650 / landscapeCols - Number(gapWidth) * (landscapeCols - 1)}px`;
 </script>
-
 
 {#if copying}
 	<div

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -34,7 +34,7 @@
 		class="chart"
 		style="
 		height: {height};
-		width: 590px;
+		width: {width};
 		margin-left: 0;
 		margin-top: 15px;
 		margin-bottom: 10px;

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -29,9 +29,9 @@
 	}
 
 	$: portraitCols = Math.min(Number(gridCols), 2);
-	$: portraitWidth = `${650 / portraitCols - Number(gapWidth) * (portraitCols - 1)}px`;
+	$: portraitWidth = `${(650 - (Number(gapWidth) * (portraitCols - 1))) / portraitCols}px`;
 	$: landscapeCols = Math.min(Number(gridCols), 3);
-	$: landscapeWidth = `${650 / landscapeCols - Number(gapWidth) * (landscapeCols - 1)}px`;
+	$: landscapeWidth = `${(650 - (Number(gapWidth) * (landscapeCols - 1))) / landscapeCols}px`;
 </script>
 
 {#if copying}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -28,10 +28,12 @@
 		({ cols: gridCols, gapWidth } = gridConfig);
 	}
 
+	// Browsers have different widths, so we need to set print width at the smallest level we expect to see across browsers to
+	// avoid overlap. This is 650px for portrait and 841px for landscape (assuming an 8.5x11 page)
 	$: portraitCols = Math.min(Number(gridCols), 2);
-	$: portraitWidth = `${(650 - (Number(gapWidth) * (portraitCols - 1))) / portraitCols}px`;
+	$: portraitWidth = `${(650 - Number(gapWidth) * (portraitCols - 1)) / portraitCols}px`;
 	$: landscapeCols = Math.min(Number(gridCols), 3);
-	$: landscapeWidth = `${(650 - (Number(gapWidth) * (landscapeCols - 1))) / landscapeCols}px`;
+	$: landscapeWidth = `${(841 - Number(gapWidth) * (landscapeCols - 1)) / landscapeCols}px`;
 </script>
 
 {#if copying}
@@ -78,10 +80,24 @@
 		/>
 	{:else}
 		<div
-			class="chart"
+			class="chart md:hidden"
 			style="
 			height: {height};
 			width: 650px;
+			margin-left: 0;
+			margin-top: 15px;
+			margin-bottom: 10px;
+			overflow: visible;
+			break-inside: avoid;
+		"
+			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+		/>
+
+		<div
+			class="chart hidden md:block"
+			style="
+			height: {height};
+			width: 841px;
 			margin-left: 0;
 			margin-top: 15px;
 			margin-bottom: 10px;

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/EChartsCopyTarget.svelte
@@ -14,6 +14,8 @@
 	export let echartsOptions = undefined;
 	export let seriesOptions = undefined;
 	export let seriesColors = undefined;
+	export let isMap = false;
+	export let extraHeight = undefined;
 
 	// Grid Context:
 	let inGrid = false;
@@ -31,9 +33,9 @@
 	// Browsers have different widths, so we need to set print width at the smallest level we expect to see across browsers to
 	// avoid overlap. This is 650px for portrait and 841px for landscape (assuming an 8.5x11 page)
 	$: portraitCols = Math.min(Number(gridCols), 2);
-	$: portraitWidth = `${(650 - Number(gapWidth) * (portraitCols - 1)) / portraitCols}px`;
+	$: portraitWidth = (650 - Number(gapWidth) * (portraitCols - 1)) / portraitCols;
 	$: landscapeCols = Math.min(Number(gridCols), 3);
-	$: landscapeWidth = `${(841 - Number(gapWidth) * (landscapeCols - 1)) / landscapeCols}px`;
+	$: landscapeWidth = (841 - Number(gapWidth) * (landscapeCols - 1)) / landscapeCols;
 </script>
 
 {#if copying}
@@ -56,27 +58,45 @@
 			class="chart md:hidden"
 			style="
 			height: {height};
-			width: {portraitWidth};
+			width: {portraitWidth}px;
 			margin-left: 0;
 			margin-top: 15px;
 			margin-bottom: 10px;
 			overflow: visible;
 			break-inside: avoid;
 		"
-			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+			use:eChartsCopy={{
+				config,
+				ratio: 4,
+				echartsOptions,
+				seriesOptions,
+				seriesColors,
+				isMap,
+				extraHeight,
+				width: portraitWidth
+			}}
 		/>
 		<div
 			class="chart hidden md:block"
 			style="
 			height: {height};
-			width: {landscapeWidth};
+			width: {landscapeWidth}px;
 			margin-left: 0;
 			margin-top: 15px;
 			margin-bottom: 10px;
 			overflow: visible;
 			break-inside: avoid;
 		"
-			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+			use:eChartsCopy={{
+				config,
+				ratio: 4,
+				echartsOptions,
+				seriesOptions,
+				seriesColors,
+				isMap,
+				extraHeight,
+				width: landscapeWidth
+			}}
 		/>
 	{:else}
 		<div
@@ -90,7 +110,16 @@
 			overflow: visible;
 			break-inside: avoid;
 		"
-			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+			use:eChartsCopy={{
+				config,
+				ratio: 4,
+				echartsOptions,
+				seriesOptions,
+				seriesColors,
+				isMap,
+				extraHeight,
+				width: 650
+			}}
 		/>
 
 		<div
@@ -104,7 +133,16 @@
 			overflow: visible;
 			break-inside: avoid;
 		"
-			use:eChartsCopy={{ config, ratio: 4, echartsOptions, seriesOptions, seriesColors }}
+			use:eChartsCopy={{
+				config,
+				ratio: 4,
+				echartsOptions,
+				seriesOptions,
+				seriesColors,
+				isMap,
+				extraHeight,
+				width: 841
+			}}
 		/>
 	{/if}
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
@@ -81,6 +81,8 @@
 		{printing}
 		{echartsOptions}
 		{seriesOptions}
+		isMap
+		{extraHeight}
 	/>
 
 	<div class="chart-footer">

--- a/sites/example-project/src/pages/grid/+page.md
+++ b/sites/example-project/src/pages/grid/+page.md
@@ -11,7 +11,7 @@ queries:
 
 ## Bar
 
-<Grid cols=2 gapSize=lg>
+<Grid cols=2>
 <BarChart
 data={orders_by_category}
 x=category

--- a/sites/example-project/src/pages/grid/+page.md
+++ b/sites/example-project/src/pages/grid/+page.md
@@ -44,6 +44,9 @@ xAxisTitle=Category
 />
 </Grid>
 
+Lorem markdownum nivea redimitus. In rector in, flumine adimunt, cinctum, dolore
+pallada senectus dixit? Crematisregia fetus Io locus viscera redde lucida
+discede?
 Some text
 
 <BarChart
@@ -53,7 +56,9 @@ y=sales_usd0k
 xAxisTitle=Category
 />
 
-
+Lorem markdownum nivea redimitus. In rector in, flumine adimunt, cinctum, dolore
+pallada senectus dixit? Crematisregia fetus Io locus viscera redde lucida
+discede?
 <Grid cols=2 gapSize=lg>
 <BarChart
 data={orders_by_category}
@@ -69,3 +74,6 @@ xAxisTitle=Category
 />
   </Grid>
 
+Lorem markdownum nivea redimitus. In rector in, flumine adimunt, cinctum, dolore
+pallada senectus dixit? Crematisregia fetus Io locus viscera redde lucida
+discede?

--- a/sites/example-project/src/pages/grid/+page.md
+++ b/sites/example-project/src/pages/grid/+page.md
@@ -69,10 +69,3 @@ xAxisTitle=Category
 />
   </Grid>
 
-## Establish page width on print
-<div style="width: 400px" class="bg-red-400 mb-5">400</div>
-<div style="width: 500px" class="bg-red-400 mb-5">500</div>
-<div style="width: 600px" class="bg-red-400 mb-5">600</div>
-<div style="width: 640px" class="bg-red-400 mb-5">640</div>
-<div style="width: 700px" class="bg-red-400 mb-5">700</div>
-<div style="width: 800px" class="bg-red-400 mb-5">800</div>

--- a/sites/example-project/src/pages/grid/+page.md
+++ b/sites/example-project/src/pages/grid/+page.md
@@ -11,7 +11,7 @@ queries:
 
 ## Bar
 
-<Grid cols=2>
+<Grid cols=3>
 <BarChart
 data={orders_by_category}
 x=category
@@ -43,3 +43,36 @@ y=sales_usd0k
 xAxisTitle=Category
 />
 </Grid>
+
+Some text
+
+<BarChart
+data={orders_by_category}
+x=category
+y=sales_usd0k
+xAxisTitle=Category
+/>
+
+
+<Grid cols=2 gapSize=lg>
+<BarChart
+data={orders_by_category}
+x=category
+y=sales_usd0k
+xAxisTitle=Category
+/>
+<BarChart
+data={orders_by_category}
+x=category
+y=sales_usd0k
+xAxisTitle=Category
+/>
+  </Grid>
+
+## Establish page width on print
+<div style="width: 400px" class="bg-red-400 mb-5">400</div>
+<div style="width: 500px" class="bg-red-400 mb-5">500</div>
+<div style="width: 600px" class="bg-red-400 mb-5">600</div>
+<div style="width: 640px" class="bg-red-400 mb-5">640</div>
+<div style="width: 700px" class="bg-red-400 mb-5">700</div>
+<div style="width: 800px" class="bg-red-400 mb-5">800</div>


### PR DESCRIPTION
(Updated)

### Description
- Adds support for landscape printing
- Fixes printing for Grid components, which were previously incorrectly sized and overlapped each other

### Example
Same page shown printed in portrait and landscape

![CleanShot 2024-04-03 at 20 21 22@2x](https://github.com/evidence-dev/evidence/assets/12602440/299a217d-9a0b-493f-bd62-2f146f17912f)
![CleanShot 2024-04-03 at 20 21 13@2x](https://github.com/evidence-dev/evidence/assets/12602440/c75cf09f-0173-44cb-9fd4-e91638d62c4f)

### Introduced in this PR
- Sets a fixed print width for portrait pages at 650px and landscape pages at 841px (assumes 8.5x11 page).
- Sets maximum grid columns at 2 for portrait and 3 for landscape
- Adds context to the Grid component to share with child components - charts are now aware they are inside a Grid, the number of columns in the grid, and the gap width

### Known Issues
- Safari printing is affected by the width of the browser window when print is selected. This does not happen in other browsers
   - Recommendation is to print using another major browser, or adjust your browser window width until the print output meets your needs

### Implementation Notes
- When a chart is in a Grid, the print action creates 2 images for each chart and swaps it out based on the size of the page
   - This relies on hardcoded numbers for gap widths and page widths 

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)