### PR TITLE
Date range default value

### DIFF
--- a/.changeset/early-crews-compete.md
+++ b/.changeset/early-crews-compete.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/components': patch
+---
+
+Add defaulValue to DateRange

--- a/.changeset/early-crews-compete.md
+++ b/.changeset/early-crews-compete.md
@@ -3,4 +3,4 @@
 '@evidence-dev/components': patch
 ---
 
-Add defaulValue to DateRange
+Add defaultValue to DateRange

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
@@ -35,6 +35,9 @@
 	/** @type {string | undefined} */
 	export let dates;
 
+	/** @type {string | undefined} */
+	export let defaultValue;
+
 	const exec = getQueryFunction();
 	let query;
 	$: if (data && dates) {
@@ -104,6 +107,7 @@
 				start={startString}
 				end={endString}
 				loaded={$query?.ready ?? true}
+				{defaultValue}
 			/>
 		{/if}
 	</div>

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
@@ -34,16 +34,12 @@
 	export let start;
 	/** @type {string} */
 	export let end;
+	/** @type {string | undefined} */
+	export let defaultValue;
 	export let loaded = true;
 
 	$: calendarStart = YYYYMMDDToCalendar(start);
 	$: calendarEnd = YYYYMMDDToCalendar(end);
-
-	function updateDateRange(start, end) {
-		selectedDateRange = { start, end };
-	}
-
-	$: updateDateRange(calendarStart, calendarEnd);
 
 	/** @type {{label: string, group: string, range: import('bits-ui').DateRange}[]} */
 	$: presets = [
@@ -144,6 +140,14 @@
 	let selectedPreset;
 	let placeholder;
 	$: setPlaceholderDefault(calendarEnd);
+
+	$: if (defaultValue) {
+		let foundPreset = presets.find((p) => p.label.toLowerCase() === defaultValue.toLowerCase());
+		if (foundPreset) {
+			selectedDateRange = foundPreset.range;
+			selectedPreset = foundPreset;
+		}
+	}
 </script>
 
 <div class="flex">
@@ -204,6 +208,7 @@
 				onValueChange={(value) => {
 					selectedPreset = undefined;
 					selectedDateRange = value;
+					defaultValue = undefined;
 				}}
 				minValue={calendarStart}
 				maxValue={calendarEnd}
@@ -216,6 +221,7 @@
 			if (!v) return;
 			selectedDateRange = presets.filter((presets) => presets.label == v.label)[0].range;
 			selectedPreset = v;
+			defaultValue = undefined;
 		}}
 		bind:selected={selectedPreset}
 		disabled={!loaded}

--- a/sites/example-project/src/pages/input-components/date-range/+page.md
+++ b/sites/example-project/src/pages/input-components/date-range/+page.md
@@ -12,3 +12,15 @@ select * from ${orders_by_month} where month between '${inputs.range.start}' and
 <DateRange data={orders_by_month} dates=month name=range/>
 
 <BarChart data={orders_by_month_filtered} x="month" y="sales_usd0k" />
+
+
+
+```sql orders_by_month_filtered_by_default_value
+select * from ${orders_by_month} where month between '${inputs.range_default.start}' and '${inputs.range_default.end}'
+```
+
+# Date Picker with default value
+
+<DateRange data={orders_by_month} dates=month name=range_default defaultValue="Last 90 days"/>
+
+<BarChart data={orders_by_month_filtered_by_default_value} x="month" y="sales_usd0k" />


### PR DESCRIPTION
### Description

This PR aims to add a defaultValue parameter to the DateRange input component.
The defaultValue has the purpose to define a default range when the component is first loaded.

To use is to simply add the defaultValue as below:
```js
<DateRange 
    data={orders_by_month} 
    dates=month 
    name=range_default 
    defaultValue="Last 90 days"
/>
```
Then, the DateRange will initialize with the defaultValue provided

<img width="755" alt="Screenshot 2024-05-08 at 19 14 02" src="https://github.com/evidence-dev/evidence/assets/67326251/1d23832b-1d5d-4380-a55b-70a3c4e7c196">

If the parameter is not provided or does not comply with the labels available on the `preset` variable, then the component's behavior should be the same as previously

<img width="745" alt="Screenshot 2024-05-08 at 19 13 52" src="https://github.com/evidence-dev/evidence/assets/67326251/ce2531b1-7e28-43b8-9dc5-cc3c201a0bc1">

Closes #1984

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [X] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
