### PR TITLE
standardizeResult should also be applied to first batch(?)

### DIFF
--- a/.changeset/hungry-chefs-wave.md
+++ b/.changeset/hungry-chefs-wave.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/postgres': patch
+---
+
+apply `standardizeResult` to first batch of postgres results

--- a/packages/datasources/postgres/index.cjs
+++ b/packages/datasources/postgres/index.cjs
@@ -168,7 +168,7 @@ const runQuery = async (queryString, database, batchSize = 100000, closeBeforeRe
 			return {
 				rows: async function* () {
 					try {
-						yield firstBatch;
+						yield standardizeResult(firstBatch);
 						let results;
 						while ((results = await cursor.read(batchSize)) && results.length > 0)
 							yield standardizeResult(results);


### PR DESCRIPTION
### Description

Closes https://github.com/evidence-dev/evidence/issues/1750.  
This PR just re-adds `standardizeResult` to the first batch. I have not extensively tested this in all combinations; AFAIU from the commits mentioned in #1750 this seems to be the right thing to do, though...

### Checklist

- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)