### PR TITLE
Reintroduce error handling to DataTable

### DIFF
--- a/.changeset/odd-readers-compete.md
+++ b/.changeset/odd-readers-compete.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Reintroduce error handling to DataTable

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.svelte
@@ -34,7 +34,7 @@
 <QueryLoad {data} let:loaded>
 	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
 	<ErrorChart let:loaded slot="error" {chartType} error={loaded.error.message} />
-	<DataTable {...spreadProps} data={loaded} {queryID}>
+	<DataTable {...spreadProps} data={Query.isQuery(loaded) ? Array.from(loaded) : loaded} {queryID}>
 		<slot />
 	</DataTable>
 </QueryLoad>

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -57,8 +57,8 @@
 				{@const scaleCol = column.scaleColumn
 					? columnSummary.find((d) => d.id === column.scaleColumn)
 					: useCol}
-				{@const column_min = column.colorMin ?? scaleCol.columnUnitSummary.min}
-				{@const column_max = column.colorMax ?? scaleCol.columnUnitSummary.max}
+				{@const column_min = column.colorMin ?? scaleCol.columnUnitSummary?.min}
+				{@const column_max = column.colorMax ?? scaleCol.columnUnitSummary?.max}
 				{@const is_nonzero =
 					column_max - column_min !== 0 && !isNaN(column_max) && !isNaN(column_min)}
 				{@const column_format = column.fmt
@@ -97,7 +97,7 @@
 						? `1px solid ${chroma(cell_color).darken(0.5)}`
 						: ''}
 				<TableCell
-					class={useCol.type}
+					class={useCol?.type}
 					verticalAlign={groupType === 'section' ? groupNamePosition : undefined}
 					rowSpan={groupType === 'section' && groupColumn === useCol.id && i === 0 ? rowSpan : 1}
 					show={!(groupType === 'section' && groupColumn === useCol.id && i !== 0)}

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -210,7 +210,7 @@
 	}
 
 	// Reactively update Fuse when `data` or `columnSummary` changes
-	$: if (browser) {
+	$: if (browser && !error) {
 		updateFuse();
 		if (searchValue !== '') {
 			runSearch(searchValue);
@@ -378,7 +378,7 @@
 	let groupedData = {};
 	let groupRowData = [];
 
-	$: {
+	$: if (!error) {
 		groupedData = data.reduce((acc, row) => {
 			const groupName = row[groupBy];
 			if (!acc[groupName]) {
@@ -397,7 +397,7 @@
 
 			columnsToAggregate.forEach((columnDef) => {
 				const column = columnDef.id;
-				const colType = columnSummary.find((d) => d.id === column).type;
+				const colType = columnSummary.find((d) => d.id === column)?.type;
 				const totalAgg = columnDef.totalAgg;
 				const weightCol = columnDef.weightCol;
 				const rows = groupedData[groupName];

--- a/sites/example-project/src/pages/charts/line-chart/+page.md
+++ b/sites/example-project/src/pages/charts/line-chart/+page.md
@@ -80,7 +80,7 @@ select '2023-04-14' as start_date, null as end_date, 'Campaign C' as label
 ```
 
 <LineChart 
-    data={orders_by_month} 
+    data=orders_by_month
     x=month
     y=sales_usd0k 
     yAxisTitle="Sales per Month"


### PR DESCRIPTION
### Description
Errors in DataTable were breaking the page. This patches over a couple of common errors: 
- `data` prop passed as a string instead of using `{ }`
- Incorrect column name passed to `Column`

Incorrect column name error is not handling well here, but better than breaking the page - it currently inserts an empty column with title "undefined"

### Examples
![CleanShot 2024-04-21 at 15 47 56@2x](https://github.com/evidence-dev/evidence/assets/12602440/0ce3fa1d-94ae-4722-a240-e39a7095bb42)

![CleanShot 2024-04-21 at 15 48 10@2x](https://github.com/evidence-dev/evidence/assets/12602440/c75e3ae4-41f1-45b1-a5c2-2b17ad50ed58)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)