### PR TITLE
Properly handle Windows paths in source query HMR

### DIFF
--- a/.changeset/shaggy-cups-jam.md
+++ b/.changeset/shaggy-cups-jam.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/sdk': patch
+---
+
+Fix sources HMR on Windows

--- a/packages/lib/sdk/src/build-dev/vite/datasource-plugins/source-query-hmr.js
+++ b/packages/lib/sdk/src/build-dev/vite/datasource-plugins/source-query-hmr.js
@@ -96,13 +96,15 @@ export const sourceQueryHmr = () => {
 		},
 		/** @type {import("vite").Plugin['watchChange']} */
 		watchChange: async function (id) {
-			if (!id.startsWith(sourcesDirectory)) return; // don't care
-			const parts = id.replace(sourcesDirectory, '').split('/');
+			const changed = path.resolve(id);
+			if (!changed.startsWith(sourcesDirectory)) return; // don't care
+
+			const parts = changed.replace(sourcesDirectory, '').split(path.sep);
 			const sourceName = parts.at(1);
-			const queryName = path.basename(id).split('.').at(0);
+			const queryName = path.basename(changed).split('.').at(0);
 			if (!sourceName || !queryName) {
 				console.warn(
-					`Failed to HMR source query at ${id}, could not identify source or query name`
+					`Failed to HMR source query at ${changed}, could not identify source or query name`
 				);
 				return;
 			}


### PR DESCRIPTION
### Description

On a Windows system, the path given to the `watchChange` callback was a unix-style path `/path/to/file.ext`, but the `sourcesDirectory` was a windows style path `C:\\path\to\file.ext` causing us to ignore the watch change.

The fix is simply to use `path.resolve` to convert the `watchChange` `id` to the proper path for the operating system, and using `path.sep` when we split the path into `parts`

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)

~~- For UI or styling changes, I have added a screenshot or gif showing before & after~~
~~- I have added to the docs where applicable~~
~~- I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
