### PR TITLE
HTML in DataTable

### DIFF
--- a/.changeset/smart-dryers-hunt.md
+++ b/.changeset/smart-dryers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adds support for HTML contentType in DataTables

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -161,6 +161,8 @@
 							neutralMax={column.neutralMax}
 							chip={column.chip}
 						/>
+					{:else if column.contentType === 'html' && row[column.id] !== undefined}
+						{@html row[column.id]}
 					{:else}
 						{formatValue(
 							row[column.id],


### PR DESCRIPTION
### Description

Adds support for HTML in table rows, so you can return HTML from queries and render it in your tables

````
```sql html_in_table
select '<b>Bold</b> text' as "HTML in Table" union all
select '<i>Italic</i> text' as "HTML in Table" union all
select '<a href="https://evidence.dev">Link</a>' as "HTML in Table" union all
select '<img src="/img/how-it-works.png" width="200px"/>' as "HTML in Table"
```
````

![CleanShot 2024-04-10 at 22 06 55](https://github.com/evidence-dev/evidence/assets/58074498/05318e3c-0887-4690-a824-85f481cd20b7)


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
