### PR TITLE
fix: adds bottom margin on LinkButton

### DIFF
--- a/.changeset/spotty-lions-sleep.md
+++ b/.changeset/spotty-lions-sleep.md
@@ -1,3 +1,3 @@
 ---
-'@evidence-dev/core-components': major
+'@evidence-dev/core-components': patch
 ---

--- a/.changeset/spotty-lions-sleep.md
+++ b/.changeset/spotty-lions-sleep.md
@@ -1,0 +1,3 @@
+---
+'@evidence-dev/core-components': major
+---

--- a/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.svelte
@@ -8,7 +8,7 @@
 
 <a
 	href={url}
-	class="font-ui font-normal text-base no-underline border mt-5 rounded-lg py-2 px-3 inline-block transition hover:ease-in hover:border-blue-200 hover:bg-blue-100 hover:no-underline hover:text-gray-800 focus:text-gray-900 focus:border-blue-200"
+	class="font-ui font-normal text-base no-underline border my-5 rounded-lg py-2 px-3 inline-block transition hover:ease-in hover:border-blue-200 hover:bg-blue-100 hover:no-underline hover:text-gray-800 focus:text-gray-900 focus:border-blue-200"
 >
 	<div>
 		<span>


### PR DESCRIPTION
### Description

Resolves #1125 

<img width="935" alt="Screenshot 2024-04-27 at 11 16 43 AM" src="https://github.com/evidence-dev/evidence/assets/82795074/8fcc33e4-3c50-4823-9884-665909899a11">


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
