### PR TITLE
Fix tooltip title autocasing in maps

### DIFF
--- a/.changeset/shaggy-sloths-fail.md
+++ b/.changeset/shaggy-sloths-fail.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix auto-casing on tooltip titles

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -287,7 +287,10 @@ export class EvidenceMap {
 			fieldClass: item.fieldClass ?? 'default-field-class', // Example default class
 			valueClass: item.valueClass ?? 'default-value-class', // Example default class
 			fmt: item.fmt ?? 'num0', // Default formatting
-			formatColumnTitle: item.formatColumnTitle === undefined ? true : item.formatColumnTitle,
+			formatColumnTitle:
+				item.formatColumnTitle === undefined && item.title === undefined
+					? true
+					: item.formatColumnTitle,
 			contentType: item.contentType ?? 'text', // Default to 'text'
 			linkLabel: item.linkLabel ?? undefined
 		}));

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/Map.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/Map.stories.svelte
@@ -27,6 +27,7 @@
 			lat="lat"
 			long="long"
 			value="sales"
+			tooltip={[{ title: 'Sales, LTM' }]}
 			colorPalette={['white', 'green']}
 			size="20"
 			opacity="0.7"


### PR DESCRIPTION
### Description

When `title` is supplied in a custom map tooltip, auto-casing should not apply.

### Example with `{title: 'Sales, LTM'}`

#### Before
![CleanShot 2024-05-28 at 21 04 29@2x](https://github.com/evidence-dev/evidence/assets/12602440/ba412ad1-50a5-49d4-9b02-c79392961cc5)


#### After
![CleanShot 2024-05-28 at 21 09 45@2x](https://github.com/evidence-dev/evidence/assets/12602440/afd6f497-706b-4f65-8792-d101b382c7d2)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] ~~I have added to the docs where applicable~~
- [ ] ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
