### PR TITLE
Remove Docker, Break out Motivation as own page

### DIFF
--- a/sites/docs/pages/index.md
+++ b/sites/docs/pages/index.md
@@ -11,21 +11,7 @@ og:
 
 Evidence is an open source framework for building data products with SQL - things like reports, decision-support tools, and embedded dashboards. It's a code-driven alternative to drag-and-drop BI tools.
 
-## Motivation
-
-We think it's still too difficult to build high quality data products. Businesses are stuck with BI software that delivers slow and clunky outputs, and analysts are stuck manually configuring reports.
-
-Our mission is to give you the tools to deliver production-quality data products that look and feel more like the [New York Times' data journalism](https://www.nytimes.com/interactive/2023/us/covid-cases.html) than a drag-and-drop dashboard.
-
-Evidence combines the best of modern web frameworks with the best parts of BI:
-
-- **Code-driven workflows:** Use your IDE, version control, and CI/CD tools
-- **First-class text support:** Add context, explanation and insight to your reports
-- **Programmatic features:** Use loops, conditionals, and templated pages to generate content from data
-- **High performance:** Evidence projects build into fast and reliable web application
-- **Lightweight setup:** Install locally and start building reports in just a few minutes
-
-To get started, [install Evidence](/install-evidence).
+Install Evidence with the [VSCode Extension](vscode:extension/Evidence.evidence-vscode), or see other [installation options](/install-evidence).
 
 ## How does Evidence work?
 

--- a/sites/docs/pages/install-evidence.md
+++ b/sites/docs/pages/install-evidence.md
@@ -1,11 +1,11 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 hide_table_of_contents: false
 title: Install Evidence
 description: Install Evidence with the VSCode Extension, from the command line, alongside dbt, or using Codespaces.
 ---
 
-The easiest way to get started with Evidence is to use the VSCode Extension.
+The easiest way to get started with Evidence is to use the [VSCode Extension](vscode:extension/Evidence.evidence-vscode).
 
 ## VSCode Extension
 
@@ -73,13 +73,6 @@ This currently needs to be done from the terminal, rather than from the dbt Clou
 
 **Note:** Codespaces is much faster on the Desktop app. After the Codespace has booted, select the hamburger menu &rarr; Open in VS Code Desktop.
 
-</Tab>
-
-<Tab value="docker" label="Docker">
-
-Evidence provides a development Docker image.
-
-See our [Docker Development Environment repository](https://github.com/evidence-dev/docker-devenv) for instructions.
 </Tab>
 </Tabs>
 

--- a/sites/docs/pages/motivation.md
+++ b/sites/docs/pages/motivation.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 2
+title: Motivation
+description: It's still too difficult to build high quality data products. We give you the tools to deliver production-quality data products that feel more like the New York Times' data journalism than a drag-and-drop dashboard.
+og:
+  image: /img/how-it-works.png
+---
+
+We think it's still too difficult to build high quality data products. Businesses are stuck with BI software that delivers slow and clunky outputs, and analysts are stuck manually configuring reports.
+
+Our mission is to give you the tools to deliver production-quality data products that look and feel more like the [New York Times' data journalism](https://www.nytimes.com/interactive/2023/us/covid-cases.html) than a drag-and-drop dashboard.
+
+Evidence combines the best of modern web frameworks with the best parts of BI:
+
+- **Code-driven workflows:** Use your IDE, version control, and CI/CD tools
+- **First-class text support:** Add context, explanation and insight to your reports
+- **Programmatic features:** Use loops, conditionals, and templated pages to generate content from data
+- **High performance:** Evidence projects build into fast and reliable web application
+- **Lightweight setup:** Install locally and start building reports in just a few minutes
+
+To get started, [install Evidence](/install-evidence).


### PR DESCRIPTION
### Description

- Remove Docker
![CleanShot 2024-05-30 at 13 29 43@2x](https://github.com/evidence-dev/evidence/assets/58074498/6b40044c-986a-4c03-8599-2ef5ee01b18c)

- Add VSCode marketplace deeplink
![CleanShot 2024-05-30 at 13 30 54](https://github.com/evidence-dev/evidence/assets/58074498/0588bf5a-2afe-4b10-bc16-6000a65024fa)


- Motivation section to own page
![CleanShot 2024-05-30 at 13 28 10@2x](https://github.com/evidence-dev/evidence/assets/58074498/b6003d23-f97e-4336-ab96-c7572c813e8c)

![CleanShot 2024-05-30 at 13 29 25@2x](https://github.com/evidence-dev/evidence/assets/58074498/90a66807-948d-41cb-8e87-cbb04e936f6d)





### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
