### PR TITLE
Don't use date in Dropdown story

### DIFF
--- a/.changeset/sixty-keys-beam.md
+++ b/.changeset/sixty-keys-beam.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Dont use a date in Dropdown story to enable UI testing

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
@@ -134,27 +134,8 @@
 	<Dropdown defaultValue={[1]} name="test1" {data} value="value" label="label" />
 </Story>
 <Story name="With a non-static default value">
-	{@const data = Query.create(
-		`
-	-- Select each day of the last 7 days using duckdb
-
-	SELECT 	strftime(generate_series, '%Y-%m-%d') as value 
-	from generate_series(
-		DATE_TRUNC('day', current_date - interval 7 days),
-		DATE_TRUNC('day', current_date),
-		interval 1 day
-	)
-	order by 1 desc
-	`,
-		query
-	)}
-
-	<Dropdown
-		defaultValue={[new Date(Date.now() - 86400000).toISOString().split('T')[0]]}
-		name="your-dropdown"
-		{data}
-		value="value"
-	/>
+	{@const data = Query.create(`select 1 as value`, query)}
+	<Dropdown defaultValue={1} name="your-dropdown" {data} value="value" />
 </Story>
 <Story name="Using Dropdowns that interact with eachother's queries">
 	<DependentDropdowns />


### PR DESCRIPTION
### Description

https://github.com/evidence-dev/evidence/assets/31896377/ab7a15d8-9623-4cbe-a4a8-28a0b275db2e

Using `select 1 as value` is essentially the same as the complicated date query, all we want to test is that the dropdown can use a default value from a query.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
