### PR TITLE
fix:  text inputs

### DIFF
--- a/.changeset/sweet-ducks-peel.md
+++ b/.changeset/sweet-ducks-peel.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+TextInput now respects Unset more effectively

--- a/.changeset/wise-rats-leave.md
+++ b/.changeset/wise-rats-leave.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/sdk': patch
+---
+
+SetTrackProxy is now callable to ensure that function values don't break pages

--- a/packages/lib/sdk/src/usql/setTrackProxy/setTrackProxy.js
+++ b/packages/lib/sdk/src/usql/setTrackProxy/setTrackProxy.js
@@ -10,9 +10,13 @@ export const setTrackProxy = (
 ) => {
 	if (parent && !parent[IsSetTracked]) throw new Error(`SetTracked parent must be SetTracked`);
 
+	const wrapped = Object.assign(() => {}, root ?? {});
+
+	console.log(wrapped());
+
 	/** @type {Array<string|number|symbol>} */
-	const modifiedKeys = Object.keys(root ?? {});
-	const self = new Proxy(root ?? {}, {
+	const modifiedKeys = Object.keys(wrapped);
+	const self = new Proxy(wrapped, {
 		get(target, prop) {
 			switch (prop) {
 				case Unset:

--- a/packages/lib/sdk/src/usql/setTrackProxy/setTrackProxy.spec.js
+++ b/packages/lib/sdk/src/usql/setTrackProxy/setTrackProxy.spec.js
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { IsSetTracked, Unset, hasUnsetValues, setTrackProxy } from './setTrackProxy.js';
 
 describe('setTrackProxy', () => {
+	describe('function emulation', () => {
+		it('should be callable, even if a function is not assigned', () => {
+			const v = setTrackProxy();
+			expect(v()).toBeUndefined();
+		});
+	});
 	describe('stringification', () => {
 		it('should respect default stringification for set values', () => {
 			// v is a bare object (e.g. nothing set on it)

--- a/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
@@ -31,16 +31,20 @@
 	export let unsafe = false;
 	$: unsafe = unsafe === true || unsafe === 'true';
 
+	let touched = false;
 	$: {
-		let sqlString = value;
-		if (!unsafe) sqlString = sqlString.replaceAll("'", "''");
-		$inputs[name] = {
-			toString() {
-				return sqlString;
-			},
-			sql: `'${sqlString}'`,
-			search: (col) => `damerau_levenshtein(${col}, '${sqlString}')`
-		};
+		if (value) touched = true;
+		if (touched) {
+			let sqlString = value;
+			if (!unsafe) sqlString = sqlString.replaceAll("'", "''");
+			$inputs[name] = {
+				toString() {
+					return sqlString;
+				},
+				sql: `'${sqlString}'`,
+				search: (col) => `damerau_levenshtein(${col}, '${sqlString}')`
+			};
+		}
 	}
 
 	let value = defaultValue;

--- a/sites/test-env/pages/text-input.md
+++ b/sites/test-env/pages/text-input.md
@@ -1,0 +1,51 @@
+<script> import {Unset} from '@evidence-dev/sdk/usql'; </script>
+
+# Text Input
+
+## Text Input
+<TextInput name=search_input/>
+
+Input: {inputs.search_input}  
+Input is set: {!inputs.search_input[Unset]}
+
+## Text Input with default
+<TextInput name=search_input_with_default defaultValue="Hello World" />
+
+Input: {inputs.search_input_with_default}  
+Input is set: {!inputs.search_input_with_default[Unset]}
+
+## Text Input with Title
+
+<TextInput name=another_search_input title="Search"/>
+
+Input: {inputs.another_search_input}  
+Input is set: {!inputs.another_search_input[Unset]}
+
+
+## Text Input with Custom Placeholder
+
+<TextInput name=another_search title="Freetext Search" placeholder="Start typing"/>
+
+Input: {inputs.another_search}  
+Input is set: {!inputs.another_search[Unset]}
+
+## Text Input with Default Value
+
+<TextInput name=yet_another_search title="Default Selected" defaultValue="Sporting"/>
+
+Input: {inputs.yet_another_search}
+
+Search Value: {inputs.yet_another_search.search?.('column_name')}
+
+<!-- TODO: Fix this which breaks when you pass input into a query
+
+## Filter a query with a text input
+
+
+```sql just_the_named_categories
+SELECT * FROM orders 
+WHERE category LIKE '%${inputs.search_input}'
+```
+
+<DataTable data={just_the_named_categories}/>
+ -->


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

- text input respects unset now
- setTrackProxy is now callable (returns undefined when unset, but doesn't break b/c not a function)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
