### PR TITLE
Fix incorrect date processing related to timezones in `formatting.js`

### DIFF
--- a/.changeset/ten-ears-build.md
+++ b/.changeset/ten-ears-build.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/component-utilities': major
+'evidence-test-environment': patch
+---
+
+Fix incorrect date processing related to timezones

--- a/packages/lib/component-utilities/src/formatting.js
+++ b/packages/lib/component-utilities/src/formatting.js
@@ -176,11 +176,6 @@ function applyFormatting(
 			try {
 				if (columnFormat.valueType === 'date' && typeof value === 'string') {
 					typedValue = new Date(standardizeDateString(value));
-				} else if (value instanceof Date) {
-					// "2023-09-06T22:40:43.000Z" minus the Z is interpreted
-					// as local time
-					// similar in behavior to standardizeDateString
-					typedValue = new Date(value.toISOString().slice(0, -1));
 				} else if (
 					columnFormat.valueType === 'number' &&
 					typeof value !== 'number' &&

--- a/sites/test-env/pages/tz.md
+++ b/sites/test-env/pages/tz.md
@@ -1,0 +1,46 @@
+# TZ
+```sql tz
+SELECT * FROM tz
+```
+
+<DataTable data={tz}>
+  {#each tz.columns as col}
+    <Column id={col.column_name} fmt="dddd mmmm d, yyyy H:MM:SS AM/PM" />
+
+  {/each}
+</DataTable>
+
+<div class="grid grid-cols-3 text-xs">
+  <span class="font-bold">Name</span>
+  <span class="font-bold">JSON.stringify</span>
+  <span class="font-bold">On page</span>
+  {#each tz.columns as col}
+    <span>{col.column_name}</span>
+    <span>{JSON.stringify(tz[0][col.column_name])}</span>
+    <span>{tz[0][col.column_name]}</span>
+  {/each}
+</div>
+
+
+# RANDOM_METRICS
+```sql random_metrics
+SELECT * FROM random_metrics
+```
+
+
+<DataTable data={random_metrics} rows="all" compact>
+  <Column id="daily1" title="Daily Formatted" fmt="dddd mmmm d, yyyy H:MM:SS AM/PM" />
+  <Column id="daily2" title="Daily" />
+  <Column id="avg_metric" />
+</DataTable>
+
+<div class="grid grid-cols-3 text-xs">
+  <span class="font-bold">Name</span>
+  <span class="font-bold">JSON.stringify</span>
+  <span class="font-bold">On page</span>
+  {#each random_metrics.columns as col}
+    <span>{col.column_name}</span>
+    <span>{JSON.stringify(random_metrics[0][col.column_name])}</span>
+    <span>{random_metrics[0][col.column_name]}</span>
+  {/each}
+</div>

--- a/sites/test-env/sources/needful_things/random_metrics.sql
+++ b/sites/test-env/sources/needful_things/random_metrics.sql
@@ -1,0 +1,24 @@
+WITH underlying_data AS (
+  SELECT * FROM (
+    SELECT 
+      "range" as hourly,
+      setseed(0) as noop,
+      random() as metric
+      FROM 
+        range(
+          DATE_TRUNC('hour', '2024-06-01 00:00:00'::timestamp AT TIME ZONE 'America/Chicago')::timestamp - INTERVAL 2 days, -- from
+          DATE_TRUNC('hour', '2024-06-01 00:00:00'::timestamp AT TIME ZONE 'America/Chicago')::timestamp, -- to
+          INTERVAL 1 hour -- space
+        )
+  )
+)
+
+
+SELECT
+  DATE_TRUNC('day', hourly) AT TIME ZONE 'America/Chicago' as daily1,
+  DATE_TRUNC('day', hourly) AT TIME ZONE 'America/Chicago' as daily2,
+  AVG(metric) as avg_metric
+FROM underlying_data
+GROUP BY ALL
+ORDER BY daily1
+

--- a/sites/test-env/sources/needful_things/tz.sql
+++ b/sites/test-env/sources/needful_things/tz.sql
@@ -1,0 +1,14 @@
+WITH inserted as (
+  SELECT
+    '2024-06-01 17:00:00+00'::timestamptz as "timestamptz_utc_offset",
+    '2024-06-01 12:00:00-05'::timestamptz as "timestamptz_local_offset",
+    '2024-06-01 17:00:00'::timestamp as "timestamp"
+)
+
+SELECT * FROM inserted
+
+-- SELECT
+--   "timestamptz_utc_offset",
+--   "timestamptz_local_offset",
+--   "timestamp" AT TIME ZONE 'America/Chicago' as "at_time_zone"
+-- FROM inserted


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

This change resolves https://github.com/evidence-dev/evidence/issues/1652

This shouldn't be released on its own, but instead it is a step in the right direction to making timezones less of a pain. Next steps explained below.

### Before and After

Using this query (`tz.sql`)
```sql
WITH inserted as (
  SELECT
    '2024-06-01 17:00:00+00'::timestamptz as "timestamptz_utc_offset",
    '2024-06-01 12:00:00-05'::timestamptz as "timestamptz_local_offset",
    '2024-06-01 17:00:00'::timestamp as "timestamp"
)

SELECT * FROM inserted
```

And a datatable with date formatting (`tz.md`)
```svelte
<DataTable data={tz}>
  {#each tz.columns as col}
    <Column id={col.column_name} fmt="dddd mmmm d, yyyy H:MM:SS AM/PM" />
  {/each}
</DataTable>
```

The dates appear in the table in UTC (5pm), not my local time (12pm)
![image](https://github.com/evidence-dev/evidence/assets/31896377/c814f17a-636f-4d15-8922-36400d306194)

After removing the incorrect date processing in `formatting.js` (truncating the `Z`), the dates correctly display in my local time (12pm)
![image](https://github.com/evidence-dev/evidence/assets/31896377/464536da-1297-40c2-98bb-e7e3c4d7fc2b)

The incorrect date processing in `formatting.js` was unnecessarily applying the timezone offset for my local timezone, causing the date to appear in UTC.

_Note: my specific timezone is not important, and this issue/solution applies to any non-UTC timezone._

### Next steps

More work is necessary to make timezones less confusing in Evidence

@archiewood Has made a diagram for the eventual timezone behavior we should work toward (may change as we get deeper into the woods)
![image](https://github.com/evidence-dev/evidence/assets/31896377/e8b753f9-ff35-496c-b3cf-ac9fed18b241)

- @archiewood @hughess QA how this change behaves with different use cases and different databases
- @archiewood Document what changes the user should make to their data/sources to accommodate this breaking change
- @archiewood Create a page in the evidence docs for Timezones as a whole

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
~~- [ ] I have added to the docs where applicable~~
~~- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
