### PR TITLE
Fix/DataTable Ensure generateMarkdown adds ""  to code when column contains spaces

### DIFF
--- a/.changeset/fresh-starfishes-sin.md
+++ b/.changeset/fresh-starfishes-sin.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+added datatable to add in ' when it contains a space

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -693,7 +693,7 @@
 				{`<DataTable data={${queryID}}>`}
 				<br />
 				{#each Object.keys(data[0]) as column}
-					{`	<Column id=${column}/>`}
+					{`   <Column id=${column.includes(' ') ? `'${column}'` : column}/>`}
 					<br />
 				{/each}
 				{`</DataTable>`}


### PR DESCRIPTION
### Description

<!---
 generateMarkdown not showing the spaces
-->

### Checklist

- [x ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable

![image](https://github.com/evidence-dev/evidence/assets/55977578/ba651fa5-26bc-4fff-9e1a-db23832b5e65)

no big change before if your table columns had spaces i nthe name generateMarkdown wouldnt add ' behind it
now it does
yay