### PR TITLE
fix: DataTable pagination input box width overflow

### DIFF
--- a/.changeset/lucky-carrots-end.md
+++ b/.changeset/lucky-carrots-end.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix: DataTable pagination input box width overflow

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -182,6 +182,7 @@
 	let index = 0;
 
 	let inputPage = null;
+	$: inputPageElWidth = `${(inputPage ?? 1).toString().length}ch`;
 
 	// ---------------------------------------------------------------------------------------
 	// SEARCH
@@ -624,11 +625,13 @@
 							<Icon src={ChevronLeft} class="h-[0.83em]" />
 						</div>
 					</button>
-					<span class="page-count"
-						>Page <input
+					<span class="page-count">
+						Page
+						<input
 							class="page-input"
 							class:hovering
 							class:error={inputPage > pageCount}
+							style="width: {inputPageElWidth};"
 							type="number"
 							bind:value={inputPage}
 							on:keyup={() => goToPage((inputPage ?? 1) - 1)}
@@ -636,11 +639,11 @@
 							placeholder={currentPage}
 						/>
 						/
-						<span class="page-count ml-1">{pageCount.toLocaleString()}</span></span
-					>
+						<span class="page-count ml-1">{pageCount.toLocaleString()}</span>
+					</span>
 					<span class="print-page-count">
-						{displayedPageLength.toLocaleString()} of {totalRows.toLocaleString()} records</span
-					>
+						{displayedPageLength.toLocaleString()} of {totalRows.toLocaleString()} records
+					</span>
 					<button
 						aria-label="next-page"
 						class="page-changer"
@@ -817,9 +820,9 @@
 	}
 
 	.page-input {
-		width: 23px;
+		box-sizing: content-box;
 		text-align: center;
-		padding: 0;
+		padding: 0.25em 0.5em;
 		margin: 0;
 		border: 1px solid transparent;
 		border-radius: 4px;

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -327,6 +327,7 @@
 	let currentPage = 1;
 
 	$: currentPage = Math.ceil((index + rows) / rows);
+	$: currentPageElWidth = `${(currentPage ?? 1).toString().length}ch`;
 	let max;
 
 	$: goToPage = (pageNumber) => {
@@ -631,7 +632,7 @@
 							class="page-input"
 							class:hovering
 							class:error={inputPage > pageCount}
-							style="width: {inputPageElWidth};"
+							style="width: {inputPage ? inputPageElWidth : currentPageElWidth};"
 							type="number"
 							bind:value={inputPage}
 							on:keyup={() => goToPage((inputPage ?? 1) - 1)}


### PR DESCRIPTION
### Description
closes #1204 

Changes:
- Added reactive `inputPageElWidth` variable to dynamically update input box width based on input.
![image](https://github.com/evidence-dev/evidence/assets/54364088/454ce4b0-7aea-444a-abbb-c37f4f534cae)

query used:
````
```sql needful_things
select * from needful_things.orders
```

<DataTable data={needful_things}/>
````

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
