### PR TITLE
Added link prop to Value Component

### DIFF
--- a/.changeset/red-readers-tan.md
+++ b/.changeset/red-readers-tan.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Added link prop to Value Component

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Value.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Value.stories.svelte
@@ -43,3 +43,6 @@
 <Story name="Agg median Usage">
 	<Value {data} column="fare" agg="median" fmt="usd0" />
 </Story>
+<Story name="Link Prop Usage">
+	<Value {data} column="fare" agg="median" fmt="usd0" link="https://evidence.dev/" />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
@@ -14,6 +14,9 @@
 	export let row = 0;
 	export let column = null;
 
+	//Passing in link for anchor tag
+	export let link;
+
 	// alias for column
 	export let value = null;
 	$: if (value && column) {
@@ -101,9 +104,17 @@
 		>[{placeholder}]<span class="error-msg">Placeholder: no data currently referenced.</span></span
 	>
 {:else if !error}
-	<span>
-		{formatValue(selected_value, format_object)}
-	</span>
+	{#if link}
+		<a class="hover:bg-blue-100" href={link}>
+			<span>
+				{formatValue(selected_value, format_object)}
+			</span>
+		</a>
+	{:else}
+		<span>
+			{formatValue(selected_value, format_object)}
+		</span>
+	{/if}
 {:else}
 	<ValueError {error} />
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Value.svelte
@@ -15,7 +15,7 @@
 	export let column = null;
 
 	//Passing in link for anchor tag
-	export let link;
+	export let link = undefined;
 
 	// alias for column
 	export let value = null;
@@ -105,7 +105,7 @@
 	>
 {:else if !error}
 	{#if link}
-		<a class="hover:bg-blue-100" href={link}>
+		<a class="markdown" href={link}>
 			<span>
 				{formatValue(selected_value, format_object)}
 			</span>

--- a/sites/docs/pages/components/value.md
+++ b/sites/docs/pages/components/value.md
@@ -162,6 +162,7 @@ Text to display when an empty dataset is received - only applies when `emptySet`
 </PropListing>
 <PropListing
     name="agg"
+    options={['sum', 'avg', 'min', 'median', 'max']}
     defaultValue="null"
 >
 
@@ -170,5 +171,5 @@ Adds aggregation to query, column name required.
 </PropListing>
 <PropListing name="link">
 
-Used to navigate to other pages. Can be a full external link like `https://google.com` or an internal link like `/sales/performance`
+Used to navigate to other pages. Can be a full external link like `https://google.com` or an internal link like `/sales/avg-sales`
 </PropListing>

--- a/sites/docs/pages/components/value.md
+++ b/sites/docs/pages/components/value.md
@@ -78,6 +78,25 @@ FROM
     <Value data={orders} column="sales" agg="avg" fmt="usd0" />
 </div>
 
+## Linking to other pages
+
+The link property makes the Value component clickable, allowing navigation to other pages.
+
+```sql total_sales
+SELECT 
+ sum(sales) as total_sales
+FROM 
+    needful_things.orders
+```
+
+```markdown
+<Value data={total_sales} column="total_sales" agg="avg" fmt="usd0" link='/components/value' />
+```
+
+<div>
+    <Value data={total_sales} column="total_sales" agg="avg" fmt="usd0" link='/components/value' />
+</div>
+
 ## Options
 
 <PropListing
@@ -143,10 +162,13 @@ Text to display when an empty dataset is received - only applies when `emptySet`
 </PropListing>
 <PropListing
     name="agg"
-    options={['sum', 'avg', 'min', 'median', 'max']}
     defaultValue="null"
 >
 
 Adds aggregation to query, column name required.
 
+</PropListing>
+<PropListing name="link">
+
+Used to navigate to other pages. Can be a full external link like `https://google.com` or an internal link like `/sales/performance`
 </PropListing>


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable

Added Link Prop to Value with Blue hover state

![image](https://github.com/evidence-dev/evidence/assets/69778837/3caf81bf-37c3-4368-af99-1809bffd7505)

Copied the structure of the Link Prop Description from the Link Button

![image](https://github.com/evidence-dev/evidence/assets/69778837/c82e9f32-e36e-426e-abd7-0a101c5c8251)

If this styling is ideal, we can normalize the blue hover state, and "link" (e.g Big Link uses "href") to the other components I've come across using links; Big Link, Button Link, Big Value


NOTE:
I think as the linking in charts/graphs becomes more specific (i.e x-axis title link, line chart link), we define those prop descriptions accordingly.  

