### PR TITLE
feat: add show/hide/never sidebar toggle in frontmatter

### DIFF
--- a/.changeset/swift-schools-juggle.md
+++ b/.changeset/swift-schools-juggle.md
@@ -1,0 +1,7 @@
+---
+'@evidence-dev/core-components': minor
+'my-evidence-project': minor
+'@evidence-dev/components': minor
+---
+
+add show/hide/never sidebar toggle in frontmatter

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -32,13 +32,13 @@
 	/** @type {boolean} */
 	export let builtWithEvidence = false;
 	/** @type {{appId: string, apiKey: string, indexName: string}} */
-	export let algolia;
+	export let algolia = undefined;
 	/** @type {string} */
-	export let githubRepo;
+	export let githubRepo = undefined;
 	/** @type {string} */
-	export let xProfile;
+	export let xProfile = undefined;
 	/** @type {string} */
-	export let slackCommunity;
+	export let slackCommunity = undefined;
 	/** @type {string}*/
 	export let maxWidth = undefined;
 
@@ -58,6 +58,39 @@
 	}
 
 	let fileTree = data?.pagesManifest;
+
+	function convertFileTreeToFileMap(fileTree) {
+		const map = new Map();
+
+		function traverse(fileTree) {
+			if (!fileTree) {
+				return;
+			}
+
+			if (fileTree.href) {
+				const decodedHref = decodeURI(fileTree.href);
+				map.set(decodedHref, fileTree);
+			}
+
+			if (fileTree.children) {
+				fileTree.children.forEach((child) => traverse(child));
+			}
+		}
+
+		traverse(fileTree);
+
+		return map;
+	}
+
+	$: fileMap = convertFileTreeToFileMap(fileTree);
+
+	$: routeFrontMatter = fileMap.get($page.route.id)?.frontMatter;
+
+	$: sidebarFrontMatter = routeFrontMatter?.sidebar;
+
+	$: if (!['show', 'hide', 'never'].includes(sidebarFrontMatter)) {
+		sidebarFrontMatter = undefined;
+	}
 </script>
 
 <slot />
@@ -79,6 +112,7 @@
 			{slackCommunity}
 			{xProfile}
 			{algolia}
+			{sidebarFrontMatter}
 		/>
 	{/if}
 	<div
@@ -86,7 +120,7 @@
 			'print:w-[650px] print:md:w-[841px] mx-auto print:md:px-0 print:px-0 px-6 sm:px-8 md:px-12 flex justify-start'}
 		style="max-width:{maxWidth}px;"
 	>
