### PR TITLE
 fix: support 0 as a `sidebar_position`

### DIFF
--- a/.changeset/beige-bobcats-applaud.md
+++ b/.changeset/beige-bobcats-applaud.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+support 0 as a sidebar_position

--- a/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
@@ -17,14 +17,14 @@
 	function sortChildrenBySidebarPosition(node) {
 		if (node.children) {
 			node.children = node.children.sort((a, b) => {
-				if (a.frontMatter?.sidebar_position && b.frontMatter?.sidebar_position) {
+				if (!isNaN(a.frontMatter?.sidebar_position) && !isNaN(b.frontMatter?.sidebar_position)) {
 					return (
 						a.frontMatter.sidebar_position - b.frontMatter.sidebar_position ||
 						a.label.localeCompare(b.label)
 					);
-				} else if (a.frontMatter?.sidebar_position) {
+				} else if (!isNaN(a.frontMatter?.sidebar_position)) {
 					return -1;
-				} else if (b.frontMatter?.sidebar_position) {
+				} else if (!isNaN(b.frontMatter?.sidebar_position)) {
 					return 1;
 				} else {
 					return a.label.localeCompare(b.label);

--- a/sites/docs/pages/components/all-components.md
+++ b/sites/docs/pages/components/all-components.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: -1
+sidebar_position: 0
 title: All Components
 hide_title: false
 hide_table_of_contents: false


### PR DESCRIPTION
### Description
closes #1797 

Changes:
- In the `if` check - `if (a.frontMatter?.sidebar_position && b.frontMatter?.sidebar_position)`, we need to check whether the `sidebar_position` value exists. However 0 being a falsy value, if `sidebar_position` is 0 then also the check evaluates to false. This is fixed by using `isNaN` function.
- Updated `sidebar_position` for `All Components` in docs from -1 to 0, where -1 was used as a workaround.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
