### PR TITLE
Fix windows print scrollbar

### DIFF
--- a/.changeset/quick-ducks-drive.md
+++ b/.changeset/quick-ducks-drive.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Fix scrollbar appearing during Windows print

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -293,13 +293,11 @@
 		print-color-adjust: exact;
 	}
 
-	h1::after,
-	h2::after,
-	h3::after {
-		content: '';
-		display: block;
-		height: 100px;
-		margin-bottom: -100px;
+	h1,
+	h2,
+	h3,
+	h4 {
+		break-after: avoid-page;
 	}
 
 	article {


### PR DESCRIPTION
### Description
Scrollbar was appearing in print/PDF for some users on Windows. This changes a CSS setting for headers, which was causing unnecessary whitespace, leading to the scrollbar.

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
