### PR TITLE
Ensure dimension grid inputs default to true while loading their data

### DIFF
--- a/.changeset/perfect-flowers-prove.md
+++ b/.changeset/perfect-flowers-prove.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Ensure dimension grid returns default 'true' state before source query has loaded

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.stories.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.stories.svelte
@@ -35,6 +35,20 @@
 	<DimensionGrid name="dimensiongrid" data={fakerSeries.airlines.flights.store} />
 </Story>
 
+<Story name="Loading State">
+	<div class="my-2 bg-gray-50 border-2 border-dashed font-mono rounded p-2 text-xs">
+		<dt class=" font-semibold">$inputs.dimensiongrid</dt>
+		<dd>{$inputStore.dimensiongrid}</dd>
+	</div>
+	<DimensionGrid
+		name="dimensiongrid"
+		data={Query.create('SELECT * FROM series_demo_source.flights', query, {
+			disableCache: true,
+			noResolve: true
+		})}
+	/>
+</Story>
+
 <Story name="Labelled Metric">
 	<DimensionGrid data={fakerSeries.airlines.flights.store} metricLabel="Flights" />
 </Story>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.svelte
@@ -5,6 +5,8 @@
 <script>
 	import { QueryLoad } from '../../atoms/query-load/index.js';
 	import DimensionGrid from './_DimensionGrid.svelte';
+	import { getContext } from 'svelte';
+	import { INPUTS_CONTEXT_KEY } from '@evidence-dev/component-utilities/globalContexts';
 
 	/** @type {import('@evidence-dev/sdk/usql').Query} */
 	export let data;
@@ -16,6 +18,9 @@
 	export let limit = 10;
 	/** @type {string} */
 	export let name;
+
+	const inputs = getContext(INPUTS_CONTEXT_KEY);
+	$inputs[name] = true;
 </script>
 
 <QueryLoad {data} let:loaded>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/dimensionGridQuery.js
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/dimensionGridQuery.js
@@ -1,4 +1,3 @@
-
 // Where clause that optionally excludes any reference to the excluded dimension
 export const getWhereClause = function (selectedDimensions, excludeDimension) {
 	let whereClause = 'true';

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/dimensionGridQuery.js
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/dimensionGridQuery.js
@@ -1,6 +1,3 @@
-// SQL query to get a long dimensional table
-// dimension | dimensionName | metric | filteredMetric - (metric filtered by the whereClause)
-// optionally includes an "Others" row and a "Grand Total" row, each which respect the whereClause
 
 // Where clause that optionally excludes any reference to the excluded dimension
 export const getWhereClause = function (selectedDimensions, excludeDimension) {
@@ -21,6 +18,9 @@ export const getWhereClause = function (selectedDimensions, excludeDimension) {
 	}
 	return whereClause;
 };
+
+// SQL query to get a long dimensional table
+// dimension | dimensionName | metric | filteredMetric - (metric filtered by the whereClause) | percentOfTotal - (metric / total(metric))
 
 export const getDimensionCutQuery = function (
 	/** @type {import("@evidence-dev/sdk/usql").Query} */


### PR DESCRIPTION
### Description

Sets the default input state for the dimension grid _before_ the data query has loaded. 

