### PR TITLE
Handle missing values for multiple y columns

### DIFF
--- a/.changeset/fuzzy-weeks-watch.md
+++ b/.changeset/fuzzy-weeks-watch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/component-utilities': patch
+---
+
+Handle nulls for multiple y columns

--- a/packages/lib/component-utilities/src/getCompletedData.js
+++ b/packages/lib/component-utilities/src/getCompletedData.js
@@ -76,10 +76,22 @@ export default function getCompletedData(_data, x, y, series, nullsZero = false,
 	for (const value of Object.values(groups)) {
 		const nullySpec = series ? { [series]: null } : {};
 		if (nullsZero) {
-			nullySpec[y] = 0;
+			if (y instanceof Array) {
+				for (let i = 0; i < y.length; i++) {
+					nullySpec[y[i]] = 0;
+				}
+			} else {
+				nullySpec[y] = 0;
+			}
 		} else {
 			// Ensure null for consistency
-			nullySpec[y] = null;
+			if (y instanceof Array) {
+				for (let i = 0; i < y.length; i++) {
+					nullySpec[y[i]] = null;
+				}
+			} else {
+				nullySpec[y] = null;
+			}
 		}
 
 		if (series) {
@@ -97,5 +109,6 @@ export default function getCompletedData(_data, x, y, series, nullsZero = false,
 		output.push(tidy(value, ...tidyFuncs));
 	}
 	if (xIsDate) return output.flat().map((r) => ({ ...r, [x]: new Date(r[x]) }));
+
 	return output.flat();
 }

--- a/sites/example-project/src/pages/charts/line-chart/+page.md
+++ b/sites/example-project/src/pages/charts/line-chart/+page.md
@@ -80,7 +80,7 @@ select '2023-04-14' as start_date, null as end_date, 'Campaign C' as label
 ```
 
 <LineChart 
-    data=orders_by_month
+    data={orders_by_month}
     x=month
     y=sales_usd0k 
     yAxisTitle="Sales per Month"
@@ -146,4 +146,29 @@ select '2023-04-14' as start_date, null as end_date, 'Campaign C' as label
         '#fcdad9',
         ]
     }
+/>
+
+## Missing Values with Multiple y Columns
+
+```sql lines
+select '2021-01-01'::date as date, null as value, null as value2
+union all
+select '2021-01-02'::date as date, null as value, null as value2
+union all
+select '2021-01-03'::date as date, null as value, null as value2
+union all
+select '2021-01-04'::date as date, 100 as value, 200 as value2
+union all
+select '2021-01-05'::date as date, null as value, null as value2
+union all
+select '2021-01-06'::date as date, null as value, null as value2
+union all
+select '2021-01-07'::date as date, null as value, null as value2
+```
+
+<LineChart
+  data={lines}
+  x=date
+  y={['value','value2']}
+  handleMissing=zero
 />


### PR DESCRIPTION
### Description
When passing multiple columns to `y`, using `handleMissing` did not take effect. This PR iterates through the y columns to set nulls to the appropriate values.

#### Before
![CleanShot 2024-05-02 at 12 45 29@2x](https://github.com/evidence-dev/evidence/assets/12602440/ad9d9000-4420-4924-ab2d-696c29378f38)


#### After
![CleanShot 2024-05-02 at 12 47 28@2x](https://github.com/evidence-dev/evidence/assets/12602440/9450dc94-bc28-4083-90a0-3c35af2df90a)



### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
