### PR TITLE
Fix Details component open option

### DIFF
--- a/.changeset/short-grapes-unite.md
+++ b/.changeset/short-grapes-unite.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix Details component open option

--- a/packages/ui/core-components/src/lib/unsorted/ui/Details.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Details.svelte
@@ -5,6 +5,7 @@
 <script>
 	export let title = 'Details';
 	export let open = false;
+	$: open = open === 'true' || open === true;
 	import { slide } from 'svelte/transition';
 </script>
 


### PR DESCRIPTION
### Description
`open=false` was not working in the Details component. This fixes that behaviour

### Checklist
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)