### PR TITLE
 Support for AAD authentication in MSSQL connector

### DIFF
--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -87,13 +87,13 @@ const buildConfig = function (database) {
 	const trust_server_certificate = database.trust_server_certificate ?? 'false';
 	const encrypt = database.encrypt ?? 'true';
 
-	port = parseInt(database.port ?? 1433)
-	authentication = { type: database.authenticationType }
+	port = parseInt(database.port ?? 1433);
+	authentication = { type: database.authenticationType };
 	options = {
 		trustServerCertificate:
 			trust_server_certificate === 'true' || trust_server_certificate === true,
 		encrypt: encrypt === 'true' || encrypt === true
-	}
+	};
 
 	if (database.authenticationType === 'default') {
 		return {
@@ -105,8 +105,7 @@ const buildConfig = function (database) {
 			port: port,
 			options: options
 		};
-	}
-	else if (database.authenticationType === 'azure-active-directory-default') {
+	} else if (database.authenticationType === 'azure-active-directory-default') {
 		return {
 			server: database.server,
 			database: database.database,
@@ -120,7 +119,7 @@ const buildConfig = function (database) {
 /** @type {import("@evidence-dev/db-commons").RunQuery<MsSQLOptions>} */
 const runQuery = async (queryString, database = {}, batchSize = 100000) => {
 	try {
-		const config = buildConfig(database)
+		const config = buildConfig(database);
 		const pool = await mssql.connect(config);
 
 		const cleaned_string = cleanQuery(queryString);
@@ -202,7 +201,7 @@ module.exports.options = {
 			}
 		],
 		children: {
-			'default': {
+			default: {
 				user: {
 					title: 'Username',
 					secret: false,
@@ -214,7 +213,7 @@ module.exports.options = {
 					secret: true,
 					type: 'string',
 					required: true
-				},
+				}
 			},
 			'azure-active-directory-default': {}
 			// TODO: authentication types not supported yet:
@@ -228,7 +227,6 @@ module.exports.options = {
 			// - [ ] azure-active-directory-msi-vm
 			// - [ ] azure-active-directory-msi-app-service
 			// - [ ] azure-active-directory-service-principal-secret
-
 		}
 	},
 	server: {


### PR DESCRIPTION
### Description

I needed to use this block to be able to login with Active Directory. This is useful if the database uses a passwordless strategy.

```
authentication: {
    type: "azure-active-directory-default"
  }
```

### Screenshots

<details>

<img width="580" alt="Screenshot 2024-05-01 at 14 08 17" src="https://github.com/evidence-dev/evidence/assets/6161385/e01455b6-2c00-485e-9f5b-e1621b0d3fa5">
<img width="580" alt="Screenshot 2024-05-01 at 14 08 30" src="https://github.com/evidence-dev/evidence/assets/6161385/427a544a-3b0f-4206-8489-57f96c21f032">

</details>

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
