### PR TITLE
Upgrades and fixes for vscode extension

### DIFF
--- a/packages/extension/language-configuration.json
+++ b/packages/extension/language-configuration.json
@@ -20,12 +20,11 @@
 		["\"", "\""]
 	],
 	"folding": {
-		"offSide": true,
 		"markers": {
-			"start": "^\\s*<!--\\s*#?region\\b.*-->",
-			"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
+			"start": "^\\s*(```\\w+|{#if\\b|<s*\\b|<s*\\b|{#each\\b).*$",
+			"end": "^\\s*(```|{/if}|/>|<\/\\S*>|{/each})$"
 		}
-	},
+	},  
 	"wordPattern": {
 		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*",
 		"flags": "ug"

--- a/packages/extension/language-configuration.json
+++ b/packages/extension/language-configuration.json
@@ -22,9 +22,9 @@
 	"folding": {
 		"markers": {
 			"start": "^\\s*(```\\w+|{#if\\b|<s*\\b|<s*\\b|{#each\\b).*$",
-			"end": "^\\s*(```|{/if}|/>|<\/\\S*>|{/each})$"
+			"end": "^\\s*(```|{/if}|/>|</\\S*>|{/each})$"
 		}
-	},  
+	},
 	"wordPattern": {
 		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*",
 		"flags": "ug"

--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "evidence-vscode",
-	"version": "1.4.15",
+	"version": "1.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "evidence-vscode",
-			"version": "1.4.15",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/extension-telemetry": "^0.9.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "evidence-vscode",
 	"displayName": "Evidence",
 	"description": "Build polished data products with SQL and Markdown",
-	"version": "1.4.15",
+	"version": "1.5.0",
 	"private": true,
 	"engines": {
 		"vscode": "^1.52.0"
@@ -63,6 +63,11 @@
 				"title": "Getting Started Walkthrough",
 				"category": "Evidence"
 			},
+			{
+                "command": "evidence.copyColumnName",
+                "title": "Copy",
+                "category": "Evidence"
+            },
 			{
 				"command": "evidence.createTemplatedPageFromQuery",
 				"title": "Create Templated Page from Query",
@@ -247,8 +252,19 @@
 				{
 					"command": "evidence.preview",
 					"when": "never"
+				},
+				{
+					"command": "evidence.copyColumnName",
+					"when": "never"
 				}
-			]
+			],
+			"view/item/context": [
+                {
+                    "command": "evidence.copyColumnName",
+                    "when": "view == schemaView && viewItem == columnItem",
+                    "group": "inline"
+                }
+            ]
 		},
 		"configuration": {
 			"title": "Evidence",
@@ -290,7 +306,27 @@
 						"Open in external web browser",
 						"No automatic preview shown"
 					]
-				}
+				},
+				"evidence.enableSQLBackground": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable background color shading for SQL blocks."
+				  },
+				  "evidence.enableIfBackground": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable background color shading for if blocks."
+				  },
+				  "evidence.enableEachBackground": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable background color shading for each blocks."
+				  },
+				  "evidence.enableFrontmatterBackground": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable background color shading for markdown frontmatter."
+				  }
 			}
 		},
 		"languages": [

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -64,10 +64,10 @@
 				"category": "Evidence"
 			},
 			{
-                "command": "evidence.copyColumnName",
-                "title": "Copy",
-                "category": "Evidence"
-            },
+				"command": "evidence.copyColumnName",
+				"title": "Copy",
+				"category": "Evidence"
+			},
 			{
 				"command": "evidence.createTemplatedPageFromQuery",
 				"title": "Create Templated Page from Query",
@@ -259,12 +259,12 @@
 				}
 			],
 			"view/item/context": [
-                {
-                    "command": "evidence.copyColumnName",
-                    "when": "view == schemaView && viewItem == columnItem",
-                    "group": "inline"
-                }
-            ]
+				{
+					"command": "evidence.copyColumnName",
+					"when": "view == schemaView && viewItem == columnItem",
+					"group": "inline"
+				}
+			]
 		},
 		"configuration": {
 			"title": "Evidence",
@@ -311,22 +311,22 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enable background color shading for SQL blocks."
-				  },
-				  "evidence.enableIfBackground": {
+				},
+				"evidence.enableIfBackground": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enable background color shading for if blocks."
-				  },
-				  "evidence.enableEachBackground": {
+				},
+				"evidence.enableEachBackground": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enable background color shading for each blocks."
-				  },
-				  "evidence.enableFrontmatterBackground": {
+				},
+				"evidence.enableFrontmatterBackground": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enable background color shading for markdown frontmatter."
-				  }
+				}
 			}
 		},
 		"languages": [

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -69,6 +69,11 @@
 				"category": "Evidence"
 			},
 			{
+				"command": "evidence.copyTableName",
+				"title": "Copy",
+				"category": "Evidence"
+			},
+			{
 				"command": "evidence.createTemplatedPageFromQuery",
 				"title": "Create Templated Page from Query",
 				"category": "Evidence"
@@ -256,12 +261,21 @@
 				{
 					"command": "evidence.copyColumnName",
 					"when": "never"
+				},
+				{
+					"command": "evidence.copyTableName",
+					"when": "never"
 				}
 			],
 			"view/item/context": [
 				{
 					"command": "evidence.copyColumnName",
 					"when": "view == schemaView && viewItem == columnItem",
+					"group": "inline"
+				},
+				{
+					"command": "evidence.copyTableName",
+					"when": "view == schemaView && viewItem == tableItem",
 					"group": "inline"
 				}
 			]

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -64,6 +64,16 @@
 				"category": "Evidence"
 			},
 			{
+				"command": "evidence.insertColumnName",
+				"title": "Insert",
+				"category": "Evidence"
+			},
+			{
+				"command": "evidence.insertTableName",
+				"title": "Insert",
+				"category": "Evidence"
+			},
+			{
 				"command": "evidence.copyColumnName",
 				"title": "Copy",
 				"category": "Evidence"
@@ -265,18 +275,36 @@
 				{
 					"command": "evidence.copyTableName",
 					"when": "never"
+				},
+				{
+					"command": "evidence.insertColumnName",
+					"when": "never"
+				},
+				{
+					"command": "evidence.insertTableName",
+					"when": "never"
 				}
 			],
 			"view/item/context": [
 				{
+					"command": "evidence.insertColumnName",
+					"when": "view == schemaView && viewItem == columnItem",
+					"group": "inline@1"
+				},
+				{
+					"command": "evidence.insertTableName",
+					"when": "view == schemaView && viewItem == tableItem",
+					"group": "inline@1"
+				},
+				{
 					"command": "evidence.copyColumnName",
 					"when": "view == schemaView && viewItem == columnItem",
-					"group": "inline"
+					"group": "inline@2"
 				},
 				{
 					"command": "evidence.copyTableName",
 					"when": "view == schemaView && viewItem == tableItem",
-					"group": "inline"
+					"group": "inline@2"
 				}
 			]
 		},

--- a/packages/extension/snippets/emd.code-snippets
+++ b/packages/extension/snippets/emd.code-snippets
@@ -81,8 +81,8 @@
 		"body": ["<Value data={${1:query_name}} column=${2:column_name} fmt=${3:usd}/>"],
 		"description": "Value Component"
 	},
-	"Loop": {
-		"prefix": "/Loop",
+	"Each Block": {
+		"prefix": "/Each Block",
 		"body": [
 			"{#each ${1:query_name} as row}\n\n\t- <Value data={row} column=${4:column_name}/>\n\n{/each}\n\n"
 		],
@@ -247,6 +247,13 @@
 		],
 		"description": "Insert Accordion"
 	},
+	"AccordionItem": {
+		"prefix": "/AccordionItem",
+		"body": [
+			"<AccordionItem title='${1:Item One}'>\n\t\t${2:Item One Content}\n</AccordionItem>\n\n"
+		],
+		"description": "Insert AccordionItem"
+	},
 	"LinkButton": {
 		"prefix": "/LinkButton",
 		"body": ["<LinkButton url=${2:'/other-page'}>\n\t${3:Button Label}\n</LinkButton>\n\n"],
@@ -297,6 +304,11 @@
 		"prefix": "/DropdownMultiSelect",
 		"body": "<Dropdown multiple=true data={data} name=${1:name_of_dropdown} value=${2:column_name}/>\n\n",
 		"description": "Insert dropdown with multi-select"
+	},
+	"DropdownOption": {
+		"prefix": "/DropdownOption",
+		"body": "<DropdownOption value=${1:value}/>\n\n",
+		"description": "Insert dropdown component"
 	},
 	"TextInput": {
 		"prefix": "/TextInput",

--- a/packages/extension/src/commands/cache.ts
+++ b/packages/extension/src/commands/cache.ts
@@ -1,21 +1,30 @@
-import { window } from 'vscode';
-
+import { window, workspace } from 'vscode';
 import { deleteFolder } from '../utils/fsUtils';
 import { telemetryService } from '../extension';
+import * as path from 'path';
 
 /**
  * Evidence application cache directories.
  */
-const cachePath = '.evidence/template/.evidence-queries';
+let cachePath = '';
+if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+    const workspaceFolderPath = workspace.workspaceFolders[0].uri.fsPath;
+    cachePath = path.join(workspaceFolderPath, '.evidence', 'template', '.evidence-queries');
+}
 
 /**
  * Deletes Evidence application cache directory.
  */
 export async function clearCache() {
-	if (await deleteFolder(cachePath)) {
-		window.showInformationMessage('Cache cleared.');
-	} else {
-		window.showInformationMessage('Cache is already empty.');
-	}
-	telemetryService?.sendEvent('clearCache');
+    if (!cachePath) {
+        window.showErrorMessage('No workspace folder is open.');
+        return;
+    }
+
+    if (await deleteFolder(cachePath)) {
+        window.showInformationMessage('Cache cleared.');
+    } else {
+        window.showInformationMessage('Cache is already empty.');
+    }
+    telemetryService?.sendEvent('clearCache');
 }

--- a/packages/extension/src/commands/cache.ts
+++ b/packages/extension/src/commands/cache.ts
@@ -8,23 +8,23 @@ import * as path from 'path';
  */
 let cachePath = '';
 if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-    const workspaceFolderPath = workspace.workspaceFolders[0].uri.fsPath;
