### PR TITLE
Fix scrollbar appearing when hovering last chart on page

### DIFF
--- a/.changeset/sour-papayas-act.md
+++ b/.changeset/sour-papayas-act.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix scrollbar appearing on last chart on page

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -118,7 +118,7 @@
 				</div>
 			{/if}
 			{#if !$navigating}
-				<article id="evidence-main-article" class="select-text markdown">
+				<article id="evidence-main-article" class="select-text markdown pb-10">
 					<slot name="content" />
 				</article>
 			{:else}


### PR DESCRIPTION
### Description
When hovering the last chart on a page, occasionally a scroll would appear on the page.

This adds padding to the article to eliminate the scrollbar.

#### Before
![CleanShot 2024-04-24 at 16 01 20](https://github.com/evidence-dev/evidence/assets/12602440/1aba5e38-fc3c-4e78-b1ed-7f982920b228)

#### After
![CleanShot 2024-04-24 at 16 02 11](https://github.com/evidence-dev/evidence/assets/12602440/ef6b231b-eb3b-4292-8c18-4e710ec57dba)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)