### PR TITLE
Fix Prism imports in CodeBlock

### DIFF
--- a/.changeset/three-pumpkins-watch.md
+++ b/.changeset/three-pumpkins-watch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix Prism imports in CodeBlock

--- a/packages/ui/core-components/src/lib/unsorted/ui/prismLoader.js
+++ b/packages/ui/core-components/src/lib/unsorted/ui/prismLoader.js
@@ -1,0 +1,10 @@
+export const loadPrismComponents = async () => {
+	const Prism = (await import('prismjs')).default;
+	await import('prismjs/components/prism-bash');
+	await import('prismjs/components/prism-sql');
+	await import('prismjs/components/prism-python');
+	await import('prismjs/components/prism-markdown');
+	await import('./prism-svelte.js');
+
+	return Prism;
+};

--- a/sites/docs/pages/components/area-map.md
+++ b/sites/docs/pages/components/area-map.md
@@ -13,7 +13,7 @@ sidebar_position: 1
     height=250
 />
 
-```html
+```svelte
 <AreaMap 
     data={la_zip_sales} 
     areaCol=zip_code
@@ -151,7 +151,7 @@ You can add a different basemap by passing in a basemap URL. You can find exampl
     borderWidth=0.5
 />
 
-```html
+```svelte
 <AreaMap 
     data={la_zip_sales} 
     areaCol=zip_code
@@ -179,7 +179,7 @@ You can add a different basemap by passing in a basemap URL. You can find exampl
     colorPalette={['yellow','orange','red','darkred']}
 />
 
-```html
+```svelte
 <AreaMap 
     data={la_zip_sales} 
     areaCol=zip_code
@@ -207,7 +207,7 @@ Pass in a `link` column to enable navigation on click of the point. These can be
     link=link_col
 />
 
-```html
+```svelte
 <AreaMap 
     data={la_zip_sales} 
     areaCol=zip_code


### PR DESCRIPTION
### Description
Aims to fix #2041 

Some Prism-related files were causing errors in the browser. These seemed to be triggered by a vite dependency optimization (which is triggered by pages in the `explore/` directory), but I believe the root cause is that `Prism` is not available at the time the other dependencies are imported.

There is some overlap and duplication of Prism usage in various places in the product - ideally we should create a consolidated component for these all to use:
- CodeBlock
- QueryViewer
- Settings > Value Formatting
- Possibly SQL console

### Checklist

- ~~[ ] For UI or styling changes, I have added a screenshot or gif showing before & after~~
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- ~~[ ] I have added to the docs where applicable~~ 
- ~~[ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~ 
