### PR TITLE
Add syntax highlighting to code blocks

### DIFF
--- a/.changeset/cyan-carrots-worry.md
+++ b/.changeset/cyan-carrots-worry.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/preprocess': patch
+'@evidence-dev/core-components': patch
+---
+
+Add syntax highlighting to code blocks

--- a/packages/lib/preprocess/src/utils/highlighter.cjs
+++ b/packages/lib/preprocess/src/utils/highlighter.cjs
@@ -25,7 +25,7 @@ function highlighter(code, lang, meta) {
         `;
 	}
 	// Ensure that "real" code blocks are rendered not run as queries
-	return `<CodeBlock source="${code}" copyToClipboard=true />`;
+	return `<CodeBlock source="${code}" copyToClipboard=true language="${lang}"/>`;
 }
 
 module.exports = { highlighter };

--- a/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -46,138 +46,25 @@
 		});
 </script>
 
-<pre
-	class="my-5 relative"
-	style="overflow-y:hidden;border: 1px solid var(--grey-200);display:flex;align-items:flex-start;justify-content:space-between;">
-	<div class="absolute" style="height:100%;width:100%">
-		{#if copyToClipboard}
-			<button
-				type="button"
-				class="container absolute right-0 top-0 h-7 w-7 transition-all duration-200 ease-in-out"
-				class:copied
-				on:click={() => {
-					if (source !== undefined) {
-						copy(source);
-					}
-				}}>
-					{#if copied}
-					<Success color="var(--green-500)" />
-				{:else}
-					<Copy />
-				{/if}
+<div class="my-5 bg-gray-50 border border-gray-200 rounded px-3 py-1 relative group">
+	{#if copyToClipboard}
+		<button
+			class={'absolute opacity-0 bg-gray-50 rounded-sm p-1 group-hover:opacity-100 top-4 right-6 h-6 w-6 z-10 transition-all duration-200 ease-in-out' +
+				(copied ? '' : '')}
+			on:click={() => {
+				if (source !== undefined) {
+					copy(source);
+				}
+			}}
+		>
+			{#if copied}
+				<Success color="var(--green-500)" />
+			{:else}
+				<Copy />
+			{/if}
 		</button>
-		{/if}
-		</div>
-<code class="language-{language}" style="overflow:auto;position:relative;display:block;"
-		>{#if source}{source}
-		{:else}<slot />
-		{/if}
-</code>		
-</pre>
-
-<style>
-	:root {
-		--scrollbar-track-color: transparent;
-		--scrollbar-color: rgba(0, 0, 0, 0.2);
-		--scrollbar-active-color: rgba(0, 0, 0, 0.4);
-		--scrollbar-size: 0.75rem;
-		--scrollbar-minlength: 1.5rem; /* Minimum length of scrollbar thumb (width of horizontal, height of vertical) */
-	}
-	pre {
-		display: flex;
-		align-items: flex-start;
-		justify-content: space-between;
-		border-radius: 0.3rem;
-		border-width: 1px;
-		--tw-bg-opacity: 1;
-		background-color: rgb(249 250 251 / var(--tw-bg-opacity));
-	}
-	pre code::-webkit-scrollbar {
-		height: var(--scrollbar-size);
-		width: var(--scrollbar-size);
-	}
-	pre code::-webkit-scrollbar-track {
-		background-color: var(--scrollbar-track-color);
-	}
-	pre code::-webkit-scrollbar-thumb {
-		background-color: var(--scrollbar-color);
-		border-radius: 7px;
-		background-clip: padding-box;
-	}
-	pre code::-webkit-scrollbar-thumb:hover {
-		background-color: var(--scrollbar-active-color);
-	}
-	pre code::-webkit-scrollbar-thumb:vertical {
-		min-height: var(--scrollbar-minlength);
-		border: 3px solid transparent;
-	}
-	pre code::-webkit-scrollbar-thumb:horizontal {
-		min-width: var(--scrollbar-minlength);
-		border: 3px solid transparent;
-	}
-	pre code {
-		position: relative;
-		display: block;
-		overflow: auto;
-		padding: 0.7rem;
-		font-size: 0.8rem;
-		line-height: 1.25rem;
-		--tw-text-opacity: 1;
-		color: rgb(17 24 39 / var(--tw-text-opacity));
-		scrollbar-width: thin;
-		scrollbar-color: var(--scrollbar-color) var(--scrollbar-track-color);
-	}
-
-	pre button.container {
-		opacity: 0;
-		box-sizing: border-box;
-		background-color: var(--grey-100);
-		border-radius: 4px 4px 4px 4px;
-		border: 1px solid var(--grey-300);
-		padding: 0.25em 0.35em 0.25em 0.35em;
-		color: var(--grey-300);
-		cursor: pointer;
-		user-select: none;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		margin: 0.5em;
-		display: flex;
-		z-index: 20;
-		align-items: center;
-		justify-content: center;
-	}
-
-	pre:hover button.container {
-		border-radius: 0.25rem;
-		--tw-border-opacity: 1;
-		border-color: rgb(229 231 235 / var(--tw-border-opacity));
-		--tw-bg-opacity: 1;
-		background-color: rgb(249 250 251 / var(--tw-bg-opacity));
-		--tw-text-opacity: 1;
-		color: rgb(107 114 128 / var(--tw-text-opacity));
-		opacity: 1;
-		padding: 0.25em 0.35em 0.25em 0.35em;
-		cursor: pointer;
-		user-select: none;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		margin: 0.5em;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	pre button.container:hover {
-		--tw-border-opacity: 1;
-		border-color: rgb(107 114 128 / var(--tw-border-opacity));
-		--tw-text-opacity: 1;
-		color: rgb(107 114 128 / var(--tw-text-opacity));
-	}
-
-	pre button.container.copied {
-		--tw-border-opacity: 1;
-		border-color: rgb(107 114 128 / var(--tw-border-opacity));
-		--tw-text-opacity: 1;
-		color: rgb(22 163 74 / var(--tw-text-opacity));
-	}
-</style>
+	{/if}
+	<pre class="overflow-auto max-h-64 pretty-scrollbar"><code class="language-{language} text-sm"
+			>{#if source}{source}{:else}<slot />{/if}</code
+		></pre>
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -38,7 +38,7 @@
 		Prism.highlightAll();
 	});
 
-	$: if(browser){
+	$: if (browser) {
 		tick().then(() => {
 			const codeElement = document.querySelector(`pre code.language-${language}`);
 			if (codeElement) {

--- a/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -3,8 +3,18 @@
 </script>
 
 <script>
+	import { onMount, tick } from 'svelte';
+	import Prism from 'prismjs';
+	import './prism-svelte.js';
+	import 'prismjs/components/prism-bash';
+	import 'prismjs/components/prism-sql';
+	import 'prismjs/components/prism-python';
+	import 'prismjs/components/prism-markdown';
+	// import 'prismjs/themes/prism-tomorrow.css'; // theme not taking effect at the moment
+
 	export let source;
 	export let copyToClipboard = false;
+	export let language = undefined;
 	import Copy from './Deployment/CopyIcon.svelte';
 	import Success from './Deployment/CopySuccessIcon.svelte';
 	let copied = false;
@@ -22,14 +32,28 @@
 			/* ignore errors */
 		}
 	}
+
+	onMount(() => {
+		Prism.highlightAll();
+	});
+
+	$: source,
+		tick().then(() => {
+			const codeElement = document.querySelector(`pre code.language-${language}`);
+			if (codeElement) {
+				Prism.highlightElement(codeElement, false);
+			}
+		});
 </script>
 
-<pre class="my-5 relative">
+<pre
+	class="my-5 relative"
+	style="overflow-y:hidden;border: 1px solid var(--grey-200);display:flex;align-items:flex-start;justify-content:space-between;">
 	<div class="absolute" style="height:100%;width:100%">
 		{#if copyToClipboard}
 			<button
 				type="button"
-				class="container absolute right-0 top-0 h-8 w-8 transition-all duration-200 ease-in-out"
+				class="container absolute right-0 top-0 h-7 w-7 transition-all duration-200 ease-in-out"
 				class:copied
 				on:click={() => {
 					if (source !== undefined) {
@@ -44,7 +68,7 @@
 		</button>
 		{/if}
 		</div>
-<code
+<code class="language-{language}" style="overflow:auto;position:relative;display:block;"
 		>{#if source}{source}
 		{:else}<slot />
 		{/if}
@@ -60,7 +84,13 @@
 		--scrollbar-minlength: 1.5rem; /* Minimum length of scrollbar thumb (width of horizontal, height of vertical) */
 	}
 	pre {
-		@apply bg-gray-50 border rounded-md flex items-start justify-between;
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		border-radius: 0.3rem;
+		border-width: 1px;
+		--tw-bg-opacity: 1;
+		background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 	}
 	pre code::-webkit-scrollbar {
 		height: var(--scrollbar-size);
@@ -86,7 +116,14 @@
 		border: 3px solid transparent;
 	}
 	pre code {
-		@apply overflow-auto relative block p-3 text-gray-900 text-sm;
+		position: relative;
+		display: block;
+		overflow: auto;
+		padding: 0.7rem;
+		font-size: 0.8rem;
+		line-height: 1.25rem;
+		--tw-text-opacity: 1;
+		color: rgb(17 24 39 / var(--tw-text-opacity));
 		scrollbar-width: thin;
 		scrollbar-color: var(--scrollbar-color) var(--scrollbar-track-color);
 	}
@@ -111,7 +148,13 @@
 	}
 
 	pre:hover button.container {
-		@apply bg-gray-50 text-gray-500 border-gray-200 rounded;
+		border-radius: 0.25rem;
+		--tw-border-opacity: 1;
+		border-color: rgb(229 231 235 / var(--tw-border-opacity));
+		--tw-bg-opacity: 1;
+		background-color: rgb(249 250 251 / var(--tw-bg-opacity));
+		--tw-text-opacity: 1;
+		color: rgb(107 114 128 / var(--tw-text-opacity));
 		opacity: 1;
 		padding: 0.25em 0.35em 0.25em 0.35em;
 		cursor: pointer;
@@ -125,10 +168,16 @@
 	}
 
 	pre button.container:hover {
-		@apply border-gray-500 text-gray-500;
+		--tw-border-opacity: 1;
+		border-color: rgb(107 114 128 / var(--tw-border-opacity));
+		--tw-text-opacity: 1;
+		color: rgb(107 114 128 / var(--tw-text-opacity));
 	}
 
 	pre button.container.copied {
-		@apply text-green-600 border-gray-500;
+		--tw-border-opacity: 1;
+		border-color: rgb(107 114 128 / var(--tw-border-opacity));
+		--tw-text-opacity: 1;
+		color: rgb(22 163 74 / var(--tw-text-opacity));
 	}
 </style>

--- a/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -4,6 +4,7 @@
 
 <script>
 	import { onMount, tick } from 'svelte';
+	import { browser } from '$app/environment';
 	import Prism from 'prismjs';
 	import './prism-svelte.js';
 	import 'prismjs/components/prism-bash';
@@ -37,13 +38,14 @@
 		Prism.highlightAll();
 	});
 
-	$: source,
+	$: if(browser){
 		tick().then(() => {
 			const codeElement = document.querySelector(`pre code.language-${language}`);
 			if (codeElement) {
 				Prism.highlightElement(codeElement, false);
 			}
 		});
+	}
 </script>
 
 <div class="my-5 bg-gray-50 border border-gray-200 rounded px-3 py-1 relative group">

--- a/packages/ui/core-components/src/lib/unsorted/ui/prism-svelte.js
+++ b/packages/ui/core-components/src/lib/unsorted/ui/prism-svelte.js
@@ -1,0 +1,168 @@
+/* eslint-disable no-useless-escape */
+import Prism from 'prismjs';
+const blocks = '(if|else if|await|then|catch|each|html|debug)';
+
+Prism.languages.svelte = Prism.languages.extend('markup', {
+	each: {
+		pattern: new RegExp(
+			'{[#/]each' + '(?:(?:\\{(?:(?:\\{(?:[^{}])*\\})|(?:[^{}]))*\\})|(?:[^{}]))*}'
+		),
+		inside: {
+			'language-javascript': [
+				{
+					pattern: /(as[\s\S]*)\([\s\S]*\)(?=\s*\})/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				},
+				{
+					pattern: /(as[\s]*)[\s\S]*(?=\s*)/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				},
+				{
+					pattern: /(#each[\s]*)[\s\S]*(?=as)/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				}
+			],
+			keyword: /[#/]each|as/,
+			punctuation: /{|}/
+		}
+	},
+	if: {
+		pattern: new RegExp(
+			'{[#/]if' + '(?:(?:\\{(?:(?:\\{(?:[^{}])*\\})|(?:[^{}]))*\\})|(?:[^{}]))*}'
+		),
+		inside: {
+			'language-javascript': [
+				{
+					pattern: /(as[\s\S]*)\([\s\S]*\)(?=\s*\})/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				},
+				{
+					pattern: /(as[\s]*)[\s\S]*(?=\s*)/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				},
+				{
+					pattern: /(#if[\s]*)[\s\S]*(?=as)/,
+					lookbehind: true,
+					inside: Prism.languages['javascript']
+				}
+			],
+			keyword: /[#/]if|as/,
+			punctuation: /{|}/
+		}
+	},
+	block: {
+		pattern: new RegExp(
+			'{[#:/@]/s' + blocks + '(?:(?:\\{(?:(?:\\{(?:[^{}])*\\})|(?:[^{}]))*\\})|(?:[^{}]))*}'
+		),
+		inside: {
+			punctuation: /^{|}$/,
+			keyword: [new RegExp('[#:/@]' + blocks + '( )*'), /as/, /then/],
+			'language-javascript': {
+				pattern: /[\s\S]*/,
+				inside: Prism.languages['javascript']
+			}
+		}
+	},
+	tag: {
+		pattern:
+			/<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?:"[^"]*"|'[^']*'|{[\s\S]+?}(?=[\s/>])))|(?=[\s/>])))+)?\s*\/?>/i,
+		greedy: true,
+		inside: {
+			tag: {
+				pattern: /^<\/?[^\s>\/]+/i,
+				inside: {
+					punctuation: /^<\/?/,
+					namespace: /^[^\s>\/:]+:/
+				}
+			},
+			'language-javascript': {
+				pattern: /\{(?:(?:\{(?:(?:\{(?:[^{}])*\})|(?:[^{}]))*\})|(?:[^{}]))*\}/,
+				inside: Prism.languages['javascript']
+			},
+			'attr-value': {
+				pattern: /=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+)/i,
+				inside: {
+					punctuation: [
+						/^=/,
+						{
+							pattern: /^(\s*)["']|["']$/,
+							lookbehind: true
+						}
+					],
+					'language-javascript': {
+						pattern: /{[\s\S]+}/,
+						inside: Prism.languages['javascript']
+					}
+				}
+			},
+			punctuation: /\/?>/,
+			'attr-name': {
+				pattern: /[^\s>\/]+/,
+				inside: {
+					namespace: /^[^\s>\/:]+:/
+				}
+			}
+		}
+	},
+	'language-javascript': {
+		pattern: /\{(?:(?:\{(?:(?:\{(?:[^{}])*\})|(?:[^{}]))*\})|(?:[^{}]))*\}/,
+		lookbehind: true,
+		inside: Prism.languages['javascript']
+	}
+});
+
+Prism.languages.svelte['tag'].inside['attr-value'].inside['entity'] =
+	Prism.languages.svelte['entity'];
+
+Prism.hooks.add('wrap', (env) => {
+	if (env.type === 'entity') {
+		env.attributes['title'] = env.content.replace(/&amp;/, '&');
+	}
+});
+
+Object.defineProperty(Prism.languages.svelte.tag, 'addInlined', {
+	value: function addInlined(tagName, lang) {
+		const includedCdataInside = {};
+		includedCdataInside['language-' + lang] = {
+			pattern: /(^<!\[CDATA\[)[\s\S]+?(?=\]\]>$)/i,
+			lookbehind: true,
+			inside: Prism.languages[lang]
+		};
+		includedCdataInside['cdata'] = /^<!\[CDATA\[|\]\]>$/i;
+
+		const inside = {
+			'included-cdata': {
+				pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+				inside: includedCdataInside
+			}
+		};
+		inside['language-' + lang] = {
+			pattern: /[\s\S]+/,
+			inside: Prism.languages[lang]
+		};
+
+		const def = {};
+		def[tagName] = {
+			pattern: RegExp(
+				/(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(
+					/__/g,
+					tagName
+				),
+				'i'
+			),
+			lookbehind: true,
+			greedy: true,
+			inside
+		};
+
+		Prism.languages.insertBefore('svelte', 'cdata', def);
+	}
+});
+
+Prism.languages.svelte.tag.addInlined('style', 'css');
+Prism.languages.svelte.tag.addInlined('script', 'javascript');

--- a/sites/docs/pages/components/data-table.md
+++ b/sites/docs/pages/components/data-table.md
@@ -12,7 +12,7 @@ select * from needful_things.orders
 limit 100
 ```
 
-```html
+```svelte
 <DataTable data={orders_summary}/>
 ```
 
@@ -20,7 +20,7 @@ limit 100
 
 ### Selecting Specific Columns
 
-```html
+```svelte
 <DataTable data={orders_summary}> 
     <Column id=state title="Sales State"/> 
 	<Column id=item/> 
@@ -42,7 +42,7 @@ limit 100
 
 You can use the `fmt` prop to format your columns using [built-in format names or Excel format codes](/core-concepts/formatting/)
 
-```html
+```svelte
 <DataTable data={country_summary}>
 	<Column id=country />
 	<Column id=category />
@@ -72,7 +72,7 @@ from ${country_summary}
 
 This example includes a `custom_format` column, which contains a different currency format code for many of the rows.
 
-```html
+```svelte
 <DataTable data={country_summary_fmts}>
 	<Column id=country />
 	<Column id=category />
@@ -91,7 +91,7 @@ This example includes a `custom_format` column, which contains a different curre
 
 ### Search
 
-```html
+```svelte
 <DataTable data={orders_summary} search=true/>
 ```
 
@@ -156,7 +156,7 @@ select date '2020-05-26' as date, 100 as value_usd, 0.011 as yoy, 'Zimbabwe' as 
 ```
 
 
-```html
+```svelte
 <DataTable data={country_summary}>
 	<Column id=country />
 	<Column id=category />
@@ -177,7 +177,7 @@ select date '2020-05-26' as date, 100 as value_usd, 0.011 as yoy, 'Zimbabwe' as 
 
 Default total aggregation is `sum`
 
-```html
+```svelte
 <DataTable data={country_example} totalRow=true rows=5>
   <Column id=country/>
   <Column id=gdp_usd/>
@@ -201,7 +201,7 @@ select * from ${countries}
 limit 5
 ```
 
-```html
+```svelte
 <DataTable data={country_example} totalRow=true rows=5>
   <Column id=country/>
   <Column id=gdp_usd totalAgg=sum/>
@@ -219,7 +219,7 @@ limit 5
 
 #### Custom Aggregations Values
 
-```html
+```svelte
 <DataTable data={countries} totalRow=true rows=5>
   <Column id=country totalAgg="Just the USA"/>
   <Column id=gdp_usd totalAgg={countries[0].gdp_usd} totalFmt=usd/>
@@ -233,7 +233,7 @@ limit 5
 
 #### Custom Total Formats
 
-```html
+```svelte
 <DataTable data={countries} totalRow=true rows=5>
   <Column id=country totalAgg="All Countries"/>
   <Column id=continent totalAgg=countDistinct totalFmt='# "Unique continents"'/>
@@ -267,7 +267,7 @@ limit 5
 
 #### Default (`scaleColor=green`)
 
-```html
+```svelte
 <DataTable data={countries}>
     <Column id=country />
     <Column id=country_id align=center/>
@@ -285,7 +285,7 @@ limit 5
 
 #### `scaleColor=red`
 
-```html
+```svelte
 <DataTable data={countries}>
     <Column id=country />
     <Column id=country_id align=center/>
@@ -303,7 +303,7 @@ limit 5
 
 #### `scaleColor=blue`
 
-```html
+```svelte
 <DataTable data={countries}>
     <Column id=country />
     <Column id=country_id align=center/>
@@ -323,7 +323,7 @@ limit 5
 
 When you pass a custom color to `scaleColor`, Evidence will create a color palette for you, starting at white and ending at the color you provided. See examples further down the page to see how to specify a custom color palette with multiple colors.
 
-```html
+```svelte
 <DataTable data={orders_by_category} rowNumbers=true>
   <Column id=month/>
   <Column id=category/>
@@ -375,7 +375,7 @@ union all
 
 #### Diverging Scale
 
-```html
+```svelte
 <DataTable data={numbers}>
   <Column id=name/>
   <Column id=number contentType=colorscale scaleColor={['#6db678','white','#ce5050']}/>
@@ -388,7 +388,7 @@ union all
 </DataTable>
 
 #### Heatmap
-```html
+```svelte
 <DataTable data={numbers}>
   <Column id=name/>
   <Column id=number contentType=colorscale scaleColor={['#6db678','#ebbb38','#ce5050']}/>
@@ -404,7 +404,7 @@ union all
 #### Color Breakpoints
 Use `colorBreakpoints` or `colorMid`/`colorMin`/`colorMax` to control which values are assigned to which sections of the color scale
 
-```html
+```svelte
 <DataTable data={negatives} rows=all>
   <Column id=name/>
   <Column id=number contentType=colorscale scaleColor={['#ce5050','white','#6db678']} colorMid=0/>
@@ -443,7 +443,7 @@ union all
  order by number asc
  ```
 
-```html
+```svelte
 <DataTable data={numbers_othercol}>
   <Column id=name/>
   <Column id=scale_defining_number fontColor={['green','red']}/>
@@ -482,7 +482,7 @@ select 'J', 4 as number,0
 order by number asc
 ```
 
-```html
+```svelte
 <DataTable data={negatives}>
   <Column id=name/>
   <Column id=number redNegatives=true/>
@@ -500,7 +500,7 @@ You can include images by indicating either an absolute path e.g. `https://www.e
 
 In this example, `flag` is either an absolute path or a relative path to the image.
 
-```html
+```svelte
 <DataTable data={countries}>
 	<Column id=flag contentType=image height=30px align=center />
 	<Column id=country />
@@ -522,7 +522,7 @@ In this example, `flag` is either an absolute path or a relative path to the ima
 
 #### Link Column with Unique Labels
 
-```html
+```svelte
 <DataTable data={countries}>
 	<Column id=country_url contentType=link linkLabel=country />
 	<Column id=country_id align=center />
@@ -540,7 +540,7 @@ In this example, `flag` is either an absolute path or a relative path to the ima
 
 #### Link Column with Consistent String Label
 
-```html
+```svelte
 <DataTable data={countries}>
 	<Column id=country />
 	<Column id=country_id align=center />
@@ -596,7 +596,7 @@ To apply styling to most HTML tags, you should add the `class=markdown` attribut
 
 This example includes a column `country_url` which contains a country name as a search term in Google (e.g., `https://google.ca/search?q=canada`)
 
-```html
+```svelte
 <DataTable data={countries} search=true link=country_url>
 	<Column id=country />
 	<Column id=country_id align=center />
@@ -629,7 +629,7 @@ group by 1
 
 You can then use the `link` property of the DataTable to use your link column as a row link (`category_link` in this example):
 
-```html
+```svelte
 <DataTable data={orders} link=category_link />
 ```
 
@@ -641,7 +641,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 #### Row Shading + Row Lines
 
-```html
+```svelte
 <DataTable data={countries} rowShading=true />
 ```
 
@@ -649,7 +649,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 #### Row Shading + No Row Lines
 
-```html
+```svelte
 <DataTable data={countries} rowShading=true rowLines=false />
 ```
 
@@ -657,7 +657,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 #### No Lines or Shading
 
-```html
+```svelte
 <DataTable data={countries} rowLines=false />
 ```
 
@@ -665,7 +665,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 ### Column Alignment
 
-```html
+```svelte
 <DataTable data={country_summary}>
 	<Column id=country align=right />
 	<Column id=country_id align=center />
@@ -683,7 +683,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 ### Custom Column Titles
 
-```html
+```svelte
 <DataTable data={country_summary}>
 	<Column id=country title="Country Name" />
 	<Column id=country_id align=center title="ID" />
@@ -701,7 +701,7 @@ By default, the link column of your table is hidden. If you would like it to be 
 
 ### Raw Column Names
 
-```html
+```svelte
 <DataTable data={country_summary} formatColumnTitles=false />
 ```
 
@@ -717,7 +717,7 @@ group by all
 limit 25
 ```
 
-```html
+```svelte
 <DataTable data={orders} groupBy=state>
  	<Column id=state/> 
 	<Column id=category totalAgg=""/> 
@@ -739,7 +739,7 @@ limit 25
 
 #### With Subtotals
 
-```html
+```svelte
 <DataTable data={orders} groupBy=state subtotals=true> 
  	<Column id=state/> 
 	<Column id=category totalAgg=""/> 
@@ -761,7 +761,7 @@ limit 25
 
 #### Closed by Default
 
-```html
+```svelte
 <DataTable data={orders} groupBy=state subtotals=true totalRow=true groupsOpen=false> 
  	<Column id=state totalAgg=countDistinct totalFmt='0 "states"'/> 
 	<Column id=category totalAgg=countDistinct totalFmt='[=1]0 "category";0 "categories"'/> 
@@ -783,7 +783,7 @@ limit 25
 
 #### With Configured Columns
 
-```html
+```svelte
 <DataTable data={orders} groupBy=category subtotals=true totalRow=true> 
  	<Column id=state totalAgg=countDistinct totalFmt='0 "states"'/> 
 	<Column id=category totalAgg=Total/> 
@@ -807,7 +807,7 @@ limit 25
 
 #### Without subtotals
 
-```html
+```svelte
 <DataTable data={orders} groupBy=state groupType=section/>
 ```
 
@@ -815,7 +815,7 @@ limit 25
 
 #### With Subtotals
 
-```html
+```svelte
 <DataTable data={orders} groupBy=state subtotals=true groupType=section>
  	<Column id=state totalAgg=countDistinct totalFmt='[=1]0 "state";0 "states"'/> 
 	<Column id=category totalAgg=Total/> 
@@ -837,7 +837,7 @@ limit 25
 
 #### With Configured Columns
 
-```html
+```svelte
 <DataTable data={orders} groupBy=category groupType=section subtotals=true totalRow=true totalRowColor=#fff0cc> 
  	<Column id=state totalAgg=countDistinct totalFmt='[=1]0 "state";0 "states"'/> 
 	<Column id=category totalAgg=Total/> 
@@ -885,7 +885,7 @@ UNION ALL
 SELECT 'Brazil', 'South America', 1609, 0.032, 0.1375, 0.1007, 0.091, -4.5, 80.27, -1.8, 213.32
 ```
 
-```html
+```svelte
 <DataTable data={countries} totalRow=true rows=5 wrapTitles groupBy=continent groupType=section totalRowColor=#f2f2f2>
   <Column id=continent totalAgg="Total" totalFmt='# "Unique continents"'/>
   <Column id=country totalAgg=countDistinct totalFmt='0 "countries"'/>
@@ -915,7 +915,7 @@ SELECT 'Brazil', 'South America', 1609, 0.032, 0.1375, 0.1007, 0.091, -4.5, 80.2
 
 ### Wrap Titles
 
-```html
+```svelte
 <DataTable data={countries} wrapTitles=true /> 
 ```
 

--- a/sites/example-project/src/app.css
+++ b/sites/example-project/src/app.css
@@ -19,7 +19,7 @@
 	}
 
 	.pretty-scrollbar::-webkit-scrollbar {
-		height: 0.75rem;
+		height: 6px;
 		width: 6px;
 	}
 

--- a/sites/example-project/src/pages/text-and-metrics/code-blocks/+page.md
+++ b/sites/example-project/src/pages/text-and-metrics/code-blocks/+page.md
@@ -77,6 +77,23 @@ pre {
 </body>
 ```
 
+### Svelte
+
+```svelte
+<DataTable data={countries} totalRow=true rows=5 wrapTitles groupBy=continent groupType=section totalRowColor=#f2f2f2>
+  <Column id=continent totalAgg="Total" totalFmt='# "Unique continents"'/>
+  <Column id=country totalAgg=countDistinct totalFmt='0 "countries"'/>
+  <Column id=gdp_usd totalAgg=sum fmt='$#,##0"B"' totalFmt='$#,##0.0,"T"' colGroup="GDP"/>
+  <Column id=gdp_growth totalAgg=weightedMean weightCol=gdp_usd fmt='pct1' colGroup="GDP" contentType=delta/>
+  <Column id=jobless_rate totalAgg=weightedMean weightCol=gdp_usd fmt='pct1' contentType=colorscale scaleColor=red colGroup="Labour Market"/>
+  <Column id=population totalAgg=sum fmt='#,##0"M"' totalFmt='#,##0.0,"B"' colGroup="Labour Market"/>
+  <Column id=interest_rate totalAgg=weightedMean weightCol=gdp_usd fmt='pct2' wrapTitle=false colGroup="Other"/>
+  <Column id=inflation_rate totalAgg=weightedMean weightCol=gdp_usd fmt='pct2' colGroup="Other"/>
+  <Column id=gov_budget totalAgg=weightedMean weightCol=gdp_usd fmt='0.0"%"' contentType=delta colGroup="Other"/>
+  <Column id=current_account totalAgg=weightedMean weightCol=gdp_usd fmt='0.0"%"' colGroup="Other"/>
+</DataTable>
+```
+
 ### Bash
 
 To install Evidence you need to run the following command in your terminal:


### PR DESCRIPTION
### Before
![CleanShot 2024-04-21 at 14 17 15@2x](https://github.com/evidence-dev/evidence/assets/12602440/b9b002a0-dea9-4755-9446-f30831399b4c)

### After
![CleanShot 2024-04-21 at 14 16 59@2x](https://github.com/evidence-dev/evidence/assets/12602440/4adec7c1-fc2d-474b-9046-373225769371)

![CleanShot 2024-04-21 at 14 10 17@2x](https://github.com/evidence-dev/evidence/assets/12602440/b92a85c5-df7d-4cd8-bbeb-ca71dbd2aba0)

## Potential Issues
- Styling issues - `@apply` wasn't working, so for now I've had to override styles in the html tag
- Uses a slightly modified definition of Svelte syntax from `svelte-prism` rather than importing from that library
- Prism themes not working, stuck on default styling
- Import method for languages may not be ideal

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable

### To do before merge
- [x] Remove `document` usage in reactive statement
- [ ] Confirm import method for languages and Prism
- [x] Clean up styling conflicts
- [ ] Set appropriate margins/padding on code box
- [ ] Add a language option for `evidence` so users can include documentation in their project without having to know about `svelte`