### PR TITLE
Remove non-functional labelVisible prop from ReferencePoint and Callout

### DIFF
--- a/.changeset/tough-windows-shout.md
+++ b/.changeset/tough-windows-shout.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Remove non-functional labelVisible prop from ReferencePoint and Callout

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/Callout.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/Callout.svelte
@@ -80,12 +80,6 @@
 	/** @type {'solid' | 'dotted' | 'dashed' | undefined} */
 	export let labelBorderType = undefined;
 
-	/**
-	 * @type {'always' | 'hover'}
-	 * @default "always"
-	 */
-	export let labelVisible = 'always';
-
 	/** @type {number | string | undefined} */
 	export let fontSize = undefined;
 
@@ -147,7 +141,6 @@
 	{labelBorderRadius}
 	{labelBorderColor}
 	{labelBorderType}
-	{labelVisible}
 	{fontSize}
 	{align}
 	{bold}

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.stories.svelte
@@ -60,10 +60,6 @@
 				control: 'select',
 				options: ['solid', 'dotted', 'dashed']
 			},
-			labelVisible: {
-				control: 'select',
-				options: ['always', 'hover']
-			},
 			fontSize: {
 				control: 'number'
 			},

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
@@ -78,12 +78,6 @@
 	/** @type {'solid' | 'dotted' | 'dashed' | undefined} */
 	export let labelBorderType = undefined;
 
-	/**
-	 * @type {'always' | 'hover'}
-	 * @default "always"
-	 */
-	export let labelVisible = 'always';
-
 	/** @type {number | string | undefined} */
 	export let fontSize = undefined;
 	$: fontSize = toNumber(fontSize);
@@ -178,7 +172,6 @@
 			labelBorderRadius,
 			labelBorderColor,
 			labelBorderType,
-			labelVisible,
 			fontSize,
 			align,
 			bold,

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/reference-point.d.ts
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/reference-point.d.ts
@@ -37,7 +37,6 @@ export type ReferencePointStoreState = {
 	labelBorderWidth?: number;
 	labelBorderRadius?: number;
 	labelBorderType?: 'solid' | 'dotted' | 'dashed';
-	labelVisible: 'always' | 'hover';
 	fontSize?: number;
 	align?: 'left' | 'center' | 'right';
 	bold?: boolean;

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/reference-point.store.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/reference-point.store.js
@@ -28,7 +28,6 @@ export const createReferencePointStore = (configStore) => {
 			labelBorderColor,
 			symbolBorderWidth,
 			symbolBorderColor,
-			labelVisible,
 			align
 		} = state;
 
@@ -107,7 +106,6 @@ export const createReferencePointStore = (configStore) => {
 			markPoint: {
 				data: seriesData,
 				label: {
-					show: labelVisible === 'always',
 					width: state.labelWidth,
 					padding: state.labelPadding,
 					position: labelPosition,

--- a/sites/docs/pages/components/annotations.md
+++ b/sites/docs/pages/components/annotations.md
@@ -919,12 +919,6 @@ where sales_diff < -2000
         options={['solid', 'dotted', 'dashed']}
     />
     <PropListing
-        name=labelVisible
-        description="Whether to always show the label, or only when the symbol is hovered"
-        options={['always', 'hover']}
-        defaultValue=always
-    />
-    <PropListing
         name=fontSize
         description="The size of the font in the label"
         options=number
@@ -1227,12 +1221,6 @@ where sales_diff < -2000
         name=labelBorderType
         description="The type of border around the label background (dashed or dotted)"
         options={['solid', 'dotted', 'dashed']}
-    />
-    <PropListing
-        name=labelVisible
-        description="Whether to always show the label, or only when the symbol is hovered"
-        options={['always', 'hover']}
-        defaultValue=always
     />
     <PropListing
         name=fontSize


### PR DESCRIPTION
### Description

The `labelVisible` prop was supposed to control whether the `ReferencePoint`/`Callout` label was visible always or only on hover of the point. However, emphasis was disabled on `ReferencePoint`/`Callout` to fix flickering issues and match the behavior of ReferenceLine and ReferenceArea, so `labelVisible` is no longer functional.

Perhaps we can add it back when we revisit interactions on charts and references.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
