### PR TITLE
Datasource CLI Tweaks

### DIFF
--- a/packages/lib/sdk/src/plugins/datasources/evalSources.js
+++ b/packages/lib/sdk/src/plugins/datasources/evalSources.js
@@ -121,11 +121,11 @@ export const evalSources = async (dataPath, metaPath, filters, strict) => {
 			outputManifest.locatedFiles[source.name].push(table.name);
 			spinner.start('Processing...');
 			if (utils.isFiltered(table.name)) {
-				spinner.warn('This query not run due to filters');
+				spinner.info('Skipped');
 				continue;
 			}
 			if (utils.isCached(table.name, table.content)) {
-				spinner.warn('This query was not run because it is already cached');
+				spinner.info('From Cache');
 				logQueryEvent('cache-query', source.type, source.name);
 				continue;
 			}

--- a/packages/lib/sdk/src/plugins/datasources/wrapSimpleConnector.js
+++ b/packages/lib/sdk/src/plugins/datasources/wrapSimpleConnector.js
@@ -48,8 +48,8 @@ export const wrapSimpleConnector = (mod, source) => {
 
 				const stat = statSync(sourceFilePath);
 				let sourceFileContent;
-				if (stat.size > 1024 * 1024 * 128 /* 128 Megabytes */) {
-					console.debug(chalk.dim('Will not eagerly load files larger than 128 Megabytes.'));
+				if (stat.size > 1024 * 1024 * 32 /* 32 Megabytes */) {
+					console.debug(chalk.dim('Will not eagerly load files larger than 32 Megabytes.'));
 					sourceFileContent = '';
 				} else {
 					sourceFileContent = readFileSync(sourceFilePath, 'utf-8');


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

This addresses issues noted in #2065 

- The eager loading notification for large files (mostly CSV and DuckDB files) is behind the debug flag, and will not show the warning
- To manage the `no results returned` for some `needful_things` table, we need to modify the duckdb connector to an advanced connector and skip duckdb files, or find some way for simple connectors to indicate that a file is not a query. Either solution (or both) would be okay
- Verbiage has changed for skipped queries / sources
<img width="684" alt="image" src="https://github.com/evidence-dev/evidence/assets/10779616/f05f4539-ae22-4eac-85af-de7d92728b2d">

- `[Filtered] source name` has been hidden behind the debug flag, the filtered sources are now only presented as a count at the end by default to reduce noise

- `Skipping: Filtered` for queries has been changed to `This query was not run due to filters`

- `Skipping: Cached` for queries has been changed to `This query was not run because it is already cached`


### Checklist

- [ ] ~~For UI or styling changes, I have added a screenshot or gif showing before & after~~
- [ ] ~~I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)~~ (piggybacks the existing datasource changes)
- [ ] ~~I have added to the docs where applicable~~
- [ ] ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
