### PR TITLE
Adjust delta neutral symbol

### DIFF
--- a/.changeset/new-cows-speak.md
+++ b/.changeset/new-cows-speak.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adjust delta neutral symbol

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
@@ -103,7 +103,7 @@
 				} else {
 					selected_format = columnSummary[0].format;
 				}
-			} else if (value) {
+			} else if (value !== undefined) {
 				if (isNaN(value)) {
 					throw Error('value must be a number (value=' + value + ')');
 				} else {
@@ -145,9 +145,15 @@
 		<span style:text-align={align ?? 'right'}>
 			{#if symbolPosition === 'right'}
 				{#if showValue}
-					<span>
-						{formatValue(selected_value, selected_format, columnUnitSummary)}
-					</span>
+					{#if selected_value === null}
+						<span class="font-[system-ui]">
+							–
+						</span>
+					{:else}
+						<span>
+							{formatValue(selected_value, selected_format, columnUnitSummary)}
+						</span>
+					{/if}
 				{/if}
 				{#if showSymbol}
 					<span class="font-[system-ui]"
@@ -169,9 +175,15 @@
 					>
 				{/if}
 				{#if showValue}
-					<span>
-						{formatValue(selected_value, selected_format, columnUnitSummary)}
-					</span>
+					{#if selected_value === null}
+						<span class="font-[system-ui]">
+							–
+						</span>
+					{:else}
+						<span> 
+							{formatValue(selected_value, selected_format, columnUnitSummary)}
+						</span>
+					{/if}
 				{/if}
 			{/if}
 			{#if text}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
@@ -165,7 +165,7 @@
 							? '&#9650;'
 							: valueStatus === 'negative'
 								? '&#9660;'
-								: '–'}</span
+								: '—'}</span
 					>
 				{/if}
 				{#if showValue}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Delta.svelte
@@ -146,9 +146,7 @@
 			{#if symbolPosition === 'right'}
 				{#if showValue}
 					{#if selected_value === null}
-						<span class="font-[system-ui]">
-							–
-						</span>
+						<span class="font-[system-ui]"> – </span>
 					{:else}
 						<span>
 							{formatValue(selected_value, selected_format, columnUnitSummary)}
@@ -176,11 +174,9 @@
 				{/if}
 				{#if showValue}
 					{#if selected_value === null}
-						<span class="font-[system-ui]">
-							–
-						</span>
+						<span class="font-[system-ui]"> – </span>
 					{:else}
-						<span> 
+						<span>
 							{formatValue(selected_value, selected_format, columnUnitSummary)}
 						</span>
 					{/if}

--- a/sites/example-project/src/pages/text-and-metrics/big-value/+page.md
+++ b/sites/example-project/src/pages/text-and-metrics/big-value/+page.md
@@ -44,6 +44,20 @@ sparklineYScale=true
 connectGroup=bigvalues
 /> 
 
+<BigValue data = {owc} 
+value=aov_usd2
+title="AOV ($)"
+sparkline=month
+comparison=aov_change_pct0
+comparisonTitle="vs. Last Month"
+sparklineColor=navy
+sparklineDateFmt=mmm
+sparklineYScale=true
+connectGroup=bigvalues
+neutralMin=-0.07
+neutralMax=0.07
+/> 
+
 Lorem markdownum nivea redimitus. In rector in, flumine adimunt, cinctum, dolore
 pallada senectus dixit? Crematisregia fetus Io locus viscera redde lucida
 discede?

--- a/sites/example-project/src/pages/text-and-metrics/delta/+page.md
+++ b/sites/example-project/src/pages/text-and-metrics/delta/+page.md
@@ -3,9 +3,9 @@
 ```sql sp
 select 100 as sales, '2020-01-01'::date as date
 union all
-select 120 as sales, '2020-02-01'::date as date
+select null as sales, '2020-02-01'::date as date
 union all
-select 140 as sales, '2020-03-01'::date as date
+select 0 as sales, '2020-03-01'::date as date
 union all
 select 170 as sales, '2020-04-01'::date as date
 union all
@@ -13,13 +13,19 @@ select 190 as sales, '2020-05-01'::date as date
 ```
 
 ### Positive
-<Delta value=0.366 fmt=pct1 text="vs. prior year"/> 
+<Delta value=36.6 fmt=pct1 text="vs. prior year"/> 
 
 ### Negative
 <Delta value=-0.366 fmt=pct1/> 
 
-### Neutral
+### Neutral (when neutralMin and neutralMax set)
 <Delta value=0.366 neutralMax=0.4 fmt=pct1/> 
+
+### Zero
+<Delta value=0 fmt=pct1/> 
+
+### Null
+<Delta value={null} fmt=pct1/> 
 
 
 ## Chip
@@ -29,8 +35,14 @@ select 190 as sales, '2020-05-01'::date as date
 ### Negative
 <Delta value=-0.366 fmt=pct1 chip=true/> 
 
-### Neutral
+### Neutral (when neutralMin and neutralMax set)
 <Delta value=0.366 neutralMax=0.4 fmt=pct1 chip=true/> 
+
+### Zero
+<Delta value=0 fmt=pct1 chip=true /> 
+
+### Null
+<Delta value={null} fmt=pct1 chip=true /> 
 
 
 ## Symbol Position
@@ -39,8 +51,17 @@ select 190 as sales, '2020-05-01'::date as date
 <Delta value=0.366 fmt=pct1 symbolPosition=left  text="vs. prior year"/>  
 <LineBreak lines=2/> 
 <Delta value=-0.366 fmt=pct1 chip=true symbolPosition=left  text="vs. prior year"s/> 
+<LineBreak lines=2/> 
+<Delta value={null} fmt=pct1 chip=true symbolPosition=left  text="vs. prior year"s/> 
 
+
+## In DataTable
+
+<DataTable data={sp}>
+    <Column id=sales contentType=delta/>
+</DataTable>
 
 <LineBreak lines=2/>
 
+## In Text
 Verba et celer purpura utraque parvas, indicat quaeritis adhaesi negate. Exsangue sibique Minos Echidnaeae miseranda infelix nunc dapes iunctisque praetereunt abluere moenia ferunt aere innuba.Sales in the last year: <Delta data={sp} column=sales fmt=usd/> <Delta data={sp} column=sales fmt=usd chip=true/> and some text after. verba et celer purpura utraque parvas, indicat quaeritis adhaesi negate. Exsangue sibique Minos Echidnaeae <Delta data={sp} column=sales fmt=usd chip=true downIsGood=true/> miseranda infelix nunc dapes iunctisque praetereunt abluere moenia ferunt aere innuba.


### PR DESCRIPTION
### Description
Changes delta neutral symbol from en dash to em dash when `symbolPosition=left`

This helps with BigValue values where positive values could be confused for negative values.

A better long-term solution is needed for this, but putting this in as a short term fix.

#### Before
![CleanShot 2024-03-29 at 14 12 56@2x](https://github.com/evidence-dev/evidence/assets/12602440/5ea49fb4-8d8d-4f34-87ec-eedc562aa4ae)

#### After
![CleanShot 2024-03-29 at 14 16 41@2x](https://github.com/evidence-dev/evidence/assets/12602440/f8131be6-43b6-421a-bb68-8f45d9386d51)

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)