### PR TITLE
Allow json columns in postgres and duckdb

### DIFF
--- a/.changeset/pretty-jobs-wait.md
+++ b/.changeset/pretty-jobs-wait.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/postgres': patch
+'@evidence-dev/universal-sql': patch
+---
+
+stop blocking advanced usage of json with usql

--- a/packages/datasources/postgres/index.cjs
+++ b/packages/datasources/postgres/index.cjs
@@ -125,7 +125,7 @@ const runQuery = async (queryString, database, batchSize = 100000, closeBeforeRe
 		// to avoid loss of accuracy in very large numbers. This is something to keep an eye on,
 		// but for now, we are replacing the default parsing functions with the applicable
 		// JavaScript parsing function for each data type:
-		var types = require('pg').types;
+		var types = pg.types;
 
 		// Override bigint:
 		types.setTypeParser(20, function (val) {
@@ -141,6 +141,10 @@ const runQuery = async (queryString, database, batchSize = 100000, closeBeforeRe
 		types.setTypeParser(790, function (val) {
 			return parseFloat(val.replace(/[^0-9.]/g, ''));
 		});
+
+		// Override json / jsonb:
+		types.setTypeParser(types.builtins.JSON, String);
+		types.setTypeParser(types.builtins.JSONB, String);
 
 		var pool = new Pool(credentials);
 

--- a/packages/lib/universal-sql/src/calculateScore.js
+++ b/packages/lib/universal-sql/src/calculateScore.js
@@ -108,6 +108,7 @@ export function duckdbTypeToEvidenceType(column_type) {
 		case 'TIME':
 		case 'TIME WITH TIME ZONE': // return 'bigint';
 		case 'BLOB':
+		case 'JSON':
 		case 'BIT': // return 'Uint8Array';
 			return 'string';
 		default:


### PR DESCRIPTION
### Description

Closes https://github.com/evidence-dev/evidence/issues/1751 by advising node-pg to extract json/jsonb as string. Also removes universal-sql "warning" when obtaining `::json` results from duckdb (just treat as string in evidence, for now).

### Checklist

- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
