### PR TITLE
run inline query updater after HMR

### DIFF
--- a/packages/lib/preprocess/src/process-queries.cjs
+++ b/packages/lib/preprocess/src/process-queries.cjs
@@ -195,6 +195,7 @@ const createDefaultProps = function (filename, componentDevelopmentMode, duckdbQ
 				$: if (dev) {
 					if (_${id}_hmr_once) {
 						data;
+						__has_hmr_run;
 						_${id}_debounced_updater();
 					} else {
 						_${id}_hmr_once = true;


### PR DESCRIPTION
### Description

Adds a svelte dependency, otherwise the updater would not run after HMR.

Closes https://github.com/evidence-dev/evidence/issues/1762

### Checklist

- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
