### PR TITLE
fix: update deprecated data.query syntax used for stacked charts in example project

### DIFF
--- a/.changeset/big-hornets-hunt.md
+++ b/.changeset/big-hornets-hunt.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/components': patch
+---
+
+update deprecated data.query syntax used for stacked charts in example project

--- a/sites/example-project/src/pages/charts/stacked-charts/+page.md
+++ b/sites/example-project/src/pages/charts/stacked-charts/+page.md
@@ -60,11 +60,11 @@ select 'China' as country, 101 as value, 1996 as year
 
 ## Examples
 
-<BarChart data={data.simpler_bar_unordered} x=year y=value series=country type=stacked100/>
+<BarChart data={simpler_bar_unordered} x=year y=value series=country type=stacked100/>
 
-<BarChart swapXY=true xType=category data={data.simpler_bar_unordered} x=year y=value series=country type=stacked100 yAxisTitle=true/>
+<BarChart swapXY=true xType=category data={simpler_bar_unordered} x=year y=value series=country type=stacked100 yAxisTitle=true/>
 
-<AreaChart data={data.simpler_bar_unordered} x=year y=value series=country type=stacked100/>
+<AreaChart data={simpler_bar_unordered} x=year y=value series=country type=stacked100/>
 
 ## Issues
 
@@ -75,7 +75,7 @@ select 'China' as country, 101 as value, 1996 as year
 </Chart>
 
 Y-axis title gets cut off when 100% stack is used:
-<BarChart xType=category data={data.simpler_bar_unordered} x=year y=value series=country type=stacked100 yAxisTitle=true/>
+<BarChart xType=category data={simpler_bar_unordered} x=year y=value series=country type=stacked100 yAxisTitle=true/>
 
 ## Single Series Stack
 


### PR DESCRIPTION
### Description

Changes:
- In example-poject, /charts/stacked-charts/ , sql queries were not working due to deprecated data={date.query} syntax. Updated to data={query}

closes #1394 

unable to reproduce issue#1394, truncated date string are working when used as x-axis in stacked bar chart

![image](https://github.com/evidence-dev/evidence/assets/54364088/91ad7b10-9390-4d27-88e6-eead76de2d27)

query used:
````
```sql needful_things
select
    substr(order_datetime,1,7) as date,
    category as category,
    sum(sales) as sales_usd0
from needful_things.orders
group by 1, 2
```
<BarChart data={needful_things} x=date y=sales_usd0 series=category type=stacked100/>
````

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