-    cachePath = path.join(workspaceFolderPath, '.evidence', 'template', '.evidence-queries');
+	const workspaceFolderPath = workspace.workspaceFolders[0].uri.fsPath;
+	cachePath = path.join(workspaceFolderPath, '.evidence', 'template', '.evidence-queries');
 }
 
 /**
  * Deletes Evidence application cache directory.
  */
 export async function clearCache() {
-    if (!cachePath) {
-        window.showErrorMessage('No workspace folder is open.');
-        return;
-    }
+	if (!cachePath) {
+		window.showErrorMessage('No workspace folder is open.');
+		return;
+	}
 
-    if (await deleteFolder(cachePath)) {
-        window.showInformationMessage('Cache cleared.');
-    } else {
-        window.showInformationMessage('Cache is already empty.');
-    }
-    telemetryService?.sendEvent('clearCache');
+	if (await deleteFolder(cachePath)) {
+		window.showInformationMessage('Cache cleared.');
+	} else {
+		window.showInformationMessage('Cache is already empty.');
+	}
+	telemetryService?.sendEvent('clearCache');
 }

--- a/packages/extension/src/commands/documents.ts
+++ b/packages/extension/src/commands/documents.ts
@@ -18,7 +18,7 @@ export async function createTemplatedPageFromQuery() {
 	if (
 		!activeEditor ||
 		!activeEditor.document.fileName.endsWith('.sql') ||
-		!activeEditor.document.fileName.includes((await isUSQL()) ? '/queries/' : '/sources/')
+		!activeEditor.document.fileName.includes((await isUSQL()) ? `${path.sep}queries${path.sep}` : `${path.sep}sources${path.sep}`)
 	) {
 		window.showWarningMessage(
 			`This command can only be run from within a .sql file in your ${(await isUSQL()) ? 'queries' : 'sources'} folder`,

--- a/packages/extension/src/commands/documents.ts
+++ b/packages/extension/src/commands/documents.ts
@@ -18,7 +18,9 @@ export async function createTemplatedPageFromQuery() {
 	if (
 		!activeEditor ||
 		!activeEditor.document.fileName.endsWith('.sql') ||
-		!activeEditor.document.fileName.includes((await isUSQL()) ? `${path.sep}queries${path.sep}` : `${path.sep}sources${path.sep}`)
+		!activeEditor.document.fileName.includes(
+			(await isUSQL()) ? `${path.sep}queries${path.sep}` : `${path.sep}sources${path.sep}`
+		)
 	) {
 		window.showWarningMessage(
 			`This command can only be run from within a .sql file in your ${(await isUSQL()) ? 'queries' : 'sources'} folder`,

--- a/packages/extension/src/commands/project.ts
+++ b/packages/extension/src/commands/project.ts
@@ -189,7 +189,7 @@ async function createProjectFolder(templateFolder: Uri, projectFolder: Uri) {
  */
 export async function openIndex() {
 	let openMarkdownFiles = workspace.textDocuments.filter((doc) => doc.fileName.endsWith('.md'));
-	
+
 	// check if evidence is in a subdirectory - don't open index/walkthrough if monorepo
 	const packageJsonFolder = await getPackageJsonFolder();
 

--- a/packages/extension/src/commands/project.ts
+++ b/packages/extension/src/commands/project.ts
@@ -189,14 +189,14 @@ async function createProjectFolder(templateFolder: Uri, projectFolder: Uri) {
  */
 export async function openIndex() {
 	let openMarkdownFiles = workspace.textDocuments.filter((doc) => doc.fileName.endsWith('.md'));
-
+	
 	// check if evidence is in a subdirectory - don't open index/walkthrough if monorepo
 	const packageJsonFolder = await getPackageJsonFolder();
 
 	if (packageJsonFolder === '' && openMarkdownFiles.length === 0) {
 		const folderPath = getWorkspaceFolder();
-		const filePath = folderPath?.uri.toString() + '/pages/index.md';
-		const fileUri = Uri.parse(filePath);
+		const filePath = path.join(folderPath?.uri.fsPath || '', 'pages', 'index.md');
+		const fileUri = Uri.file(filePath);
 		await commands.executeCommand('vscode.open', fileUri, 1);
 		await commands.executeCommand('vscode.open', fileUri, 2);
 		openWalkthrough();

--- a/packages/extension/src/commands/settings.ts
+++ b/packages/extension/src/commands/settings.ts
@@ -1,4 +1,5 @@
-import { commands, env, window, workspace, Uri } from 'vscode';
+import { commands, window, workspace, Uri } from 'vscode';
+import * as path from 'path';
 
 import { Commands } from './commands';
 import { getWorkspaceFolder } from '../config';
@@ -8,7 +9,7 @@ import { getAppPageUri, isServerRunning, startServer } from './server';
 /**
  * Evidence app setting file location to configure data sources.
  */
-const settingsFilePath = '.evidence/template/evidence.settings.json';
+const settingsFilePath = path.join('.evidence', 'template', 'evidence.settings.json');
 
 /**
  * Evidence app settings page to configure data source(s).

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -39,7 +39,7 @@ import { isGitRepository } from './utils/gitCheck';
 import { countFilesInDirectory, countTemplatedPages } from './utils/fsUtils';
 import * as path from 'path';
 import * as fs from 'fs';
-import { SchemaViewProvider, ColumnItem } from './providers/schemaViewProvider'; 
+import { SchemaViewProvider, ColumnItem } from './providers/schemaViewProvider';
 
 export const enum Context {
 	isNewLine = 'evidence.isNewLine',
@@ -124,15 +124,15 @@ export async function activate(context: ExtensionContext) {
 	// register markdown symbol provider
 	const markdownLanguage = { language: 'emd', scheme: 'file' };
 	const provider = new MarkdownSymbolProvider();
-    // const selector: DocumentSelector = { language: 'emd', scheme: 'file' };
+	// const selector: DocumentSelector = { language: 'emd', scheme: 'file' };
 
-    // const symbolProviderRegistration = languages.registerDocumentSymbolProvider(
-    //     selector,
-    //     provider
-    // );
+	// const symbolProviderRegistration = languages.registerDocumentSymbolProvider(
+	//     selector,
+	//     provider
+	// );
 
-    // // Add to context subscriptions to ensure proper disposal
-    // context.subscriptions.push(symbolProviderRegistration);
+	// // Add to context subscriptions to ensure proper disposal
+	// context.subscriptions.push(symbolProviderRegistration);
 	// languages.registerDocumentSymbolProvider(markdownLanguage, provider);
 
 	// load package.json
@@ -155,7 +155,7 @@ export async function activate(context: ExtensionContext) {
 			let frontmatterDecorationType: TextEditorDecorationType;
 			let svelteEachDecorationType: TextEditorDecorationType;
 			let svelteIfDecorationType: TextEditorDecorationType;
-		
+
 			const getThemeBasedDecorationType = () => {
 				const colorTheme = window.activeColorTheme.kind;
 				const isLightTheme = colorTheme === ColorThemeKind.Light;
@@ -165,21 +165,21 @@ export async function activate(context: ExtensionContext) {
 				});
 
 				frontmatterDecorationType = window.createTextEditorDecorationType({
-					backgroundColor: isLightTheme ? 'rgba(197, 220, 237, 0.2)' : 'rgba(197, 220, 237, 0.05)', // light blue or darker blue background with some transparency
+					backgroundColor: isLightTheme ? 'rgba(84, 134, 209, 0.04)' : 'rgba(84, 134, 209, 0.05)', // light blue or darker blue background with some transparency
 					isWholeLine: true
 				});
-		
+
 				svelteEachDecorationType = window.createTextEditorDecorationType({
 					backgroundColor: isLightTheme ? 'rgba(156, 58, 176, 0.05)' : 'rgba(75, 0, 130, 0.05)', // light purple or darker purple background with some transparency
 					isWholeLine: true
 				});
-		
+
 				svelteIfDecorationType = window.createTextEditorDecorationType({
 					backgroundColor: isLightTheme ? 'rgba(255, 165, 0, 0.08)' : 'rgba(255, 140, 0, 0.05)', // light orange or darker orange background with some transparency
 					isWholeLine: true
 				});
 			};
-		
+
 			const clearDecorations = (editor: TextEditor) => {
 				if (sqlDecorationType) {
 					editor.setDecorations(sqlDecorationType, []);
@@ -194,28 +194,33 @@ export async function activate(context: ExtensionContext) {
 					editor.setDecorations(svelteIfDecorationType, []);
 				}
 			};
-		
+
 			const highlightCodeBlocks = (editor: TextEditor) => {
-				if (!editor) {return;};
+				if (!editor) {
+					return;
+				}
 
 				const config = workspace.getConfiguration('evidence');
 				const enableSQLBackground = config.get<boolean>('enableSQLBackground', true);
-				const enableFrontmatterBackground = config.get<boolean>('enableFrontmatterBackground', true);
+				const enableFrontmatterBackground = config.get<boolean>(
+					'enableFrontmatterBackground',
+					true
+				);
 				const enableIfBackground = config.get<boolean>('enableIfBackground', true);
 				const enableEachBackground = config.get<boolean>('enableEachBackground', true);
-		
+
 				const text = editor.document.getText();
-		
+
 				const sqlRegex = /```[\s\S]*?```/gm;
 				const frontmatterRegex = /^---[\s\S]*?---/g;
 				const svelteEachRegex = /{#each[\s\S]*?{\/each}/gm;
 				const svelteIfRegex = /{#if[\s\S]*?{\/if}/gm;
-		
+
 				const sqlRanges: DecorationOptions[] = [];
 				const frontmatterRanges: DecorationOptions[] = [];
 				const svelteEachRanges: DecorationOptions[] = [];
 				const svelteIfRanges: DecorationOptions[] = [];
-		
+
 				let match;
 				if (enableSQLBackground) {
 					while ((match = sqlRegex.exec(text)) !== null) {
@@ -234,8 +239,8 @@ export async function activate(context: ExtensionContext) {
 						frontmatterRanges.push({ range });
 					}
 				}
-		
-				if(enableEachBackground){
+
+				if (enableEachBackground) {
 					while ((match = svelteEachRegex.exec(text)) !== null) {
 						const startPos = editor.document.positionAt(match.index);
 						const endPos = editor.document.positionAt(match.index + match[0].length);
@@ -243,21 +248,21 @@ export async function activate(context: ExtensionContext) {
 						svelteEachRanges.push({ range });
 					}
 				}
-		
+
 				const svelteIfRangesRecursively = (regex: RegExp, text: string, startIndex = 0) => {
 					let nestedCount = 0;
 					let startPos: number | null = null;
 					const ranges: Range[] = [];
-		
+
 					let match;
 					regex.lastIndex = startIndex;
 					while ((match = regex.exec(text)) !== null) {
-						if (match[0].startsWith("{#if")) {
+						if (match[0].startsWith('{#if')) {
 							if (nestedCount === 0) {
 								startPos = match.index;
 							}
 							nestedCount++;
-						} else if (match[0] === "{/if}") {
+						} else if (match[0] === '{/if}') {
 							nestedCount--;
 							if (nestedCount === 0 && startPos !== null) {
 								const start = editor.document.positionAt(startPos);
@@ -269,27 +274,27 @@ export async function activate(context: ExtensionContext) {
 					}
 					return ranges;
 				};
-		
-				if(enableIfBackground){
-					svelteIfRangesRecursively(/({#if.*?})|({\/if})/gm, text).forEach(range => {
+
+				if (enableIfBackground) {
+					svelteIfRangesRecursively(/({#if.*?})|({\/if})/gm, text).forEach((range) => {
 						svelteIfRanges.push({ range });
 					});
 				}
-		
+
 				const svelteEachRangesRecursively = (regex: RegExp, text: string, startIndex = 0) => {
 					let nestedCount = 0;
 					let startPos: number | null = null;
 					const ranges: Range[] = [];
-		
+
 					let match;
 					regex.lastIndex = startIndex;
 					while ((match = regex.exec(text)) !== null) {
-						if (match[0].startsWith("{#each")) {
+						if (match[0].startsWith('{#each')) {
 							if (nestedCount === 0) {
 								startPos = match.index;
 							}
 							nestedCount++;
-						} else if (match[0] === "{/each}") {
+						} else if (match[0] === '{/each}') {
 							nestedCount--;
 							if (nestedCount === 0 && startPos !== null) {
 								const start = editor.document.positionAt(startPos);
@@ -301,47 +306,63 @@ export async function activate(context: ExtensionContext) {
 					}
 					return ranges;
 				};
-		
-				if(enableEachBackground){
-				svelteEachRangesRecursively(/({#each.*?})|({\/each})/gm, text).forEach(range => {
-					svelteEachRanges.push({ range });
-				});
-			}
-		
+
+				if (enableEachBackground) {
+					svelteEachRangesRecursively(/({#each.*?})|({\/each})/gm, text).forEach((range) => {
+						svelteEachRanges.push({ range });
+					});
+				}
+
 				editor.setDecorations(sqlDecorationType, sqlRanges);
 				editor.setDecorations(frontmatterDecorationType, frontmatterRanges);
 				editor.setDecorations(svelteEachDecorationType, svelteEachRanges);
 				editor.setDecorations(svelteIfDecorationType, svelteIfRanges);
 			};
-		
+
 			// Initial setup
 			getThemeBasedDecorationType();
-		
-			window.onDidChangeActiveTextEditor(editor => {
-				if (editor && editor.document.languageId === 'emd') {
-					highlightCodeBlocks(editor);
-				}
-			}, null, context.subscriptions);
-		
-			workspace.onDidChangeTextDocument(event => {
-				const editor = window.activeTextEditor;
-				if (editor && event.document === editor.document && editor.document.languageId === 'emd') {
-					highlightCodeBlocks(editor);
-				}
-			}, null, context.subscriptions);
-		
+
+			window.onDidChangeActiveTextEditor(
+				(editor) => {
+					if (editor && editor.document.languageId === 'emd') {
+						highlightCodeBlocks(editor);
+					}
+				},
+				null,
+				context.subscriptions
+			);
+
+			workspace.onDidChangeTextDocument(
+				(event) => {
+					const editor = window.activeTextEditor;
+					if (
+						editor &&
+						event.document === editor.document &&
+						editor.document.languageId === 'emd'
+					) {
+						highlightCodeBlocks(editor);
+					}
+				},
+				null,
+				context.subscriptions
+			);
+
 			// Reapply decorations on theme change
-			window.onDidChangeActiveColorTheme(() => {
-				// Update decoration types
-				getThemeBasedDecorationType();
-				// Reapply decorations in the active editor
-				const editor = window.activeTextEditor;
-				if (editor && editor.document.languageId === 'emd') {
-					clearDecorations(editor);
-					highlightCodeBlocks(editor);
-				}
-			}, null, context.subscriptions);
-		
+			window.onDidChangeActiveColorTheme(
+				() => {
+					// Update decoration types
+					getThemeBasedDecorationType();
+					// Reapply decorations in the active editor
+					const editor = window.activeTextEditor;
+					if (editor && editor.document.languageId === 'emd') {
+						clearDecorations(editor);
+						highlightCodeBlocks(editor);
+					}
+				},
+				null,
+				context.subscriptions
+			);
+
 			// Highlight code blocks in the active editor if it's an emd file
 			if (window.activeTextEditor && window.activeTextEditor.document.languageId === 'emd') {
 				highlightCodeBlocks(window.activeTextEditor);
@@ -595,7 +616,10 @@ export async function activate(context: ExtensionContext) {
 			workspace.onDidCreateFiles((event) => {
 				try {
 					event.files.forEach((file) => {
-						if (fs.lstatSync(file.path).isDirectory() && file.path.includes(`${path.sep}pages${path.sep}`)) {
+						if (
+							fs.lstatSync(file.path).isDirectory() &&
+							file.path.includes(`${path.sep}pages${path.sep}`)
+						) {
 							const isTemplated = /\[.+\]/.test(file.path);
 							telemetryService?.sendEvent('createDirectory', { templated: isTemplated.toString() });
 						}
@@ -684,7 +708,7 @@ export async function activate(context: ExtensionContext) {
 						} else if (item.label && typeof item.label.label === 'string') {
 							label = item.label.label;
 						}
-			
+
 						if (label) {
 							env.clipboard.writeText(label);
 							window.showInformationMessage(`Copied: ${label}`);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -107,64 +107,68 @@ function isPagesDirectory() {
 }
 
 async function initializeSchemaViewer(context: ExtensionContext) {
-    try {
-        console.log('Initializing schema viewer...');
-        
-        if (await isUSQL()) {
-            const manifestUri = await getManifestUri();
+	try {
+		console.log('Initializing schema viewer...');
+
+		if (await isUSQL()) {
+			const manifestUri = await getManifestUri();
 			const workspaceFolder = workspace.workspaceFolders?.[0];
 			const packageJsonFolder = await getPackageJsonFolder();
-			const manifestPath = workspaceFolder ? path.join(
-				workspaceFolder.uri.fsPath,
-				packageJsonFolder ?? '',
-				'.evidence',
-				'template',
-				'static',
-				'data',
-				'manifest.json'
-			) : '';
-			
-            const manifestWatcher = workspace.createFileSystemWatcher(manifestUri ? manifestUri.fsPath : manifestPath);
-            registerCopyCommands(context);
+			const manifestPath = workspaceFolder
+				? path.join(
+						workspaceFolder.uri.fsPath,
+						packageJsonFolder ?? '',
+						'.evidence',
+						'template',
+						'static',
+						'data',
+						'manifest.json'
+					)
+				: '';
 
-            const schemaViewProvider = new SchemaViewProvider(manifestUri ?? Uri.file(manifestPath));
-            window.registerTreeDataProvider('schemaView', schemaViewProvider);
+			const manifestWatcher = workspace.createFileSystemWatcher(
+				manifestUri ? manifestUri.fsPath : manifestPath
+			);
+			registerCopyCommands(context);
 
-            manifestWatcher.onDidChange(() => schemaViewProvider.refresh());
-            manifestWatcher.onDidCreate(() => schemaViewProvider.refresh());
-            manifestWatcher.onDidDelete(() => schemaViewProvider.refresh());
+			const schemaViewProvider = new SchemaViewProvider(manifestUri ?? Uri.file(manifestPath));
+			window.registerTreeDataProvider('schemaView', schemaViewProvider);
 
-            context.subscriptions.push(manifestWatcher);
+			manifestWatcher.onDidChange(() => schemaViewProvider.refresh());
+			manifestWatcher.onDidCreate(() => schemaViewProvider.refresh());
+			manifestWatcher.onDidDelete(() => schemaViewProvider.refresh());
 
-            commands.executeCommand(Commands.SetContext, Context.isNonLegacyProject, await isUSQL());
-        }
-    } catch (error) {
-        console.error('Error initializing schema viewer:', error);
-    }
+			context.subscriptions.push(manifestWatcher);
+
+			commands.executeCommand(Commands.SetContext, Context.isNonLegacyProject, await isUSQL());
+		}
+	} catch (error) {
+		console.error('Error initializing schema viewer:', error);
+	}
 }
 
 function registerCopyCommands(context: ExtensionContext) {
-    context.subscriptions.push(
-        commands.registerCommand('evidence.copyColumnName', (item: ColumnItem) => {
-            let label = '';
+	context.subscriptions.push(
+		commands.registerCommand('evidence.copyColumnName', (item: ColumnItem) => {
+			let label = '';
 
-            if (typeof item.label === 'string') {
-                label = item.label;
-            } else if (item.label && typeof item.label.label === 'string') {
-                label = item.label.label;
-            }
+			if (typeof item.label === 'string') {
+				label = item.label;
+			} else if (item.label && typeof item.label.label === 'string') {
+				label = item.label.label;
+			}
 
-            if (label) {
-                env.clipboard.writeText(label);
-                window.showInformationMessage(`Copied: ${label}`);
-            }
-        }),
-        commands.registerCommand('evidence.copyTableName', (item: TableItem) => {
-            const label = `${item.id}`;
-            env.clipboard.writeText(label);
-            window.showInformationMessage(`Copied: ${label}`);
-        })
-    );
+			if (label) {
+				env.clipboard.writeText(label);
+				window.showInformationMessage(`Copied: ${label}`);
+			}
+		}),
+		commands.registerCommand('evidence.copyTableName', (item: TableItem) => {
+			const label = `${item.id}`;
+			env.clipboard.writeText(label);
+			window.showInformationMessage(`Copied: ${label}`);
+		})
+	);
 }
 
 /**

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -169,36 +169,35 @@ function registerCopyCommands(context: ExtensionContext) {
 			window.showInformationMessage(`Copied: ${label}`);
 		}),
 		commands.registerCommand('evidence.insertColumnName', (item: ColumnItem) => {
-            let label = '';
+			let label = '';
 
-            if (typeof item.label === 'string') {
-                label = item.label;
-            } else if (item.label && typeof item.label.label === 'string') {
-                label = item.label.label;
-            }
+			if (typeof item.label === 'string') {
+				label = item.label;
+			} else if (item.label && typeof item.label.label === 'string') {
+				label = item.label.label;
+			}
 
-            if (label) {
-                insertTextAtCursor(label);
-                window.showInformationMessage(`Inserted: ${label}`);
-            }
-        }),
-        commands.registerCommand('evidence.insertTableName', (item: TableItem) => {
+			if (label) {
+				insertTextAtCursor(label);
+				window.showInformationMessage(`Inserted: ${label}`);
+			}
+		}),
+		commands.registerCommand('evidence.insertTableName', (item: TableItem) => {
 			const label = `${item.id}`;
-            insertTextAtCursor(label);
-            window.showInformationMessage(`Inserted: ${label}`);
-        })
+			insertTextAtCursor(label);
+			window.showInformationMessage(`Inserted: ${label}`);
+		})
 	);
 }
 
-
 function insertTextAtCursor(text: string) {
-    const editor = window.activeTextEditor;
-    if (editor) {
-        const position = editor.selection.active;
-        editor.edit(editBuilder => {
-            editBuilder.insert(position, text);
-        });
-    }
+	const editor = window.activeTextEditor;
+	if (editor) {
+		const position = editor.selection.active;
+		editor.edit((editBuilder) => {
+			editBuilder.insert(position, text);
+		});
+	}
 }
 
 /**

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -167,8 +167,38 @@ function registerCopyCommands(context: ExtensionContext) {
 			const label = `${item.id}`;
 			env.clipboard.writeText(label);
 			window.showInformationMessage(`Copied: ${label}`);
-		})
+		}),
+		commands.registerCommand('evidence.insertColumnName', (item: ColumnItem) => {
+            let label = '';
+
+            if (typeof item.label === 'string') {
+                label = item.label;
+            } else if (item.label && typeof item.label.label === 'string') {
+                label = item.label.label;
+            }
+
+            if (label) {
+                insertTextAtCursor(label);
+                window.showInformationMessage(`Inserted: ${label}`);
+            }
+        }),
+        commands.registerCommand('evidence.insertTableName', (item: TableItem) => {
+			const label = `${item.id}`;
+            insertTextAtCursor(label);
+            window.showInformationMessage(`Inserted: ${label}`);
+        })
 	);
+}
+
+
+function insertTextAtCursor(text: string) {
+    const editor = window.activeTextEditor;
+    if (editor) {
+        const position = editor.selection.active;
+        editor.edit(editBuilder => {
+            editBuilder.insert(position, text);
+        });
+    }
 }
 
 /**

--- a/packages/extension/src/providers/markdownSymbolProvider.ts
+++ b/packages/extension/src/providers/markdownSymbolProvider.ts
@@ -1,40 +1,133 @@
-import {
-	CancellationToken,
-	DocumentSymbolProvider,
-	Location,
-	ProviderResult,
-	SymbolInformation,
-	SymbolKind,
-	TextDocument
-} from 'vscode';
+import { CancellationToken, DocumentSymbol, DocumentSymbolProvider, ProviderResult, SymbolKind, TextDocument, Range } from 'vscode';
 
-/**
- * Implements custom Evidence markdown document symbol provider.
- */
 export class MarkdownSymbolProvider implements DocumentSymbolProvider {
-	provideDocumentSymbols(
-		document: TextDocument,
-		token: CancellationToken
-	): ProviderResult<SymbolInformation[]> {
-		// parse text document symbols per line
-		const symbols: SymbolInformation[] = [];
-		for (let i = 0; i < document.lineCount; i++) {
-			const line = document.lineAt(i);
+    provideDocumentSymbols(
+        document: TextDocument,
+        token: CancellationToken
+    ): ProviderResult<DocumentSymbol[]> {
+        const symbols: DocumentSymbol[] = [];
+        const stack: { symbol: DocumentSymbol, level: number }[] = [];
 
-			// match heading lines
-			const match = line.text.match(/^#+\s+(.*)$/);
-			if (match) {
-				const symbol = new SymbolInformation(
-					match[1],
-					SymbolKind.String,
-					'', // container name
-					new Location(document.uri, line.range)
-				);
+        for (let i = 0; i < document.lineCount; i++) {
+            const line = document.lineAt(i);
 
-				symbols.push(symbol);
-			}
-		}
+            // Handle headers
+            const headerMatch = line.text.match(/^(#+)\s+(.*)$/);
+            if (headerMatch) {
+                const level = headerMatch[1].length;
+                const symbol = new DocumentSymbol(
+                    headerMatch[2],
+                    '',
+                    SymbolKind.Number,
+                    line.range,
+                    line.range
+                );
+                this.addToHierarchy(symbols, stack, symbol, level);
+                console.log(`Header: ${headerMatch[2]} at level ${level}, stack length: ${stack.length}`);
+                continue;
+            }
 
-		return symbols;
-	}
+            // Handle Svelte components (self-closing and with closing tags)
+            const componentStartMatch = line.text.match(/<\s*([A-Z][A-Za-z0-9]*)\b[^>]*(\/?)/);
+            if (componentStartMatch) {
+                const componentName = componentStartMatch[1];
+                let componentEndLine = i;
+                let isSelfClosing = componentStartMatch[2] === '/';
+
+                if (!isSelfClosing && !line.text.endsWith('>')) {
+                    // Continue reading lines until we find the closing tag
+                    for (let j = i + 1; j < document.lineCount; j++) {
+                        componentEndLine = j;
+                        const endLineText = document.lineAt(j).text;
+                        if (endLineText.includes('>')) {
+                            isSelfClosing = endLineText.includes('/>');
+                            break;
+                        }
+                    }
+                }
+
+                const range = new Range(i, 0, componentEndLine, document.lineAt(componentEndLine).text.length);
+                const componentSymbol = new DocumentSymbol(
+                    `${componentName}`,
+                    '',
+                    SymbolKind.Field,
+                    range,
+                    range
+                );
+                const level = stack.length > 0 ? stack[0].level + 1 : 1;
+                this.addToHierarchy(symbols, stack, componentSymbol, level);
+                if (!isSelfClosing) {
+					i = componentEndLine;
+				};
+                console.log(`Svelte Component: ${componentName}, level: ${level}, stack length: ${stack.length}`);
+                continue;
+            }
+
+            // Handle SQL blocks with backticks
+            const sqlBlockMatch = line.text.match(/^\s*```\s*(sql)?\s*(\w*)/);
+            if (sqlBlockMatch) {
+                const sqlName = sqlBlockMatch[2];
+                const endLine = this.findClosingTag(document, i, /^```$/);
+                if (endLine !== -1) {
+                    const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
+                    const sqlSymbol = new DocumentSymbol(
+                        `Query | ${sqlName}`,
+                        '',
+                        SymbolKind.Method,
+                        range,
+                        range
+                    );
+                    const level = stack.length > 0 ? stack[stack.length - 1].level + 1 : 1;
+                    this.addToHierarchy(symbols, stack, sqlSymbol, level);
+                    i = endLine;
+                }
+                continue;
+            }
+
+            // Handle Svelte {#each} and {#if} blocks
+            const controlBlockMatch = line.text.match(/\{#(each|if)\s/);
+            if (controlBlockMatch) {
+				const blockName = `${controlBlockMatch[1].charAt(0).toUpperCase() + controlBlockMatch[1].slice(1)} Block`;
+                const endLine = this.findClosingTag(document, i, new RegExp(`{\\/${controlBlockMatch[1]}}`));
+                if (endLine !== -1) {
+                    const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
+                    const controlBlockSymbol = new DocumentSymbol(
+                        blockName,
+                        '',
+                        SymbolKind.Namespace,
+                        range,
+                        range
+                    );
+					const level = stack.length > 0 ? stack[0].level + 1 : 1;
+                    this.addToHierarchy(symbols, stack, controlBlockSymbol, level);
+                    i = endLine;
+                    console.log(`Control Block: ${blockName}, level: ${level}, stack length: ${stack.length}`);
+                }
+                continue;
+            }
+        }
+
+        return symbols;
+    }
+
+    addToHierarchy(symbols: DocumentSymbol[], stack: { symbol: DocumentSymbol, level: number }[], symbol: DocumentSymbol, level: number) {
+        while (stack.length > 0 && stack[stack.length - 1].level >= level) {
+            stack.pop();
+        }
+        if (stack.length > 0) {
+            stack[stack.length - 1].symbol.children.push(symbol);
+        } else {
+            symbols.push(symbol);
+        }
+        stack.push({ symbol, level });
+    }
+
+    findClosingTag(document: TextDocument, startLine: number, regex: RegExp): number {
+        for (let i = startLine + 1; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.match(regex)) {
+                return i;
+            }
+        }
+        return -1; // Not found
+    }
 }

--- a/packages/extension/src/providers/markdownSymbolProvider.ts
+++ b/packages/extension/src/providers/markdownSymbolProvider.ts
@@ -1,133 +1,159 @@
-import { CancellationToken, DocumentSymbol, DocumentSymbolProvider, ProviderResult, SymbolKind, TextDocument, Range } from 'vscode';
+import {
+	CancellationToken,
+	DocumentSymbol,
+	DocumentSymbolProvider,
+	ProviderResult,
+	SymbolKind,
+	TextDocument,
+	Range
+} from 'vscode';
 
 export class MarkdownSymbolProvider implements DocumentSymbolProvider {
-    provideDocumentSymbols(
-        document: TextDocument,
-        token: CancellationToken
-    ): ProviderResult<DocumentSymbol[]> {
-        const symbols: DocumentSymbol[] = [];
-        const stack: { symbol: DocumentSymbol, level: number }[] = [];
+	provideDocumentSymbols(
+		document: TextDocument,
+		token: CancellationToken
+	): ProviderResult<DocumentSymbol[]> {
+		const symbols: DocumentSymbol[] = [];
+		const stack: { symbol: DocumentSymbol; level: number }[] = [];
 
-        for (let i = 0; i < document.lineCount; i++) {
-            const line = document.lineAt(i);
+		for (let i = 0; i < document.lineCount; i++) {
+			const line = document.lineAt(i);
 
-            // Handle headers
-            const headerMatch = line.text.match(/^(#+)\s+(.*)$/);
-            if (headerMatch) {
-                const level = headerMatch[1].length;
-                const symbol = new DocumentSymbol(
-                    headerMatch[2],
-                    '',
-                    SymbolKind.Number,
-                    line.range,
-                    line.range
-                );
-                this.addToHierarchy(symbols, stack, symbol, level);
-                console.log(`Header: ${headerMatch[2]} at level ${level}, stack length: ${stack.length}`);
-                continue;
-            }
+			// Handle headers
+			const headerMatch = line.text.match(/^(#+)\s+(.*)$/);
+			if (headerMatch) {
+				const level = headerMatch[1].length;
+				const symbol = new DocumentSymbol(
+					headerMatch[2],
+					'',
+					SymbolKind.Number,
+					line.range,
+					line.range
+				);
+				this.addToHierarchy(symbols, stack, symbol, level);
+				console.log(`Header: ${headerMatch[2]} at level ${level}, stack length: ${stack.length}`);
+				continue;
+			}
 
-            // Handle Svelte components (self-closing and with closing tags)
-            const componentStartMatch = line.text.match(/<\s*([A-Z][A-Za-z0-9]*)\b[^>]*(\/?)/);
-            if (componentStartMatch) {
-                const componentName = componentStartMatch[1];
-                let componentEndLine = i;
-                let isSelfClosing = componentStartMatch[2] === '/';
+			// Handle Svelte components (self-closing and with closing tags)
+			const componentStartMatch = line.text.match(/<\s*([A-Z][A-Za-z0-9]*)\b[^>]*(\/?)/);
+			if (componentStartMatch) {
+				const componentName = componentStartMatch[1];
+				let componentEndLine = i;
+				let isSelfClosing = componentStartMatch[2] === '/';
 
-                if (!isSelfClosing && !line.text.endsWith('>')) {
-                    // Continue reading lines until we find the closing tag
-                    for (let j = i + 1; j < document.lineCount; j++) {
-                        componentEndLine = j;
-                        const endLineText = document.lineAt(j).text;
-                        if (endLineText.includes('>')) {
-                            isSelfClosing = endLineText.includes('/>');
-                            break;
-                        }
-                    }
-                }
+				if (!isSelfClosing && !line.text.endsWith('>')) {
+					// Continue reading lines until we find the closing tag
+					for (let j = i + 1; j < document.lineCount; j++) {
+						componentEndLine = j;
+						const endLineText = document.lineAt(j).text;
+						if (endLineText.includes('>')) {
+							isSelfClosing = endLineText.includes('/>');
+							break;
+						}
+					}
+				}
 
-                const range = new Range(i, 0, componentEndLine, document.lineAt(componentEndLine).text.length);
-                const componentSymbol = new DocumentSymbol(
-                    `${componentName}`,
-                    '',
-                    SymbolKind.Field,
-                    range,
-                    range
-                );
-                const level = stack.length > 0 ? stack[0].level + 1 : 1;
-                this.addToHierarchy(symbols, stack, componentSymbol, level);
-                if (!isSelfClosing) {
+				const range = new Range(
+					i,
+					0,
+					componentEndLine,
+					document.lineAt(componentEndLine).text.length
+				);
+				const componentSymbol = new DocumentSymbol(
+					`${componentName}`,
+					'',
+					SymbolKind.Field,
+					range,
+					range
+				);
+				const level = stack.length > 0 ? stack[0].level + 1 : 1;
+				this.addToHierarchy(symbols, stack, componentSymbol, level);
+				if (!isSelfClosing) {
 					i = componentEndLine;
-				};
-                console.log(`Svelte Component: ${componentName}, level: ${level}, stack length: ${stack.length}`);
-                continue;
-            }
+				}
+				console.log(
+					`Svelte Component: ${componentName}, level: ${level}, stack length: ${stack.length}`
+				);
+				continue;
+			}
 
-            // Handle SQL blocks with backticks
-            const sqlBlockMatch = line.text.match(/^\s*```\s*(sql)?\s*(\w*)/);
-            if (sqlBlockMatch) {
-                const sqlName = sqlBlockMatch[2];
-                const endLine = this.findClosingTag(document, i, /^```$/);
-                if (endLine !== -1) {
-                    const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
-                    const sqlSymbol = new DocumentSymbol(
-                        `Query | ${sqlName}`,
-                        '',
-                        SymbolKind.Method,
-                        range,
-                        range
-                    );
-                    const level = stack.length > 0 ? stack[stack.length - 1].level + 1 : 1;
-                    this.addToHierarchy(symbols, stack, sqlSymbol, level);
-                    i = endLine;
-                }
-                continue;
-            }
+			// Handle SQL blocks with backticks
+			const sqlBlockMatch = line.text.match(/^\s*```\s*(sql)?\s*(\w*)/);
+			if (sqlBlockMatch) {
+				const sqlName = sqlBlockMatch[2];
+				const endLine = this.findClosingTag(document, i, /^```$/);
+				if (endLine !== -1) {
+					const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
+					const sqlSymbol = new DocumentSymbol(
+						`Query | ${sqlName}`,
+						'',
+						SymbolKind.Method,
+						range,
+						range
+					);
+					const level = stack.length > 0 ? stack[stack.length - 1].level + 1 : 1;
+					this.addToHierarchy(symbols, stack, sqlSymbol, level);
+					i = endLine;
+				}
+				continue;
+			}
 
-            // Handle Svelte {#each} and {#if} blocks
-            const controlBlockMatch = line.text.match(/\{#(each|if)\s/);
-            if (controlBlockMatch) {
+			// Handle Svelte {#each} and {#if} blocks
+			const controlBlockMatch = line.text.match(/\{#(each|if)\s/);
+			if (controlBlockMatch) {
 				const blockName = `${controlBlockMatch[1].charAt(0).toUpperCase() + controlBlockMatch[1].slice(1)} Block`;
-                const endLine = this.findClosingTag(document, i, new RegExp(`{\\/${controlBlockMatch[1]}}`));
-                if (endLine !== -1) {
-                    const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
-                    const controlBlockSymbol = new DocumentSymbol(
-                        blockName,
-                        '',
-                        SymbolKind.Namespace,
-                        range,
-                        range
-                    );
+				const endLine = this.findClosingTag(
+					document,
+					i,
+					new RegExp(`{\\/${controlBlockMatch[1]}}`)
+				);
+				if (endLine !== -1) {
+					const range = new Range(i, 0, endLine, document.lineAt(endLine).text.length);
+					const controlBlockSymbol = new DocumentSymbol(
+						blockName,
+						'',
+						SymbolKind.Namespace,
+						range,
+						range
+					);
 					const level = stack.length > 0 ? stack[0].level + 1 : 1;
-                    this.addToHierarchy(symbols, stack, controlBlockSymbol, level);
-                    i = endLine;
-                    console.log(`Control Block: ${blockName}, level: ${level}, stack length: ${stack.length}`);
-                }
-                continue;
-            }
-        }
+					this.addToHierarchy(symbols, stack, controlBlockSymbol, level);
+					i = endLine;
+					console.log(
+						`Control Block: ${blockName}, level: ${level}, stack length: ${stack.length}`
+					);
+				}
+				continue;
+			}
+		}
 
-        return symbols;
-    }
+		return symbols;
+	}
 
-    addToHierarchy(symbols: DocumentSymbol[], stack: { symbol: DocumentSymbol, level: number }[], symbol: DocumentSymbol, level: number) {
-        while (stack.length > 0 && stack[stack.length - 1].level >= level) {
-            stack.pop();
-        }
-        if (stack.length > 0) {
-            stack[stack.length - 1].symbol.children.push(symbol);
-        } else {
-            symbols.push(symbol);
-        }
-        stack.push({ symbol, level });
-    }
+	addToHierarchy(
+		symbols: DocumentSymbol[],
+		stack: { symbol: DocumentSymbol; level: number }[],
+		symbol: DocumentSymbol,
+		level: number
+	) {
+		while (stack.length > 0 && stack[stack.length - 1].level >= level) {
+			stack.pop();
+		}
+		if (stack.length > 0) {
+			stack[stack.length - 1].symbol.children.push(symbol);
+		} else {
+			symbols.push(symbol);
+		}
+		stack.push({ symbol, level });
+	}
 
-    findClosingTag(document: TextDocument, startLine: number, regex: RegExp): number {
-        for (let i = startLine + 1; i < document.lineCount; i++) {
-            if (document.lineAt(i).text.match(regex)) {
-                return i;
-            }
-        }
-        return -1; // Not found
-    }
+	findClosingTag(document: TextDocument, startLine: number, regex: RegExp): number {
+		for (let i = startLine + 1; i < document.lineCount; i++) {
+			if (document.lineAt(i).text.match(regex)) {
+				return i;
+			}
+		}
+		return -1; // Not found
+	}
 }

--- a/packages/extension/src/providers/schemaViewProvider.ts
+++ b/packages/extension/src/providers/schemaViewProvider.ts
@@ -98,21 +98,19 @@ class TableItem extends vscode.TreeItem {
 		);
 	}
 }
-
-class ColumnItem extends vscode.TreeItem {
-	constructor(name: string, table: string, schema: string, evidenceType: string) {
-		super(name, vscode.TreeItemCollapsibleState.None);
-		this.description = evidenceType;
-		this.id = `${table}.${schema}.${name}`;
-		this.iconPath =
-			evidenceType === 'string'
-				? new vscode.ThemeIcon('symbol-string')
-				: evidenceType === 'number'
-					? new vscode.ThemeIcon('symbol-number')
-					: evidenceType === 'boolean'
-						? new vscode.ThemeIcon('symbol-boolean')
-						: new vscode.ThemeIcon('calendar');
-	}
-
-	// todo: convert evidenceType to iconPath like sqltools
+export class ColumnItem extends vscode.TreeItem {
+    constructor(name: string, table: string, schema: string, evidenceType: string) {
+        super(name, vscode.TreeItemCollapsibleState.None);
+        this.description = evidenceType;
+        this.id = `${table}.${schema}.${name}`;
+        this.iconPath =
+            evidenceType === 'string'
+                ? new vscode.ThemeIcon('symbol-string')
+                : evidenceType === 'number'
+                    ? new vscode.ThemeIcon('symbol-number')
+                    : evidenceType === 'boolean'
+                        ? new vscode.ThemeIcon('symbol-boolean')
+                        : new vscode.ThemeIcon('calendar');
+        this.contextValue = 'columnItem';
+    }
 }

--- a/packages/extension/src/providers/schemaViewProvider.ts
+++ b/packages/extension/src/providers/schemaViewProvider.ts
@@ -99,18 +99,18 @@ class TableItem extends vscode.TreeItem {
 	}
 }
 export class ColumnItem extends vscode.TreeItem {
-    constructor(name: string, table: string, schema: string, evidenceType: string) {
-        super(name, vscode.TreeItemCollapsibleState.None);
-        this.description = evidenceType;
-        this.id = `${table}.${schema}.${name}`;
-        this.iconPath =
-            evidenceType === 'string'
-                ? new vscode.ThemeIcon('symbol-string')
-                : evidenceType === 'number'
-                    ? new vscode.ThemeIcon('symbol-number')
-                    : evidenceType === 'boolean'
-                        ? new vscode.ThemeIcon('symbol-boolean')
-                        : new vscode.ThemeIcon('calendar');
-        this.contextValue = 'columnItem';
-    }
+	constructor(name: string, table: string, schema: string, evidenceType: string) {
+		super(name, vscode.TreeItemCollapsibleState.None);
+		this.description = evidenceType;
+		this.id = `${table}.${schema}.${name}`;
+		this.iconPath =
+			evidenceType === 'string'
+				? new vscode.ThemeIcon('symbol-string')
+				: evidenceType === 'number'
+					? new vscode.ThemeIcon('symbol-number')
+					: evidenceType === 'boolean'
+						? new vscode.ThemeIcon('symbol-boolean')
+						: new vscode.ThemeIcon('calendar');
+		this.contextValue = 'columnItem';
+	}
 }

--- a/packages/extension/src/providers/schemaViewProvider.ts
+++ b/packages/extension/src/providers/schemaViewProvider.ts
@@ -96,7 +96,7 @@ export class TableItem extends vscode.TreeItem {
 		this.columns = table.columns.map(
 			({ name, evidenceType }) => new ColumnItem(name, table.name, schema, evidenceType)
 		);
-		this.contextValue = 'tableItem'; 
+		this.contextValue = 'tableItem';
 	}
 }
 export class ColumnItem extends vscode.TreeItem {

--- a/packages/extension/src/providers/schemaViewProvider.ts
+++ b/packages/extension/src/providers/schemaViewProvider.ts
@@ -58,7 +58,7 @@ export class SchemaViewProvider implements vscode.TreeDataProvider<vscode.TreeIt
 	}
 }
 
-class SchemaItem extends vscode.TreeItem {
+export class SchemaItem extends vscode.TreeItem {
 	constructor(
 		private schema: string,
 		private tables: vscode.Uri[]

--- a/packages/extension/src/providers/schemaViewProvider.ts
+++ b/packages/extension/src/providers/schemaViewProvider.ts
@@ -87,22 +87,23 @@ type Table = {
 	columns: { name: string; evidenceType: string }[];
 };
 
-class TableItem extends vscode.TreeItem {
+export class TableItem extends vscode.TreeItem {
 	columns: ColumnItem[];
 
 	constructor(table: Table, schema: string) {
 		super(table.name, vscode.TreeItemCollapsibleState.Collapsed);
-		this.id = `${table.name}.${schema}`;
+		this.id = `${schema}.${table.name}`;
 		this.columns = table.columns.map(
 			({ name, evidenceType }) => new ColumnItem(name, table.name, schema, evidenceType)
 		);
+		this.contextValue = 'tableItem'; 
 	}
 }
 export class ColumnItem extends vscode.TreeItem {
 	constructor(name: string, table: string, schema: string, evidenceType: string) {
 		super(name, vscode.TreeItemCollapsibleState.None);
 		this.description = evidenceType;
-		this.id = `${table}.${schema}.${name}`;
+		this.id = `${schema}.${table}.${name}`;
 		this.iconPath =
 			evidenceType === 'string'
 				? new vscode.ThemeIcon('symbol-string')

--- a/packages/extension/syntaxes/emd.tmLanguage.json
+++ b/packages/extension/syntaxes/emd.tmLanguage.json
@@ -21,7 +21,7 @@
 					"include": "#svelte-js-expression"
 				}
 			],
-			"repository": {			
+			"repository": {
 				"svelte-tag": {
 					"patterns": [
 						{
@@ -35,7 +35,7 @@
 							]
 						}
 					]
-				},	
+				},
 				"svelte-template": {
 					"patterns": [
 						{
@@ -1093,8 +1093,6 @@
 				}
 			}
 		}
-
-		
 	},
 	"scopeName": "text.html.markdown.svelte"
 }

--- a/packages/extension/syntaxes/emd.tmLanguage.json
+++ b/packages/extension/syntaxes/emd.tmLanguage.json
@@ -1,5 +1,4 @@
 {
-	"$schema": "https://raw.githubusercontent.com/Septh/tmlanguage/master/tmLanguage.schema.json",
 	"name": "Markdown Svelte",
 	"patterns": [
 		{
@@ -22,11 +21,11 @@
 					"include": "#svelte-js-expression"
 				}
 			],
-			"repository": {
+			"repository": {			
 				"svelte-tag": {
 					"patterns": [
 						{
-							"begin": "(?!^#{1,}\\s+?)(?:[^{}]*?)(?=<[^(script)])",
+							"begin": "(?!^\\s*#{1,}\\s+?)(?:[^{}]*?)(?=<[^(script)])",
 							"end": "(?<=>|$)",
 							"contentName": "source.svelte",
 							"patterns": [
@@ -36,11 +35,11 @@
 							]
 						}
 					]
-				},
+				},	
 				"svelte-template": {
 					"patterns": [
 						{
-							"begin": "(?!^#{1,}\\s+?)(?:.*?)(?={[#/])",
+							"begin": "(?!^\\s*#{1,}\\s+?)(?:.*?)(?={[#/])",
 							"end": "(?<=}|$)",
 							"contentName": "source.svelte",
 							"patterns": [
@@ -54,7 +53,7 @@
 				"svelte-js-expression": {
 					"patterns": [
 						{
-							"begin": "(?!^#{1,}\\s+?)(?:.*?)(?={[^#/])",
+							"begin": "(?!^\\s*#{1,}\\s+?)(?:.*?)(?={[^#/])",
 							"end": "(?<=}|$)",
 							"contentName": "source.svelte",
 							"patterns": [
@@ -71,10 +70,1031 @@
 			"contentName": "text.html.markdown",
 			"patterns": [
 				{
-					"include": "text.html.markdown"
+					"include": "#frontMatter"
+				},
+				{
+					"include": "#block"
 				}
-			]
+			],
+			"repository": {
+				"block": {
+					"patterns": [
+						{
+							"include": "#separator"
+						},
+						{
+							"include": "#heading"
+						},
+						{
+							"include": "#blockquote"
+						},
+						{
+							"include": "#lists"
+						},
+						{
+							"include": "#link-def"
+						},
+						{
+							"include": "#html"
+						},
+						{
+							"include": "#table"
+						},
+						{
+							"include": "#paragraph"
+						}
+					]
+				},
+				"blockquote": {
+					"begin": "(^|\\G)[ ]{0,3}(>) ?",
+					"captures": {
+						"2": {
+							"name": "punctuation.definition.quote.begin.markdown"
+						}
+					},
+					"name": "markup.quote.markdown",
+					"patterns": [
+						{
+							"include": "#block"
+						}
+					],
+					"while": "(^|\\G)\\s*(>) ?"
+				},
+				"fenced_code_block_unknown": {
+					"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?=([^`]*)?$)",
+					"beginCaptures": {
+						"3": {
+							"name": "punctuation.definition.markdown"
+						},
+						"4": {
+							"name": "fenced_code.block.language"
+						}
+					},
+					"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+					"endCaptures": {
+						"3": {
+							"name": "punctuation.definition.markdown"
+						}
+					},
+					"name": "markup.fenced_code.block.markdown"
+				},
+				"heading": {
+					"match": "(?:^|\\G)\\s*(#{1,6}\\s+(.*?)(\\s+#{1,6})?\\s*)$",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "(#{6})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.6.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								},
+								{
+									"match": "(#{5})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.5.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								},
+								{
+									"match": "(#{4})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.4.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								},
+								{
+									"match": "(#{3})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.3.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								},
+								{
+									"match": "(#{2})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.2.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								},
+								{
+									"match": "(#{1})\\s+(.*?)(?:\\s+(#+))?\\s*$",
+									"name": "heading.1.markdown",
+									"captures": {
+										"1": {
+											"name": "punctuation.definition.heading.markdown"
+										},
+										"2": {
+											"name": "entity.name.section.markdown",
+											"patterns": [
+												{
+													"include": "#inline"
+												},
+												{
+													"include": "text.html.derivative"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.definition.heading.markdown"
+										}
+									}
+								}
+							]
+						}
+					},
+					"name": "markup.heading.markdown"
+				},
+				"heading-setext": {
+					"patterns": [
+						{
+							"match": "^(={3,})(?=[ \\t]*$\\n?)",
+							"name": "markup.heading.setext.1.markdown"
+						},
+						{
+							"match": "^(-{3,})(?=[ \\t]*$\\n?)",
+							"name": "markup.heading.setext.2.markdown"
+						}
+					]
+				},
+				"html": {
+					"patterns": [
+						{
+							"begin": "(^|\\G)\\s*(<!--)",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.comment.html"
+								},
+								"2": {
+									"name": "punctuation.definition.comment.html"
+								}
+							},
+							"end": "(-->)",
+							"name": "comment.block.html"
+						},
+						{
+							"begin": "(?i)(^|\\G)\\s*(?=<(script|style|pre)(\\s|$|>)(?!.*?</(script|style|pre)>))",
+							"end": "(?i)(.*)((</)(script|style|pre)(>))",
+							"endCaptures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "text.html.derivative"
+										}
+									]
+								},
+								"2": {
+									"name": "meta.tag.structure.$4.end.html"
+								},
+								"3": {
+									"name": "punctuation.definition.tag.begin.html"
+								},
+								"4": {
+									"name": "entity.name.tag.html"
+								},
+								"5": {
+									"name": "punctuation.definition.tag.end.html"
+								}
+							},
+							"patterns": [
+								{
+									"begin": "(\\s*|$)",
+									"patterns": [
+										{
+											"include": "text.html.derivative"
+										}
+									],
+									"while": "(?i)^(?!.*</(script|style|pre)>)"
+								}
+							]
+						},
+						{
+							"begin": "(?i)(^|\\G)\\s*(?=</?[a-zA-Z]+[^\\s/&gt;]*(\\s|$|/?>))",
+							"patterns": [
+								{
+									"include": "text.html.derivative"
+								}
+							],
+							"while": "^(?!\\s*$)"
+						},
+						{
+							"begin": "(^|\\G)\\s*(?=(<[a-zA-Z0-9\\-](/?>|\\s.*?>)|</[a-zA-Z0-9\\-]>)\\s*$)",
+							"patterns": [
+								{
+									"include": "text.html.derivative"
+								}
+							],
+							"while": "^(?!\\s*$)"
+						}
+					]
+				},
+				"link-def": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.constant.markdown"
+						},
+						"2": {
+							"name": "constant.other.reference.link.markdown"
+						},
+						"3": {
+							"name": "punctuation.definition.constant.markdown"
+						},
+						"4": {
+							"name": "punctuation.separator.key-value.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"6": {
+							"name": "markup.underline.link.markdown"
+						},
+						"7": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"8": {
+							"name": "markup.underline.link.markdown"
+						},
+						"9": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"10": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"11": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"12": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"13": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"14": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"15": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"16": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"17": {
+							"name": "punctuation.definition.string.end.markdown"
+						}
+					},
+					"match": "(?x)\n  \\s*            # Leading whitespace\n  (\\[)([^]]+?)(\\])(:)    # Reference name\n  [ \\t]*          # Optional whitespace\n  (?:(<)((?:\\\\[<>]|[^<>\\n])*)(>)|(\\S+?))      # The url\n  [ \\t]*          # Optional whitespace\n  (?:\n      ((\\().+?(\\)))    # Match title in parens…\n    | ((\").+?(\"))    # or in double quotes…\n    | ((').+?('))    # or in single quotes.\n  )?            # Title is optional\n  \\s*            # Optional whitespace\n  $\n",
+					"name": "meta.link.reference.def.markdown"
+				},
+				"list_paragraph": {
+					"begin": "(^|\\G)(?=\\S)(?![*+->]\\s|[0-9]+\\.\\s)",
+					"name": "meta.paragraph.markdown",
+					"patterns": [
+						{
+							"include": "#inline"
+						},
+						{
+							"include": "text.html.derivative"
+						},
+						{
+							"include": "#heading-setext"
+						}
+					],
+					"while": "(^|\\G)(?!\\s*$|#|[ ]{0,3}([-*_>][ ]{2,}){3,}[ \\t]*$\\n?|[ ]{0,3}[*+->]|[ ]{0,3}[0-9]+\\.)"
+				},
+				"lists": {
+					"patterns": [
+						{
+							"begin": "(^|\\G)([ ]{0,3})([*+-])([ \\t])",
+							"beginCaptures": {
+								"3": {
+									"name": "punctuation.definition.list.begin.markdown"
+								}
+							},
+							"comment": "Currently does not support un-indented second lines.",
+							"name": "markup.list.unnumbered.markdown",
+							"patterns": [
+								{
+									"include": "#block"
+								},
+								{
+									"include": "#list_paragraph"
+								}
+							],
+							"while": "((^|\\G)([ ]{2,4}|\\t))|(^[ \\t]*$)"
+						},
+						{
+							"begin": "(^|\\G)([ ]{0,3})([0-9]+[\\.\\)])([ \\t])",
+							"beginCaptures": {
+								"3": {
+									"name": "punctuation.definition.list.begin.markdown"
+								}
+							},
+							"name": "markup.list.numbered.markdown",
+							"patterns": [
+								{
+									"include": "#block"
+								},
+								{
+									"include": "#list_paragraph"
+								}
+							],
+							"while": "((^|\\G)([ ]{2,4}|\\t))|(^[ \\t]*$)"
+						}
+					]
+				},
+				"paragraph": {
+					"begin": "(^|\\G)[ ]{0,3}(?=[^ \\t\\n])",
+					"name": "meta.paragraph.markdown",
+					"patterns": [
+						{
+							"include": "#inline"
+						},
+						{
+							"include": "text.html.derivative"
+						},
+						{
+							"include": "#heading-setext"
+						}
+					],
+					"while": "(^|\\G)((?=\\s*[-=]{3,}\\s*$)|[ ]{4,}(?=[^ \\t\\n]))"
+				},
+				"separator": {
+					"match": "(^|\\G)[ ]{0,3}([\\*\\-\\_])([ ]{0,2}\\2){2,}[ \\t]*$\\n?",
+					"name": "meta.separator.markdown"
+				},
+				"frontMatter": {
+					"begin": "\\A-{3}\\s*$",
+					"contentName": "meta.embedded.block.frontmatter",
+					"patterns": [
+						{
+							"include": "source.yaml"
+						}
+					],
+					"end": "(^|\\G)-{3}|\\.{3}\\s*$"
+				},
+				"table": {
+					"name": "markup.table.markdown",
+					"begin": "(^|\\G)(\\|)(?=[^|].+\\|\\s*$)",
+					"beginCaptures": {
+						"2": {
+							"name": "punctuation.definition.table.markdown"
+						}
+					},
+					"while": "(^|\\G)(?=\\|)",
+					"patterns": [
+						{
+							"match": "\\|",
+							"name": "punctuation.definition.table.markdown"
+						},
+						{
+							"match": "(?<=\\|)\\s*(:?-+:?)\\s*(?=\\|)",
+							"captures": {
+								"1": {
+									"name": "punctuation.separator.table.markdown"
+								}
+							}
+						},
+						{
+							"match": "(?<=\\|)\\s*(?=\\S)((\\\\\\||[^|])+)(?<=\\S)\\s*(?=\\|)",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline"
+										}
+									]
+								}
+							}
+						}
+					]
+				},
+				"inline": {
+					"patterns": [
+						{
+							"include": "#ampersand"
+						},
+						{
+							"include": "#bracket"
+						},
+						{
+							"include": "#bold"
+						},
+						{
+							"include": "#italic"
+						},
+						{
+							"include": "#raw"
+						},
+						{
+							"include": "#strikethrough"
+						},
+						{
+							"include": "#escape"
+						},
+						{
+							"include": "#image-inline"
+						},
+						{
+							"include": "#image-ref"
+						},
+						{
+							"include": "#link-email"
+						},
+						{
+							"include": "#link-inet"
+						},
+						{
+							"include": "#link-inline"
+						},
+						{
+							"include": "#link-ref"
+						},
+						{
+							"include": "#link-ref-literal"
+						},
+						{
+							"include": "#link-ref-shortcut"
+						}
+					]
+				},
+				"ampersand": {
+					"comment": "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.",
+					"match": "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)",
+					"name": "meta.other.valid-ampersand.markdown"
+				},
+				"bold": {
+					"begin": "(?x) (?<open>(\\*\\*(?=\\w)|(?<!\\w)\\*\\*|(?<!\\w)\\b__))(?=\\S) (?=\n  (\n    <[^>]*+>              # HTML tags\n    | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n                      # Raw\n    | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+      # Escapes\n    | \\[\n    (\n        (?<square>          # Named group\n          [^\\[\\]\\\\]        # Match most chars\n          | \\\\.            # Escaped chars\n          | \\[ \\g<square>*+ \\]    # Nested brackets\n        )*+\n      \\]\n      (\n        (              # Reference Link\n          [ ]?          # Optional space\n          \\[[^\\]]*+\\]        # Ref name\n        )\n        | (              # Inline Link\n          \\(            # Opening paren\n            [ \\t]*+        # Optional whitespace\n            <?(.*?)>?      # URL\n            [ \\t]*+        # Optional whitespace\n            (          # Optional Title\n              (?<title>['\"])\n              (.*?)\n              \\k<title>\n            )?\n          \\)\n        )\n      )\n    )\n    | (?!(?<=\\S)\\k<open>).            # Everything besides\n                      # style closer\n  )++\n  (?<=\\S)(?=__\\b|\\*\\*)\\k<open>                # Close\n)\n",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.bold.markdown"
+						}
+					},
+					"end": "(?<=\\S)(\\1)",
+					"name": "markup.bold.markdown",
+					"patterns": [
+						{
+							"applyEndPatternLast": 1,
+							"begin": "(?=<[^>]*?>)",
+							"end": "(?<=>)",
+							"patterns": [
+								{
+									"include": "text.html.derivative"
+								}
+							]
+						},
+						{
+							"include": "#escape"
+						},
+						{
+							"include": "#ampersand"
+						},
+						{
+							"include": "#bracket"
+						},
+						{
+							"include": "#raw"
+						},
+						{
+							"include": "#bold"
+						},
+						{
+							"include": "#italic"
+						},
+						{
+							"include": "#image-inline"
+						},
+						{
+							"include": "#link-inline"
+						},
+						{
+							"include": "#link-inet"
+						},
+						{
+							"include": "#link-email"
+						},
+						{
+							"include": "#image-ref"
+						},
+						{
+							"include": "#link-ref-literal"
+						},
+						{
+							"include": "#link-ref"
+						},
+						{
+							"include": "#link-ref-shortcut"
+						},
+						{
+							"include": "#strikethrough"
+						}
+					]
+				},
+				"bracket": {
+					"comment": "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.",
+					"match": "<(?![a-zA-Z/?\\$!])",
+					"name": "meta.other.valid-bracket.markdown"
+				},
+				"escape": {
+					"match": "\\\\[-`*_#+.!(){}\\[\\]\\\\>]",
+					"name": "constant.character.escape.markdown"
+				},
+				"image-inline": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.description.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.description.markdown"
+						},
+						"4": {
+							"name": "punctuation.definition.link.description.end.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.metadata.markdown"
+						},
+						"7": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"8": {
+							"name": "markup.underline.link.image.markdown"
+						},
+						"9": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"10": {
+							"name": "markup.underline.link.image.markdown"
+						},
+						"12": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"13": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"14": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"15": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"16": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"17": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"18": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"19": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"20": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"21": {
+							"name": "punctuation.definition.metadata.markdown"
+						}
+					},
+					"match": "(?x)\n  (\\!\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])\n                # Match the link text.\n  (\\()            # Opening paren for url\n    # The url\n      [ \\t]*\n      (\n         (<)((?:\\\\[<>]|[^<>\\n])*)(>)\n         | ((?<url>(?>[^\\s()]+)|\\(\\g<url>*\\))*)\n      )\n      [ \\t]*\n    (?:\n        ((\\().+?(\\)))    # Match title in parens…\n      | ((\").+?(\"))    # or in double quotes…\n      | ((').+?('))    # or in single quotes.\n    )?            # Title is optional\n    \\s*            # Optional whitespace\n  (\\))\n",
+					"name": "meta.image.inline.markdown"
+				},
+				"image-ref": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.description.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.description.markdown"
+						},
+						"4": {
+							"name": "punctuation.definition.link.description.end.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.constant.markdown"
+						},
+						"6": {
+							"name": "constant.other.reference.link.markdown"
+						},
+						"7": {
+							"name": "punctuation.definition.constant.markdown"
+						}
+					},
+					"match": "(\\!\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])[ ]?(\\[)(.*?)(\\])",
+					"name": "meta.image.reference.markdown"
+				},
+				"italic": {
+					"begin": "(?x) (?<open>(\\*(?=\\w)|(?<!\\w)\\*|(?<!\\w)\\b_))(?=\\S)                # Open\n  (?=\n    (\n      <[^>]*+>              # HTML tags\n      | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n                        # Raw\n      | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+      # Escapes\n      | \\[\n      (\n          (?<square>          # Named group\n            [^\\[\\]\\\\]        # Match most chars\n            | \\\\.            # Escaped chars\n            | \\[ \\g<square>*+ \\]    # Nested brackets\n          )*+\n        \\]\n        (\n          (              # Reference Link\n            [ ]?          # Optional space\n            \\[[^\\]]*+\\]        # Ref name\n          )\n          | (              # Inline Link\n            \\(            # Opening paren\n              [ \\t]*+        # Optional whtiespace\n              <?(.*?)>?      # URL\n              [ \\t]*+        # Optional whtiespace\n              (          # Optional Title\n                (?<title>['\"])\n                (.*?)\n                \\k<title>\n              )?\n            \\)\n          )\n        )\n      )\n      | \\k<open>\\k<open>                   # Must be bold closer\n      | (?!(?<=\\S)\\k<open>).            # Everything besides\n                        # style closer\n    )++\n    (?<=\\S)(?=_\\b|\\*)\\k<open>                # Close\n  )\n",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.italic.markdown"
+						}
+					},
+					"end": "(?<=\\S)(\\1)((?!\\1)|(?=\\1\\1))",
+					"name": "markup.italic.markdown",
+					"patterns": [
+						{
+							"applyEndPatternLast": 1,
+							"begin": "(?=<[^>]*?>)",
+							"end": "(?<=>)",
+							"patterns": [
+								{
+									"include": "text.html.derivative"
+								}
+							]
+						},
+						{
+							"include": "#escape"
+						},
+						{
+							"include": "#ampersand"
+						},
+						{
+							"include": "#bracket"
+						},
+						{
+							"include": "#raw"
+						},
+						{
+							"include": "#bold"
+						},
+						{
+							"include": "#image-inline"
+						},
+						{
+							"include": "#link-inline"
+						},
+						{
+							"include": "#link-inet"
+						},
+						{
+							"include": "#link-email"
+						},
+						{
+							"include": "#image-ref"
+						},
+						{
+							"include": "#link-ref-literal"
+						},
+						{
+							"include": "#link-ref"
+						},
+						{
+							"include": "#link-ref-shortcut"
+						},
+						{
+							"include": "#strikethrough"
+						}
+					]
+				},
+				"link-email": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"2": {
+							"name": "markup.underline.link.markdown"
+						},
+						"4": {
+							"name": "punctuation.definition.link.markdown"
+						}
+					},
+					"match": "(<)((?:mailto:)?[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*)(>)",
+					"name": "meta.link.email.lt-gt.markdown"
+				},
+				"link-inet": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"2": {
+							"name": "markup.underline.link.markdown"
+						},
+						"3": {
+							"name": "punctuation.definition.link.markdown"
+						}
+					},
+					"match": "(<)((?:https?|ftp)://.*?)(>)",
+					"name": "meta.link.inet.markdown"
+				},
+				"link-inline": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.title.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.title.markdown",
+							"patterns": [
+								{
+									"include": "#raw"
+								},
+								{
+									"include": "#bold"
+								},
+								{
+									"include": "#italic"
+								},
+								{
+									"include": "#strikethrough"
+								},
+								{
+									"include": "#image-inline"
+								}
+							]
+						},
+						"4": {
+							"name": "punctuation.definition.link.title.end.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.metadata.markdown"
+						},
+						"7": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"8": {
+							"name": "markup.underline.link.markdown"
+						},
+						"9": {
+							"name": "punctuation.definition.link.markdown"
+						},
+						"10": {
+							"name": "markup.underline.link.markdown"
+						},
+						"12": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"13": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"14": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"15": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"16": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"17": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"18": {
+							"name": "string.other.link.description.title.markdown"
+						},
+						"19": {
+							"name": "punctuation.definition.string.begin.markdown"
+						},
+						"20": {
+							"name": "punctuation.definition.string.end.markdown"
+						},
+						"21": {
+							"name": "punctuation.definition.metadata.markdown"
+						}
+					},
+					"match": "(?x)\n  (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])\n                # Match the link text.\n  (\\()            # Opening paren for url\n    # The url\n      [ \\t]*\n      (\n         (<)((?:\\\\[<>]|[^<>\\n])*)(>)\n         | ((?<url>(?>[^\\s()]+)|\\(\\g<url>*\\))*)\n      )\n      [ \\t]*\n    # The title  \n    (?:\n        ((\\()[^()]*(\\)))    # Match title in parens…\n      | ((\")[^\"]*(\"))    # or in double quotes…\n      | ((')[^']*('))    # or in single quotes.\n    )?            # Title is optional\n    \\s*            # Optional whitespace\n  (\\))\n",
+					"name": "meta.link.inline.markdown"
+				},
+				"link-ref": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.title.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.title.markdown",
+							"patterns": [
+								{
+									"include": "#raw"
+								},
+								{
+									"include": "#bold"
+								},
+								{
+									"include": "#italic"
+								},
+								{
+									"include": "#strikethrough"
+								},
+								{
+									"include": "#image-inline"
+								}
+							]
+						},
+						"4": {
+							"name": "punctuation.definition.link.title.end.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.constant.begin.markdown"
+						},
+						"6": {
+							"name": "constant.other.reference.link.markdown"
+						},
+						"7": {
+							"name": "punctuation.definition.constant.end.markdown"
+						}
+					},
+					"match": "(?<![\\]\\\\])(\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])(\\[)([^\\]]*+)(\\])",
+					"name": "meta.link.reference.markdown"
+				},
+				"link-ref-literal": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.title.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.title.markdown"
+						},
+						"4": {
+							"name": "punctuation.definition.link.title.end.markdown"
+						},
+						"5": {
+							"name": "punctuation.definition.constant.begin.markdown"
+						},
+						"6": {
+							"name": "punctuation.definition.constant.end.markdown"
+						}
+					},
+					"match": "(?<![\\]\\\\])(\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])[ ]?(\\[)(\\])",
+					"name": "meta.link.reference.literal.markdown"
+				},
+				"link-ref-shortcut": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.link.title.begin.markdown"
+						},
+						"2": {
+							"name": "string.other.link.title.markdown"
+						},
+						"3": {
+							"name": "punctuation.definition.link.title.end.markdown"
+						}
+					},
+					"match": "(?<![\\]\\\\])(\\[)((?:[^\\s\\[\\]\\\\]|\\\\[\\[\\]])+?)((?<!\\\\)\\])",
+					"name": "meta.link.reference.markdown"
+				},
+				"raw": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.raw.markdown"
+						},
+						"3": {
+							"name": "punctuation.definition.raw.markdown"
+						}
+					},
+					"match": "(`+)((?:[^`]|(?!(?<!`)\\1(?!`))`)*+)(\\1)",
+					"name": "markup.inline.raw.string.markdown"
+				},
+				"strikethrough": {
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.strikethrough.markdown"
+						},
+						"2": {
+							"patterns": [
+								{
+									"applyEndPatternLast": 1,
+									"begin": "(?=<[^>]*?>)",
+									"end": "(?<=>)",
+									"patterns": [
+										{
+											"include": "text.html.derivative"
+										}
+									]
+								},
+								{
+									"include": "#escape"
+								},
+								{
+									"include": "#ampersand"
+								},
+								{
+									"include": "#bracket"
+								},
+								{
+									"include": "#raw"
+								},
+								{
+									"include": "#bold"
+								},
+								{
+									"include": "#italic"
+								},
+								{
+									"include": "#image-inline"
+								},
+								{
+									"include": "#link-inline"
+								},
+								{
+									"include": "#link-inet"
+								},
+								{
+									"include": "#link-email"
+								},
+								{
+									"include": "#image-ref"
+								},
+								{
+									"include": "#link-ref-literal"
+								},
+								{
+									"include": "#link-ref"
+								},
+								{
+									"include": "#link-ref-shortcut"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.strikethrough.markdown"
+						}
+					},
+					"match": "(?<!\\\\)(~{2,})((?:[^~]|(?!(?<![~\\\\])\\1(?!~))~)*+)(\\1)",
+					"name": "markup.strikethrough.markdown"
+				}
+			}
 		}
