### PR TITLE
2084: reset to last page when current page is beyond pageCount, after…

### DIFF
--- a/.changeset/nasty-pumas-wonder.md
+++ b/.changeset/nasty-pumas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix stale pagination where current page extends beyond pageCount after a filter change

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -340,6 +340,9 @@
 		pageCount = Math.ceil(filteredData.length / rows);
 		displayedData = filteredData.slice(index, index + rows);
 		displayedPageLength = displayedData.length;
+		if (pageCount < currentPage) {
+			goToPage(pageCount - 1);
+		}
 	} else {
 		currentPage = 1;
 		displayedData = filteredData;


### PR DESCRIPTION
### Description

Addresses [Issue 2084](https://github.com/evidence-dev/evidence/issues/2084)

See the screenshots below for re-cap of pagination issue - essentially, when a filter changes and the current page is beyond the new `pageCount`, no detective or corrective action is currently taken.

The PR selects the last page in the set, as the "closest" to the previous page. An alternative might be to select the first page in the new set.

I tested with the example project's [Initially Filtered Table](http://localhost:3000/tables/initially-filtered-table/) example which is a good test for this.

Steps to test:
1. Navigate to the test above
2. Replace the existing "Bra" text in the external input filter, with the single character `a`
3. Navigate to page 3/3
4. Replace the external input filter text with the single character `e`, reducing results to 2 pages

![evidence-datatable-1](https://github.com/evidence-dev/evidence/assets/36790149/801f3d03-d71a-405d-9e16-b84709f823fd)
![evidence-datatable-2](https://github.com/evidence-dev/evidence/assets/36790149/f2e86f59-b077-4fd9-82ec-7cbe92c40ee1)
![evidence-datatable-3](https://github.com/evidence-dev/evidence/assets/36790149/7935c0a1-37d0-4a10-ae1d-780ded708161)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [X] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
