### PR TITLE
Use pull_request_target for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   Tests-sources:


### PR DESCRIPTION
### Description

- Contributor tests are failing as they do not have access to secrets in their forks. 
- `pull_request_target` allows tests to run in the context of the main repo, and has access to secrets, after approval by a maintainer for tests to run.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
