### PR TITLE
Added test for testing false values

### DIFF
--- a/packages/lib/plugin-connector/src/data-sources/get-sources.spec.js
+++ b/packages/lib/plugin-connector/src/data-sources/get-sources.spec.js
@@ -87,4 +87,10 @@ describe('loadSourceOptions', () => {
 		expect('ssl' in result).toBeTruthy();
 		expect('rejectUnauthorized' in result.ssl).toBeTruthy();
 	});
+	it('should pickup boolean flags', () => {
+		vi.stubEnv('EVIDENCE_SOURCE__source__ssl__rejectUnauthorized', 'false');
+		const result = loadSourceOptions('source');
+		expect('ssl' in result).toBeTruthy();
+		expect('rejectUnauthorized' in result.ssl).toBeFalsy(); // <-- this is failing
+	});
 });


### PR DESCRIPTION
### Description

It seems that `EVIDENCE_SOURCE__source__ssl__rejectUnauthorized="false"` is picked up incorrectly (always treated as true).  This failing test might be an indication as to why.  Seems to have to do with interpreting strings as boolean in loading source options.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
