### PR TITLE
feat(UI): Ability to select all dropdown options by default

### DIFF
--- a/.changeset/big-walls-rule.md
+++ b/.changeset/big-walls-rule.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'my-evidence-project': patch
+---
+
+Adding a selectAllByDefault property to Dropdowns

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -58,6 +58,12 @@
 
 	export let noDefault = false;
 
+	/**
+	 * When true, all values will be selected by default
+	 * @type {boolean}
+	 */
+	export let selectAllByDefault = false;
+
 	const state = dropdownOptionStore(multiple);
 	const { selectedOptions, options, addOption, removeOption, flagOption, select, deselectAll } =
 		state;
@@ -140,6 +146,7 @@
 		label,
 		order = undefined,
 		where = undefined;
+
 	/** @type {import("@evidence-dev/component-utilities/buildQuery.js").QueryProps}*/
 	const { results, update } = buildReactiveInputQuery(
 		{ value, data, label, order, where },
@@ -241,6 +248,11 @@
 					if (presentValues.length) return; // no need to take action
 				}
 
+				if (selectAllByDefault) {
+					selectAllOptions();
+					return;
+				}
+
 				if (noDefault) {
 					deselectAll();
 					return;
@@ -268,6 +280,12 @@
 				console.error(`Error while updating Dropdown Query: ${err.message}`);
 			}
 		);
+	}
+
+	function selectAllOptions() {
+		$queryOptions.forEach((opt) => {
+			flagOption([opt, DropdownValueFlag.FORCE_SELECT]);
+		});
 	}
 </script>
 
@@ -364,14 +382,7 @@
 							{#if multiple}
 								{#if !disableSelectAll}
 									<div class="-mx-1 h-px bg-gray-200" />
-									<Command.Item
-										class="justify-center text-center"
-										onSelect={() => {
-											$queryOptions.forEach((opt) => {
-												flagOption([opt, DropdownValueFlag.FORCE_SELECT]);
-											});
-										}}
-									>
+									<Command.Item class="justify-center text-center" onSelect={selectAllOptions}>
 										Select all
 									</Command.Item>
 								{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -248,7 +248,7 @@
 					if (presentValues.length) return; // no need to take action
 				}
 
-				if (selectAllByDefault) {
+				if (selectAllByDefault && multiple) {
 					selectAllOptions();
 					return;
 				}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
@@ -23,6 +23,10 @@
 	{@const data = Query.create(`SELECT id as value, tag as label from hashtags`, query)}
 	<Dropdown multiple name="test" {data} value="value" label="label" />
 </Story>
+<Story name="Select all by default">
+	{@const data = Query.create(`SELECT id as value, tag as label from hashtags`, query)}
+	<Dropdown multiple name="test" {data} value="value" label="label" selectAllByDefault />
+</Story>
 <Story name="With a default value">
 	{@const data = Query.create(`SELECT id as value, tag as label from hashtags`, query)}
 	<Dropdown defaultValue={0} name="test1" {data} value="value" label="label" />

--- a/sites/docs/pages/components/dropdown.md
+++ b/sites/docs/pages/components/dropdown.md
@@ -247,6 +247,15 @@ SQL where fragment to filter options by (e.g., where sales > 40000)
 Hide the component when the report is printed
 
 </PropListing>
+<PropListing 
+    name="selectAllByDefault"
+    options={["true", "false"]}
+    defaultValue="false"
+>
+
+When `multiple` is `true`, select all available options
+
+</PropListing>
 
 # DropdownOption
 


### PR DESCRIPTION
### Description

This PR adds the ability to select all available options in a dropdown by default. I'm just reusing the same action as the `Select all` button.

resolve #1997 #1991 

https://github.com/evidence-dev/evidence/assets/16650656/885fa96a-2908-428f-8503-ccae802ab265

Documentation updates:
![CleanShot 2024-05-12 at 16 58 22@2x](https://github.com/evidence-dev/evidence/assets/16650656/bbaa3d9c-5c07-45dc-8f01-ef371962db00)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
