### PR TITLE
docs: update location of `supportedLanguages.cjs`

### DIFF
--- a/sites/docs/pages/core-concepts/syntax/index.md
+++ b/sites/docs/pages/core-concepts/syntax/index.md
@@ -135,7 +135,7 @@ There were {orders_by_month[0].number_of_orders} orders last month.
 
 It can be useful to include code that isn't SQL, eg for documentation or examples.
 
-If a code fence is named one of the [reserved language names](https://github.com/evidence-dev/evidence/blob/main/packages/preprocess/src/utils/supportedLanguages.cjs), such as `python` or `r`, the code fence will render a code block. The code is _not_ executed.
+If a code fence is named one of the [reserved language names](https://github.com/evidence-dev/evidence/blob/main/packages/lib/preprocess/src/utils/supportedLanguages.cjs), such as `python` or `r`, the code fence will render a code block. The code is _not_ executed.
 
 ````markdown
 ```python

--- a/sites/docs/pages/reference/markdown.md
+++ b/sites/docs/pages/reference/markdown.md
@@ -95,7 +95,7 @@ WHERE category = 'Sinister Toys'
 ```
 ````
 
-The exception is if you use one of the [reserved language names](https://github.com/evidence-dev/evidence/blob/main/packages/preprocess/supportedLanguages.cjs), which will render the code in a code block.
+The exception is if you use one of the [reserved language names](https://github.com/evidence-dev/evidence/blob/main/packages/lib/preprocess/src/utils/supportedLanguages.cjs), which will render the code in a code block.
 
 ````markdown
 ```python


### PR DESCRIPTION
### Description

This is a small PR. The #710 and #1716 PRs moved the location of `supportedLanguages.cjs` between different places. This PR adjusts sources to changes.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
