### PR TITLE
fix: calendar heatmap off by 1 error

### DIFF
--- a/.changeset/red-boxes-impress.md
+++ b/.changeset/red-boxes-impress.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix: calendar heatmap off by 1 error

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_CalendarHeatmap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_CalendarHeatmap.svelte
@@ -88,7 +88,7 @@
 
 		const updatedData = data.map((obj) => ({
 			...obj,
-			year: new Date(obj[date]).getFullYear()
+			year: new Date(obj[date]).getUTCFullYear()
 		}));
 
 		const distinctYears = [...new Set(updatedData.map((obj) => obj.year))];


### PR DESCRIPTION
### Description

closes #1911 
![image](https://github.com/evidence-dev/evidence/assets/54364088/b2ad2c97-9a32-409c-9400-a0ffe7a892a2)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
