### PR TITLE
fix: only use label as id if id not specified

### DIFF
--- a/.changeset/big-cougars-retire.md
+++ b/.changeset/big-cougars-retire.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix regression in Tabs where label always overrides id

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tab.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tab.svelte
@@ -14,7 +14,7 @@
 	 * @type {string}
 	 */
 	export let id;
-	$: id = label;
+	$: id = id ?? label;
 
 	/**
 	 * @type {boolean}

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
@@ -32,6 +32,14 @@
 	);
 </script>
 
+<Story name="Basic Usage">
+	<Tabs>
+		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
+		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
+		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
+	</Tabs>
+</Story>
+
 <Story name="Generated from a query">
 	<TextInput name="offset" title="Offset" />
 


### PR DESCRIPTION
Fixes a bug added by https://github.com/evidence-dev/evidence/pull/2158