+
+		
 	},
 	"scopeName": "text.html.markdown.svelte"
 }


### PR DESCRIPTION
## Evidence VS Code Extension v1.5.0
Several new features for writing queries and managing large markdown files.

### Autocomplete for SQL queries
![CleanShot 2024-06-20 at 08 35 11](https://github.com/evidence-dev/evidence/assets/12602440/878e248e-b307-4b46-b456-015d639dc571)

### Improved syntax highlighting
- Better handling of nested components and indenting
- Headers stay highlighted when indented

![CleanShot 2024-06-19 at 12 46 13](https://github.com/evidence-dev/evidence/assets/12602440/83bb4766-d5f8-4319-a1fa-a25992d9084d)

### Background shading for blocks
When you add any of the below elements to your markdown page, the extension will shade the background to make it clear where that element starts and stops:
- Frontmatter
- SQL queries
- Each blocks
- If blocks

This behaviour can be turned off in the Evidence extension settings in the VS Code settings menu.

![CleanShot 2024-06-19 at 13 00 09](https://github.com/evidence-dev/evidence/assets/12602440/8ecaf32f-8733-4ef4-add9-401e85baad95)

### Collapsible blocks
You should now see an arrow at the top of large blocks of code on your page - you can click this to collapse that section, making your page easier to read and navigate.  

![CleanShot 2024-06-19 at 12 51 59](https://github.com/evidence-dev/evidence/assets/12602440/5973c8ab-46ec-4740-a6bd-3510752afb11)

This also works well for nested elements:

![CleanShot 2024-06-19 at 12 54 28](https://github.com/evidence-dev/evidence/assets/12602440/9949a203-b2bf-498f-874d-150c9933a772)


### Schema Viewer
The built-in schema viewer now lets you copy the column names from your schema and paste them into your markdown

![CleanShot 2024-06-19 at 12 58 39](https://github.com/evidence-dev/evidence/assets/12602440/aac99ca8-c1b7-4ebd-84c4-54c3bf018fb6)


### Fixes
- Fixes issue with templated page command on Windows
- Adds missing components to the slash command list