-		{#if !hideSidebar}
+		{#if !hideSidebar && sidebarFrontMatter !== 'never'}
 			<div class="print:hidden">
 				<Sidebar
 					{fileTree}
@@ -95,6 +129,7 @@
 					{logo}
 					{builtWithEvidence}
 					{hideHeader}
+					{sidebarFrontMatter}
 				/>
 			</div>
 		{/if}

--- a/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/header/Header.svelte
@@ -14,6 +14,7 @@
 	export let fullWidth = undefined;
 	export let maxWidth = undefined;
 	export let hideSidebar = undefined;
+	export let sidebarFrontMatter = undefined;
 
 	export let algolia = undefined;
 
@@ -31,29 +32,32 @@
 			'mx-auto px-6 sm:px-8 md:px-12 flex flex-1 items-center justify-between'}
 		style="max-width:{maxWidth}px;"
 	>
-		{#if hideSidebar}
+		{#if hideSidebar || sidebarFrontMatter === 'never'}
 			<a href="/" class="block text-sm font-bold text-gray-800">
 				<Logo {logo} {title} />
 			</a>
 		{:else}
-			<a href="/" class="hidden md:block text-sm font-bold text-gray-800">
-				<Logo {logo} {title} />
-			</a>
-			<button
-				type="button"
-				class="text-gray-900 hover:bg-gray-50 rounded-lg p-1 md:hidden transition-all duration-500"
-				on:click={() => {
-					mobileSidebarOpen = !mobileSidebarOpen;
-				}}
-			>
-				{#if mobileSidebarOpen}
-					<span class="sr-only">Close sidebar</span>
-					<Icon class="w-5 h-5" src={X} />
-				{:else}
-					<span class="sr-only">Open sidebar</span>
-					<Icon class="w-5 h-5" src={Menu2} />
-				{/if}
-			</button>
+			<div class="flex gap-x-4 items-center">
+				<button
+					type="button"
+					class="text-gray-900 hover:bg-gray-50 rounded-lg p-1 transition-all duration-500
+          {sidebarFrontMatter === 'hide' ? 'block' : 'md:hidden'}"
+					on:click={() => {
+						mobileSidebarOpen = !mobileSidebarOpen;
+					}}
+				>
+					{#if mobileSidebarOpen}
+						<span class="sr-only">Close sidebar</span>
+						<Icon class="w-5 h-5" src={X} />
+					{:else}
+						<span class="sr-only">Open sidebar</span>
+						<Icon class="w-5 h-5" src={Menu2} />
+					{/if}
+				</button>
+				<a href="/" class="text-sm font-bold text-gray-800 hidden md:block">
+					<Logo {logo} {title} />
+				</a>
+			</div>
 		{/if}
 		<div class="flex gap-2 text-sm items-center">
 			{#if algolia}

--- a/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
@@ -12,6 +12,7 @@
 	export let logo = undefined;
 	export let builtWithEvidence = undefined;
 	export let hideHeader = false;
+	export let sidebarFrontMatter = undefined;
 
 	// sort children arrays by sidebar_position
 	function sortChildrenBySidebarPosition(node) {
@@ -191,7 +192,7 @@
 {/if}
 
 <!-- Desktop Sidebar -->
-<aside class="w-48 hidden md:flex flex-none">
+<aside class="w-48 flex-none {sidebarFrontMatter === 'hide' ? 'hidden' : 'hidden md:flex'}">
 	{#if !mobileSidebarOpen}
 		<div
 			class="hidden: md:block fixed w-48 top-20 bottom-8 overflow-y-auto flex-1 text-sm text-gray-500 pretty-scrollbar"

--- a/sites/docs/pages/reference/markdown.md
+++ b/sites/docs/pages/reference/markdown.md
@@ -188,6 +188,12 @@ You can put whatever data you would like here, and it uses a [yaml syntax](https
     description="references SQL queries stored in the /queries directory."
 />
 <PropListing
+    name="sidebar"
+    description="changes the visibility of the sidebar. 'show' results in a responsive sidebar, 'hide' results in a sidebar accessible via hamburger button and 'never' hides both - the sidebar and the hamburger button."
+    type=string
+    options={['show', 'hide', 'never']}
+/>
+<PropListing
     name="sidebar_position"
     description="changes the position of the page in the sidebar. When used in index.md pages, changes the position of their parent in the sidebar."
 />

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -4,8 +4,8 @@ import preprocess from '@evidence-dev/preprocess';
 import { error } from '@sveltejs/kit';
 
 // Import pages and create an object structure corresponding to the file structure
-const pages = import.meta.glob(['/src/pages/*/**/+page.md']);
-let pagePaths = Object.keys(pages).map((path) => path.replace('/src/pages/', ''));
+const pages = import.meta.glob(['/src/pages/**/+page.md']);
+const pagePaths = Object.keys(pages).map((path) => path.replace('/src/pages/', ''));
 
 export const prerender = true;
 
@@ -38,7 +38,7 @@ function deleteEmptyNodes(node) {
  */
 export async function GET() {
 	try {
-		let fileTree = {
+		const fileTree = {
 			label: 'Home',
 			href: '/',
 			children: {},
@@ -47,17 +47,17 @@ export async function GET() {
 		pagePaths.forEach(function (pagePath) {
 			pagePath.split('/').reduce(function (r, e) {
 				if (e === '+page.md') {
-					let href = pagePath.includes('[')
+					const href = pagePath.includes('[')
 						? undefined
-						: encodeURI('/' + pagePath.replace('/+page.md', ''));
+						: encodeURI('/' + pagePath.replace(/\/?\+page.md$/, ''));
 
-					let absolutePath = path.join(process.cwd(), 'src', 'pages', pagePath);
-					let pageContent = fs.readFileSync(absolutePath, 'utf-8');
-					let frontMatter = preprocess.parseFrontmatter(pageContent);
+					const absolutePath = path.join(process.cwd(), 'src', 'pages', pagePath);
+					const pageContent = fs.readFileSync(absolutePath, 'utf-8');
+					const frontMatter = preprocess.parseFrontmatter(pageContent);
 
 					return (r['href'] = href), (r['frontMatter'] = frontMatter);
 				} else {
-					let label = e.includes('[') ? undefined : e.replace(/_/g, ' ').replace(/-/g, ' ');
+					const label = e.includes('[') ? undefined : e.replace(/_/g, ' ').replace(/-/g, ' ');
 					r.isTemplated = e.includes('[');
 					return (
 						r?.children[e] ||

--- a/sites/example-project/src/pages/sidebar/hide/+page.md
+++ b/sites/example-project/src/pages/sidebar/hide/+page.md
@@ -1,0 +1,6 @@
+---
+sidebar: hide
+sidebar_position: 2
+---
+
+# Sidebar - Hide

--- a/sites/example-project/src/pages/sidebar/never/+page.md
+++ b/sites/example-project/src/pages/sidebar/never/+page.md
@@ -1,0 +1,6 @@
+---
+sidebar: never
+sidebar_position: 3
+---
+
+# Sidebar - Never

--- a/sites/example-project/src/pages/sidebar/show/+page.md
+++ b/sites/example-project/src/pages/sidebar/show/+page.md
@@ -1,0 +1,6 @@
+---
+sidebar: show
+sidebar_position: 1
+---
+
+# Sidebar - Show


### PR DESCRIPTION
### Description
closes #1468 

Changes:
- Added support for sidebar toggle - "show" / "hide" / "never"
- Added PropLisiting in docs
- Enabled frontmatter for home page
- Added test cases in example-project
   - /sidebar/show
![image](https://github.com/evidence-dev/evidence/assets/54364088/9f65aaf4-124a-4c7b-a8b6-1be135d75b81)

   - /sidebar/hide
![image](https://github.com/evidence-dev/evidence/assets/54364088/524cbb2a-517f-4bd8-b228-98804aa6cdc2)

   - /sidebar/never
![image](https://github.com/evidence-dev/evidence/assets/54364088/0dd965dd-fade-4a0f-afd2-119fa4ee9cfe)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
