### PR TITLE
fix: prevent name collisions

### DIFF
--- a/.changeset/lovely-hats-bow.md
+++ b/.changeset/lovely-hats-bow.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Renamed all instances of `container` class to prevent collisions with tailwind container

--- a/packages/ui/core-components/src/lib/unsorted/ui/Deployment/DeploySettingsPanel.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Deployment/DeploySettingsPanel.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <form id="deploy">
-	<div class="container">
+	<div class="deploy-settings-box">
 		<div class="panel">
 			<h2>Deployment</h2>
 			<p>
@@ -101,7 +101,7 @@
 	form {
 		scroll-margin-top: 3.5rem; /* offset for sticky header */
 	}
-	.container {
+	.deploy-settings-box {
 		margin-top: 2em;
 		border-top: 1px solid var(--grey-200);
 		border-left: 1px solid var(--grey-200);

--- a/packages/ui/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Formatting/FormattingSettingsPanel.svelte
@@ -23,7 +23,7 @@ from table`;
 </script>
 
 <form id="formatting">
-	<div class="container">
+	<div class="formatting-settings-box">
 		<div class="panel">
 			<h2>Value Formatting</h2>
 			<p>
@@ -105,7 +105,7 @@ from table`;
 		scroll-margin-top: 3.5rem; /* offset for sticky header */
 	}
 
-	.container {
+	.formatting-settings-box {
 		margin-top: 2em;
 		border-top: 1px solid var(--grey-200);
 		border-left: 1px solid var(--grey-200);

--- a/packages/ui/core-components/src/lib/unsorted/ui/QueryViewer.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/QueryViewer.svelte
@@ -60,7 +60,7 @@
 <div class="over-container" in:blur|local>
 	{#if $showQueries}
 		<!-- Title -->
-		<div class="container" transition:slide|local>
+		<div class="scrollbox" transition:slide|local>
 			<div class="container-a">
 				<button type="button" aria-label="show-sql" on:click={toggleSQL} class="title">
 					<ChevronToggle toggled={$showSQL} />
@@ -253,7 +253,7 @@
 		border-top-right-radius: 6px;
 	}
 
-	.container {
+	.scrollbox {
 		@apply my-3;
 		display: flex;
 		flex-direction: column;
@@ -270,7 +270,7 @@
 	/* container-a avoids whitespace appearing in the slide transition */
 
 	@media print {
-		.container {
+		.scrollbox {
 			break-inside: avoid;
 		}
 	}

--- a/packages/ui/core-components/src/lib/unsorted/ui/QueryViewerSupport/QueryDataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/QueryViewerSupport/QueryDataTable.svelte
@@ -51,7 +51,7 @@
 </script>
 
 <div class="results-pane py-1" transition:slide|local>
-	<div class="container">
+	<div class="scrollbox">
 		<table in:blur>
 			<thead>
 				<tr>
@@ -232,7 +232,7 @@
 		--scrollbar-minlength: 1.5rem; /* Minimum length of scrollbar thumb (width of horizontal, height of vertical) */
 	}
 
-	.container {
+	.scrollbox {
 		width: 100%;
 		overflow-x: auto;
 		border-bottom: 1px solid var(--grey-200);
@@ -241,26 +241,26 @@
 		background-color: white;
 	}
 
-	.container::-webkit-scrollbar {
+	.scrollbox::-webkit-scrollbar {
 		height: var(--scrollbar-size);
 		width: var(--scrollbar-size);
 	}
-	.container::-webkit-scrollbar-track {
+	.scrollbox::-webkit-scrollbar-track {
 		background-color: var(--scrollbar-track-color);
 	}
-	.container::-webkit-scrollbar-thumb {
+	.scrollbox::-webkit-scrollbar-thumb {
 		background-color: var(--scrollbar-color);
 		border-radius: 7px;
 		background-clip: padding-box;
 	}
-	.container::-webkit-scrollbar-thumb:hover {
+	.scrollbox::-webkit-scrollbar-thumb:hover {
 		background-color: var(--scrollbar-active-color);
 	}
-	.container::-webkit-scrollbar-thumb:vertical {
+	.scrollbox::-webkit-scrollbar-thumb:vertical {
 		min-height: var(--scrollbar-minlength);
 		border: 3px solid transparent;
 	}
-	.container::-webkit-scrollbar-thumb:horizontal {
+	.scrollbox::-webkit-scrollbar-thumb:horizontal {
 		min-width: var(--scrollbar-minlength);
 		border: 3px solid transparent;
 	}

--- a/packages/ui/core-components/src/lib/unsorted/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/TelemetryOptOut/TelemetrySettingsPanel.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <form id="telemetry">
-	<div class="container">
+	<div class="telemetry-settings-box">
 		<div class="panel">
 			<h2>Telemetry</h2>
 			<p>
@@ -88,7 +88,7 @@
 	form {
 		scroll-margin-top: 3.5rem; /* offset for sticky header */
 	}
-	.container {
+	.telemetry-settings-box {
 		margin-top: 2em;
 		border-top: 1px solid var(--grey-200);
 		border-left: 1px solid var(--grey-200);

--- a/packages/ui/core-components/src/lib/unsorted/ui/VersionControl/VersionControlPanel.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/VersionControl/VersionControlPanel.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <form id="version-control">
-	<div class="container">
+	<div class="version-control-box">
 		<div class="panel">
 			<h2>Version Control</h2>
 			Use version control to keep track of changes to your project. A published git repo is needed if
@@ -89,7 +89,7 @@
 		@apply font-semibold text-lg pt-3 pb-2;
 	}
 
-	.container {
+	.version-control-box {
 		margin-top: 2em;
 		border-top: 1px solid var(--grey-200);
 		border-left: 1px solid var(--grey-200);

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -467,7 +467,7 @@
 			<SearchBar bind:value={searchValue} searchFunction={runSearch} />
 		{/if}
 
-		<div class="container" style:background-color={backgroundColor}>
+		<div class="scrollbox" style:background-color={backgroundColor}>
 			<table>
 				<TableHeader
 					{rowNumbers}
@@ -703,10 +703,9 @@
 <style>
 	.table-container {
 		font-size: 9.5pt;
-		width: 98%;
 	}
 
-	.container {
+	.scrollbox {
 		width: 100%;
 		overflow-x: auto;
 		/* border-bottom: 1px solid var(--grey-200);    */
@@ -722,31 +721,31 @@
 		--scrollbar-minlength: 1.5rem; /* Minimum length of scrollbar thumb (width of horizontal, height of vertical) */
 	}
 
-	.container::-webkit-scrollbar {
+	.scrollbox::-webkit-scrollbar {
 		height: var(--scrollbar-size);
 		width: var(--scrollbar-size);
 	}
 
-	.container::-webkit-scrollbar-track {
+	.scrollbox::-webkit-scrollbar-track {
 		background-color: var(--scrollbar-track-color);
 	}
 
-	.container::-webkit-scrollbar-thumb {
+	.scrollbox::-webkit-scrollbar-thumb {
 		background-color: var(--scrollbar-color);
 		border-radius: 7px;
 		background-clip: padding-box;
 	}
 
-	.container::-webkit-scrollbar-thumb:hover {
+	.scrollbox::-webkit-scrollbar-thumb:hover {
 		background-color: var(--scrollbar-active-color);
 	}
 
-	.container::-webkit-scrollbar-thumb:vertical {
+	.scrollbox::-webkit-scrollbar-thumb:vertical {
 		min-height: var(--scrollbar-minlength);
 		border: 3px solid transparent;
 	}
 
-	.container::-webkit-scrollbar-thumb:horizontal {
+	.scrollbox::-webkit-scrollbar-thumb:horizontal {
 		min-width: var(--scrollbar-minlength);
 		border: 3px solid transparent;
 	}

--- a/packages/ui/core-components/src/lib/unsorted/viz/venn/VennDiagram.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/venn/VennDiagram.svelte
@@ -65,7 +65,7 @@
 		]);
 </script>
 
-<div class="container">
+<div class="venndiagram-container">
 	<svg class="main">
 		<!-- Circles -->
 		{#each circles as circle}
@@ -149,7 +149,7 @@
 		/* fill: #fb923c; */
 	}
 
-	div.container {
+	div.venndiagram-container {
 		display: flex;
 		margin: 1.5em 0;
 		align-items: center;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,7 @@ importers:
         version: link:../../lib/db-commons
       mysql2:
         specifier: ^3.8.0
-        version: 3.9.5
+        version: 3.9.6
     devDependencies:
       dotenv:
         specifier: ^16.0.1
@@ -839,7 +839,7 @@ importers:
         version: 1.0.0
       pkg-types:
         specifier: ^1.0.3
-        version: 1.0.3
+        version: 1.1.0
       prettier:
         specifier: ^3.1.1
         version: 3.2.5
@@ -5996,7 +5996,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.12.0
-      '@swc/core': 1.4.15
+      '@swc/core': 1.4.16
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
@@ -6017,7 +6017,7 @@ packages:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0)
       '@parcel/utils': 2.12.0
       '@parcel/workers': 2.12.0(@parcel/core@2.12.0)
-      '@swc/core': 1.4.15
+      '@swc/core': 1.4.16
       semver: 7.6.0
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -8300,8 +8300,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@swc/core-darwin-arm64@1.4.15:
-    resolution: {integrity: sha512-m1D89yN82QTp8AcSm3p9YgcfbdOqc9WmhvnMwoS0lUs6RIIFekI2tEboc9Rp9gre/1lkgzPYI+KGge1BaQzScA==}
+  /@swc/core-darwin-arm64@1.4.16:
+    resolution: {integrity: sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -8309,8 +8309,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64@1.4.15:
-    resolution: {integrity: sha512-aQBTfKrXIKiBrZY5MtqMRtbXTYCnMxUir4qy0me0+sIWTVxQ7znBxrwQsXsbPHIIZ+pohcLCg0HKfybev0NqXA==}
+  /@swc/core-darwin-x64@1.4.16:
+    resolution: {integrity: sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -8318,8 +8318,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.4.15:
-    resolution: {integrity: sha512-EZhdJBjzct/0UiF3sPD1w+LbLFJOsvym4b3njyl7jnP+py5rz2WlIJDxVKcS+b1RKEebLU7OsnYXzuXFjq0dwA==}
+  /@swc/core-linux-arm-gnueabihf@1.4.16:
+    resolution: {integrity: sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -8327,8 +8327,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.4.15:
-    resolution: {integrity: sha512-plKc41q8PgOm5rm3gEmPs+0skuddW0CrXPsERFzyaJ8gKTEwOVtg3sa3folXzsIgw0ODr61xzqYnh7zgJllMGg==}
+  /@swc/core-linux-arm64-gnu@1.4.16:
+    resolution: {integrity: sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -8336,8 +8336,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.4.15:
-    resolution: {integrity: sha512-4Gj0z1bo1rI3pKanqv5grH4EZ/pJRGZXG9LnkZ9FBrg4LUgptEumomca1UYFgBifHi3hirJsOQacuKFpw2NCEg==}
+  /@swc/core-linux-arm64-musl@1.4.16:
+    resolution: {integrity: sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -8345,8 +8345,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.4.15:
-    resolution: {integrity: sha512-7nZrrYvHpklwrQboHGXMvpefOP4m5Jf46ncQSztprZ0Ah2Z8vZhehuEiUo9xOB3jl5Vdhw2KP4uAhzzppES+PA==}
+  /@swc/core-linux-x64-gnu@1.4.16:
+    resolution: {integrity: sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -8354,8 +8354,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl@1.4.15:
-    resolution: {integrity: sha512-LJYSnttiR5vhnn7D92HAEgy/D4Jc5MDpLurF4MHyhN/9wlhQPfa5/2fdF3ogtZTzr1cckxyipYdyuzfVF+WISg==}
+  /@swc/core-linux-x64-musl@1.4.16:
+    resolution: {integrity: sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -8363,8 +8363,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.4.15:
-    resolution: {integrity: sha512-q+u2toNPU9OQonSUI0pB6BIGkNsIrvok6AbUJYpmvZqawmNrngSs9quS2WDe58vfIe9r0lVenweY6WIRlGMFTg==}
+  /@swc/core-win32-arm64-msvc@1.4.16:
+    resolution: {integrity: sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -8372,8 +8372,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.4.15:
-    resolution: {integrity: sha512-eEtU3yQXuBJO5tiokLz0sf0lABVNqR/l6p071v1ltDJGUD4vSer5kHOmm0Hn1zWB43EGda6b17Bb2DEHZ1DpKA==}
+  /@swc/core-win32-ia32-msvc@1.4.16:
+    resolution: {integrity: sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -8381,8 +8381,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.4.15:
-    resolution: {integrity: sha512-9CWhKyrDgrotsciAYFSsDIYgi/4LRbvJusyAtA3RBeXar1eNouFPwdlwj8zTqtJsOteZAUpbZSret0Z59cTqCQ==}
+  /@swc/core-win32-x64-msvc@1.4.16:
+    resolution: {integrity: sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -8390,8 +8390,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.4.15:
-    resolution: {integrity: sha512-7Wl4d4CCJ8xnhArfomHe+x5C0roewn0mRedtiZlTsV/9t61z2who18E9bSZI/IRjS00FGJCAlbbd7aWKLpyieg==}
+  /@swc/core@1.4.16:
+    resolution: {integrity: sha512-Xaf+UBvW6JNuV131uvSNyMXHn+bh6LyKN4tbv7tOUFQpXyz/t9YWRE04emtlUW9Y0qrm/GKFCbY8n3z6BpZbTA==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -8403,16 +8403,16 @@ packages:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.6
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.4.15
-      '@swc/core-darwin-x64': 1.4.15
-      '@swc/core-linux-arm-gnueabihf': 1.4.15
-      '@swc/core-linux-arm64-gnu': 1.4.15
-      '@swc/core-linux-arm64-musl': 1.4.15
-      '@swc/core-linux-x64-gnu': 1.4.15
-      '@swc/core-linux-x64-musl': 1.4.15
-      '@swc/core-win32-arm64-msvc': 1.4.15
-      '@swc/core-win32-ia32-msvc': 1.4.15
-      '@swc/core-win32-x64-msvc': 1.4.15
+      '@swc/core-darwin-arm64': 1.4.16
+      '@swc/core-darwin-x64': 1.4.16
+      '@swc/core-linux-arm-gnueabihf': 1.4.16
+      '@swc/core-linux-arm64-gnu': 1.4.16
+      '@swc/core-linux-arm64-musl': 1.4.16
+      '@swc/core-linux-x64-gnu': 1.4.16
+      '@swc/core-linux-x64-musl': 1.4.16
+      '@swc/core-win32-arm64-msvc': 1.4.16
+      '@swc/core-win32-ia32-msvc': 1.4.16
+      '@swc/core-win32-x64-msvc': 1.4.16
     dev: true
 
   /@swc/counter@0.1.3:
@@ -9571,7 +9571,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.23.0
-      caniuse-lite: 1.0.30001610
+      caniuse-lite: 1.0.30001611
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -9928,8 +9928,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001610
-      electron-to-chromium: 1.4.738
+      caniuse-lite: 1.0.30001611
+      electron-to-chromium: 1.4.742
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
@@ -10073,8 +10073,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001610:
-    resolution: {integrity: sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==}
+  /caniuse-lite@1.0.30001611:
+    resolution: {integrity: sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==}
 
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -10476,6 +10476,9 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /confbox@0.1.7:
+    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
+
   /consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -10668,20 +10671,17 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
-  /cytoscape-cose-bilkent@4.1.0(cytoscape@3.28.1):
+  /cytoscape-cose-bilkent@4.1.0(cytoscape@3.29.0):
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
     peerDependencies:
       cytoscape: ^3.2.0
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.28.1
+      cytoscape: 3.29.0
 
-  /cytoscape@3.28.1:
-    resolution: {integrity: sha512-xyItz4O/4zp9/239wCcH8ZcFuuZooEeF8KHRmzjDfGdXsj3OG9MFSMA0pJE0uX3uCN/ygof6hHf4L7lst+JaDg==}
+  /cytoscape@3.29.0:
+    resolution: {integrity: sha512-ADqhlrCKhhQF8s/s3hTpvVAIyWwsfgFI/hD2vhAXc2ndncJFVZaq3/uBkDIhf4RrNwPw93vUarW36x6rFbUk0Q==}
     engines: {node: '>=0.10'}
-    dependencies:
-      heap: 0.2.7
-      lodash: 4.17.21
 
   /d3-array@2.12.1:
     resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
@@ -11396,8 +11396,8 @@ packages:
       jake: 10.8.7
     dev: true
 
-  /electron-to-chromium@1.4.738:
-    resolution: {integrity: sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A==}
+  /electron-to-chromium@1.4.742:
+    resolution: {integrity: sha512-EhE+z1d5RNytAq/qnGAxPR+ie3UzKbv7qqQc0wnEbOh+KDUplgfzkGSCy9d78B+S+nVNTS42BabHXB6Ni+Ud4w==}
 
   /elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
@@ -12404,8 +12404,8 @@ packages:
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  /flow-parser@0.233.0:
-    resolution: {integrity: sha512-E/mv51GYJfLuRX6fZnw4M52gBxYa8pkHUOgNEZOcQK2RTXS8YXeU5rlalkTcY99UpwbeNVCSUFKaavpOksi/pQ==}
+  /flow-parser@0.234.0:
+    resolution: {integrity: sha512-J1Wn32xDF1l8FqwshoQnTwC9K3aJ83MFuXUx9AcBQr8ttbI/rkjEgAqnjxaIJuZ6RGMfccN5ZxDJSOMM64qy9Q==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -13047,9 +13047,6 @@ packages:
   /hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
     dev: false
-
-  /heap@0.2.7:
-    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
 
   /highlight.js@11.9.0:
     resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
@@ -14380,7 +14377,7 @@ packages:
       '@babel/register': 7.23.7(@babel/core@7.24.4)
       babel-core: 7.0.0-bridge.0(@babel/core@7.24.4)
       chalk: 4.1.2
-      flow-parser: 0.233.0
+      flow-parser: 0.234.0
       graceful-fs: 4.2.11
       micromatch: 4.0.5
       neo-async: 2.6.2
@@ -14469,9 +14466,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  /jsonc-parser@3.2.1:
-    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -14788,7 +14782,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       mlly: 1.6.1
-      pkg-types: 1.0.3
+      pkg-types: 1.1.0
     dev: false
 
   /locate-character@3.0.0:
@@ -14872,6 +14866,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -15209,8 +15204,8 @@ packages:
       '@braintree/sanitize-url': 6.0.4
       '@types/d3-scale': 4.0.8
       '@types/d3-scale-chromatic': 3.0.3
-      cytoscape: 3.28.1
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.28.1)
+      cytoscape: 3.29.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.29.0)
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.10
@@ -15565,7 +15560,7 @@ packages:
     dependencies:
       acorn: 8.11.3
       pathe: 1.1.2
-      pkg-types: 1.0.3
+      pkg-types: 1.1.0
       ufo: 1.5.3
 
   /mock-fs@5.2.0:
@@ -15643,8 +15638,8 @@ packages:
       - supports-color
     dev: false
 
-  /mysql2@3.9.5:
-    resolution: {integrity: sha512-idfCjWgJEIU2zToiAsy1UO9RQ+VvCrbfB9458LrComY7mJmAIvjdD+/58VmNLFUeQpKE4xZZqD+yZe3tlu62NQ==}
+  /mysql2@3.9.6:
+    resolution: {integrity: sha512-9NYUMLQv6yXnu+5hUh8PZ5CdKoG6VWDzXbojIdTyob8upNZXU3rBNQK9viaEqfgw+LMifhd+53VEZPxZk3bTWA==}
     engines: {node: '>= 8.0'}
     dependencies:
       denque: 2.1.0
@@ -16595,10 +16590,10 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /pkg-types@1.0.3:
-    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+  /pkg-types@1.1.0:
+    resolution: {integrity: sha512-/RpmvKdxKf8uILTtoOhAgf30wYbP2Qw+L9p3Rvshx1JZVX+XQNZQFjlbmGHEGIm4CkVPlSn+NXmIM8+9oWQaSA==}
     dependencies:
-      jsonc-parser: 3.2.1
+      confbox: 0.1.7
       mlly: 1.6.1
       pathe: 1.1.2
 

--- a/sites/test-env/pages/index.md
+++ b/sites/test-env/pages/index.md
@@ -1,3 +1,6 @@
 ```sql xyz
-SELECT * FROM users LIMIT 5000
+SELECT * FROM orders LIMIT 5000
 ```
+
+
+<DataTable data={xyz}/>


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

Before the introduction of tailwind, we were using the `container` class name in a few places, once tailwind was introduced there were collisions that broke a few niche scenarios.

This renames all of the relevant classes to prevent the collision

### Checklist

~~- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after~~
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
~~- [ ] I have added to the docs where applicable~~
~~- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
