### PR TITLE
Fix label and font styling props for ReferenceLine and ReferenceArea

### DIFF
--- a/.changeset/spotty-dots-double.md
+++ b/.changeset/spotty-dots-double.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix font styling props for ReferenceLine/ReferenceArea

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.stories.svelte
@@ -45,19 +45,15 @@
 			labelPosition: {
 				control: 'select',
 				options: [
-					'left',
-					'right',
+					'topLeft',
 					'top',
+					'topRight',
+					'bottomLeft',
 					'bottom',
-					'inside',
-					'insideLeft',
-					'insideRight',
-					'insideTop',
-					'insideBottom',
-					'insideTopLeft',
-					'insideTopRight',
-					'insideBottomLeft',
-					'insideBottomRight'
+					'bottomRight',
+					'left',
+					'center',
+					'right'
 				]
 			},
 			labelBackgroundColor: {

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.stories.svelte
@@ -248,6 +248,37 @@
 	</LineChart>
 </Story>
 
+<Story
+	name="Very styled"
+	args={{
+		xMin: 20,
+		xMax: 40,
+		areaColor: 'red',
+		opacity: 0.2,
+		border: true,
+		borderType: 'dotted',
+		borderColor: 'orange',
+		borderWidth: 14,
+		labelColor: 'purple',
+		labelPadding: 10,
+		labelPosition: 'topRight',
+		labelBackgroundColor: 'cornflowerblue',
+		labelBorderWidth: 12,
+		labelBorderRadius: 8,
+		labelBorderColor: 'plum',
+		labelBorderType: 'dashed',
+		fontSize: 18,
+		align: 'center',
+		bold: true,
+		italic: true
+	}}
+	let:args
+>
+	<LineChart x="x" y="y" {data}>
+		<ReferenceArea {...args} />
+	</LineChart>
+</Story>
+
 <Story name="Error: Outside of a chart">
 	<ReferenceArea label="Reference Area" />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/reference-area.store.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/reference-area.store.js
@@ -162,7 +162,7 @@ export class ReferenceAreaStore {
 					},
 					itemStyle: {
 						color: areaColor,
-						opacity: 1,
+						opacity: config.opacity,
 						borderWidth,
 						borderColor,
 						borderType: config.borderType
@@ -170,7 +170,17 @@ export class ReferenceAreaStore {
 					label: {
 						show: true,
 						position: LABEL_POSITIONS[labelPosition],
-						color: labelColor
+						color: labelColor,
+						padding: config.labelPadding,
+						backgroundColor: config.labelBackgroundColor,
+						borderColor: config.labelBorderColor,
+						borderWidth: config.labelBorderWidth,
+						borderRadius: config.labelBorderRadius,
+						borderType: config.labelBorderType,
+						fontSize: config.fontSize,
+						align: config.align,
+						fontWeight: config.bold ? 'bold' : undefined,
+						fontStyle: config.italic ? 'italic' : undefined
 					}
 				}
 			};

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.stories.svelte
@@ -59,21 +59,7 @@
 			},
 			labelPosition: {
 				control: 'select',
-				options: [
-					'left',
-					'right',
-					'top',
-					'bottom',
-					'inside',
-					'insideLeft',
-					'insideRight',
-					'insideTop',
-					'insideBottom',
-					'insideTopLeft',
-					'insideTopRight',
-					'insideBottomLeft',
-					'insideBottomRight'
-				]
+				options: ['aboveStart', 'aboveCenter', 'aboveEnd', 'belowStart', 'belowCenter', 'belowEnd']
 			},
 			labelBackgroundColor: {
 				control: 'color'

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.stories.svelte
@@ -345,6 +345,34 @@
 	</LineChart>
 </Story>
 
+<Story
+	name="Very styled"
+	args={{
+		x: 50,
+		lineType: 'dotted',
+		lineColor: 'red',
+		lineWidth: 5,
+		hideValue: true,
+		labelColor: 'cyan',
+		labelPadding: 10,
+		labelPosition: 'belowCenter',
+		labelBackgroundColor: 'purple',
+		labelBorderWidth: 12,
+		labelBorderRadius: 8,
+		labelBorderColor: 'orangered',
+		labelBorderType: 'dashed',
+		fontSize: 15,
+		align: 'center',
+		bold: true,
+		italic: true
+	}}
+	let:args
+>
+	<LineChart x="x" y="y" {data}>
+		<ReferenceLine {...args} />
+	</LineChart>
+</Story>
+
 <Story name="Error: Outside of a chart">
 	<ReferenceLine x={50} label="Reference Line" />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
@@ -85,11 +85,8 @@
 	/** @type {import('../types.js').Symbol | undefined} */
 	export let symbolEnd = undefined;
 
-	/**
-	 * @type {number | string}
-	 * @default 8
-	 */
-	export let symbolEndSize = 8;
+	/** @type {number | string | undefined} */
+	export let symbolEndSize = undefined;
 
 	/** @type {import('../types.js').ReferenceColor | undefined} */
 	export let labelColor = undefined;

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/reference-line.store.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/reference-line.store.js
@@ -179,8 +179,15 @@ export class ReferenceLineStore {
 						position: labelPosition,
 						color: labelColor,
 						backgroundColor: config.labelBackgroundColor,
-						padding: config.labelPadding,
+						borderColor: config.labelBorderColor,
+						borderWidth: config.labelBorderWidth,
 						borderRadius: config.labelBorderRadius,
+						borderType: config.labelBorderType,
+						padding: config.labelPadding,
+						fontSize: config.fontSize,
+						align: config.align,
+						fontWeight: config.bold ? 'bold' : undefined,
+						fontStyle: config.italic ? 'italic' : undefined,
 						formatter: (params) => {
 							const label = params.name;
 							let result = '';

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.stories.svelte
@@ -95,6 +95,9 @@
 			preserveWhitespace: {
 				control: 'boolean'
 			}
+		},
+		args: {
+			label: 'Reference Point'
 		}
 	};
 </script>
@@ -237,6 +240,36 @@
 			with
 			line breaks
 		</Callout>
+	</LineChart>
+</Story>
+
+<Story
+	name="Very styled"
+	args={{
+		x: 24,
+		y: 514,
+		labelColor: 'lightgreen',
+		labelPadding: 10,
+		labelPosition: 'bottom',
+		labelBackgroundColor: 'cornflowerblue',
+		labelBorderWidth: 3,
+		labelBorderRadius: 999,
+		labelBorderColor: 'orangered',
+		labelBorderType: 'dashed',
+		fontSize: 10,
+		align: 'center',
+		bold: true,
+		italic: true,
+		symbolSize: 30,
+		symbolOpacity: 0.5,
+		symbolBorderWidth: 10,
+		symbolBorderColor: 'plum'
+	}}
+	let:args
+>
+	{@const data = Query.create(`SELECT * FROM numeric_series WHERE series='pink'`, query)}
+	<LineChart x="x" y="y" {data}>
+		<ReferencePoint {...args} />
 	</LineChart>
 </Story>
 


### PR DESCRIPTION
### Description

In the haste of refactoring, new props were added but weren't being properly utilized. Now they are, and we have stories to catch any bugs in the future with these props.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

![image](https://github.com/user-attachments/assets/fce3d080-1c20-43a1-875b-447158b5a002)
![image](https://github.com/user-attachments/assets/87b1ed87-c614-4641-a2e7-9f69480f571e)
![image](https://github.com/user-attachments/assets/3f206e43-9249-4257-bf73-618ee04e173c)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

~~- [ ] I have added to the docs where applicable~~
~~- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
