### PR TITLE
maintain correct sizing for bold, italic, strikethrough, code spans

### DIFF
--- a/.changeset/smooth-boats-tell.md
+++ b/.changeset/smooth-boats-tell.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fixes bold, italic, strikethrough and code span sizing issues in markdown

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -172,7 +172,7 @@
 	}
 
 	code.markdown {
-		@apply font-mono text-gray-800 text-sm bg-gray-50 border rounded px-1 select-all py-0.5;
+		@apply font-mono text-gray-800 text-[0.875em] bg-gray-50 border rounded px-1 select-all py-0.5;
 	}
 
 	form code {
@@ -185,6 +185,18 @@
 
 	blockquote.markdown * {
 		@apply text-gray-500;
+	}
+	/* Ensure size and color are maintained for bold, italic, strikethrough */
+	strong.markdown {
+		@apply text-[1em] text-inherit;
+	}
+
+	em.markdown {
+		@apply text-[1em] text-inherit;
+	}
+
+	del.markdown {
+		@apply text-[1em] text-inherit;
 	}
 
 	table.markdown {

--- a/sites/example-project/src/pages/text-and-metrics/markdown/+page.md
+++ b/sites/example-project/src/pages/text-and-metrics/markdown/+page.md
@@ -15,6 +15,14 @@ title: Markdown
 
 ###### Heading Level 6
 
+# ~~Heading Level 1 with Strikethrough~~
+
+# Heading Level 1 with _Italics_
+
+# Heading Level 1 with **Bold**
+
+# Heading Level 1 with `code`
+
 # Link Headers
 
 # [Link h1](/)
@@ -67,7 +75,7 @@ _Italic_
 ~~Strikethrough~~  
 Text<sup>superscript</sup>  
 Text<sub>subscript</sub>  
-<u>Underline</u>
+# This is <u>Underline</u> and **Bold**
 
 ## Highlighting
 
@@ -140,7 +148,7 @@ Link to [Google](https://google.com)
 
 | Column One | Column Two | Column Three |
 | :--------: | :--------: | :----------: |
-|     A      |     B      |      C       |
+|     A `with code`      |     B      |      C       |
 |     1      |     2      |      3       |
 |     D      |     E      |      F       |
 |     4      |     5      |      6       |


### PR DESCRIPTION
### Description

Fixes #1330

After
![CleanShot 2024-04-10 at 23 25 53@2x](https://github.com/evidence-dev/evidence/assets/58074498/e35d153e-3249-48ee-a767-0d4527265f95)


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
