### PR TITLE
downgrade databricks dep to 1.7.1 to remove lz4 dep

### DIFF
--- a/.changeset/forty-doors-leave.md
+++ b/.changeset/forty-doors-leave.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/databricks': patch
+---
+
+downgrade databricks connector to 1.7.1 to remove lz4 dep causing install issues

--- a/packages/datasources/databricks/package.json
+++ b/packages/datasources/databricks/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"@evidence-dev/db-commons": "workspace:*",
-		"@databricks/sql": "^1.5.0"
+		"@databricks/sql": "1.7.1"
 	},
 	"devDependencies": {
 		"dotenv": "^16.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
   packages/datasources/databricks:
     dependencies:
       '@databricks/sql':
-        specifier: ^1.5.0
-        version: 1.8.2
+        specifier: 1.7.1
+        version: 1.7.1
       '@evidence-dev/db-commons':
         specifier: workspace:*
         version: link:../../lib/db-commons
@@ -4222,13 +4222,12 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@databricks/sql@1.8.2:
-    resolution: {integrity: sha512-Ry8VUuzkALAoanzVLswbXZCxwmL7I0W3WPMclTCzvh7emVnGqEcpI8vheKddoiumJQOAVgyCKqoQF63nQnXZtg==}
+  /@databricks/sql@1.7.1:
+    resolution: {integrity: sha512-waxZUfB3HEFx+jEzzIbavPfieF2C5kZzzH0isAS10GUiTA5l43bSamIcCMez1w/N0zgEe7jdsjJtV06np6dfyA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       apache-arrow: 13.0.0
       commander: 9.5.0
-      lz4: 0.6.5
       node-fetch: 2.7.0
       node-int64: 0.4.0
       open: 8.4.2
@@ -9946,6 +9945,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
 
   /buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -10657,10 +10657,6 @@ packages:
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
     dev: true
-
-  /cuint@0.2.2:
-    resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
-    dev: false
 
   /cytoscape-cose-bilkent@4.1.0(cytoscape@3.28.1):
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -15039,17 +15035,6 @@ packages:
     hasBin: true
     dev: true
 
-  /lz4@0.6.5:
-    resolution: {integrity: sha512-KSZcJU49QZOlJSItaeIU3p8WoAvkTmD9fJqeahQXNu1iQ/kR0/mQLdbrK8JY9MY8f6AhJoMrihp1nu1xDbscSQ==}
-    engines: {node: '>= 0.10'}
-    requiresBuild: true
-    dependencies:
-      buffer: 5.7.1
-      cuint: 0.2.2
-      nan: 2.19.0
-      xxhashjs: 0.2.2
-    dev: false
-
   /magic-string@0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
@@ -15751,10 +15736,6 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       lru-cache: 7.18.3
-    dev: false
-
-  /nan@2.19.0:
-    resolution: {integrity: sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==}
     dev: false
 
   /nanoid@3.3.7:
@@ -19899,12 +19880,6 @@ packages:
   /xxhash-wasm@0.4.2:
     resolution: {integrity: sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==}
     dev: true
-
-  /xxhashjs@0.2.2:
-    resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}
-    dependencies:
-      cuint: 0.2.2
-    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}


### PR DESCRIPTION
### Description

Fixes: https://github.com/evidence-dev/evidence/issues/1885 by temporarily downgrading

Maintainer suggested they may be able to release a version with the lz4 dep as optional in the future, which would allow us to get back to latest

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
