### PR TITLE
Fix map image download

### DIFF
--- a/.changeset/twelve-bottles-wink.md
+++ b/.changeset/twelve-bottles-wink.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': patch
+'@evidence-dev/core-components': patch
+---
+
+Fix map image download

--- a/packages/lib/component-utilities/src/echartsCanvasDownload.js
+++ b/packages/lib/component-utilities/src/echartsCanvasDownload.js
@@ -41,7 +41,6 @@ export default (node, option) => {
 				...option.echartsOptions
 			});
 		}
-		console.log(chart.getOption());
 	};
 
 	// seriesOptions - loop through series and apply same changes to each

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
@@ -143,7 +143,7 @@
         margin-bottom: 15px;
         overflow: visible;
     "
-		use:echartsCanvasDownload={{ ...config, echartsOptions, seriesOptions, queryID }}
+		use:echartsCanvasDownload={{ config, ...$$restProps, echartsOptions, seriesOptions, queryID }}
 	/>
 {/if}
 


### PR DESCRIPTION
### Description
Fixes map image download button, which was broken after a recent change to the underlying functions use for chart downloads.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)