### PR TITLE
Exclude base map story from chromatic snapshots

### DIFF
--- a/packages/ui/core-components/src/lib/unsorted/viz/map/Map.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/Map.stories.svelte
@@ -26,7 +26,8 @@
 	const la_locations = Query.create(`select * from la_locations order by 1`, query);
 </script>
 
-<Story name="Basic Usage">
+<!-- Exlcuded from chromatic, map layers don't reliably load in the same order -->
+<Story name="Basic Usage" parameters={{ chromatic: { disableSnapshot: true } }}>
 	<BaseMap title="My Map" height="300">
 		<Points
 			data={la_locations}


### PR DESCRIPTION
### Description

Excludes the base map story from chromatic snapshots. 

The base map story alternates between plotting the orange la locations at the top of the layers and at the bottom, which generate spurious diffs. 

![CleanShot 2024-06-20 at 10 29 16](https://github.com/evidence-dev/evidence/assets/6857673/6e4d831d-c829-427b-8f8a-78bbedc8d425)
