### PR TITLE
Allow disabling downloads / image saving for charts

### DIFF
--- a/.changeset/mighty-chefs-reflect.md
+++ b/.changeset/mighty-chefs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adds option to disable downloads for data and/or images from charts

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
@@ -157,7 +157,7 @@
 			downloadableImage: {
 				control: 'boolean',
 				options: [true, false]
-			},
+			}
 		}
 	};
 </script>

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
@@ -149,7 +149,15 @@
 			renderer: {
 				control: 'options',
 				options: ['canvas', 'svg']
-			}
+			},
+			downloadableData: {
+				control: 'boolean',
+				options: [true, false]
+			},
+			downloadableImage: {
+				control: 'boolean',
+				options: [true, false]
+			},
 		}
 	};
 </script>
@@ -242,4 +250,17 @@ LIMIT 200`,
 >
 	{@const emptySet = []}
 	<AreaChart data={emptySet} {...args} />
+</Story>
+
+<Story
+	name="Non-downloadable"
+	args={{
+		x: 'departure_date',
+		y: 'total_fare',
+		downloadableData: false,
+		downloadableImage: false
+	}}
+	let:args
+>
+	<AreaChart data={planeData} {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
@@ -73,6 +73,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let seriesColors = undefined;
 
 	export let connectGroup = undefined;
@@ -116,6 +118,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
@@ -42,7 +42,7 @@
 			downloadableImage: {
 				control: 'boolean',
 				options: [true, false]
-			},
+			}
 		},
 		args: {
 			xHasGaps: false,

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
@@ -34,7 +34,15 @@
 			seriesLabels: {
 				type: 'boolean',
 				control: { type: 'boolean' }
-			}
+			},
+			downloadableData: {
+				control: 'boolean',
+				options: [true, false]
+			},
+			downloadableImage: {
+				control: 'boolean',
+				options: [true, false]
+			},
 		},
 		args: {
 			xHasGaps: false,

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
@@ -110,6 +110,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let seriesColors = undefined;
 
 	export let connectGroup = undefined;
@@ -167,6 +169,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.stories.svelte
@@ -93,6 +93,14 @@
 				control: 'select',
 				options: ['canvas', 'svg']
 			},
+			downloadableData: {
+				control: 'boolean',
+				options: [true, false]
+			},
+			downloadableImage: {
+				control: 'boolean',
+				options: [true, false]
+			},
 			eChartsOptions: {
 				control: 'object'
 			},

--- a/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
@@ -46,6 +46,8 @@
 	export let seriesOptions = undefined;
 	export let printEchartsConfig = false;
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
 
@@ -107,6 +109,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
@@ -112,6 +112,14 @@
 				control: 'select',
 				options: ['canvas', 'svg']
 			},
+			downloadableData: {
+				control: 'boolean',
+				options: [true, false]
+			},
+			downloadableImage: {
+				control: 'boolean',
+				options: [true, false]
+			},
 			echartsOptions: {
 				control: 'object'
 			},

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
@@ -61,6 +61,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let seriesColors = undefined;
 
 	export let connectGroup = undefined;
@@ -105,6 +107,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
@@ -24,7 +24,8 @@
 	export let data;
 
 	export let renderer = undefined;
-
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let echartsOptions = undefined;
 	export let seriesOptions = undefined;
 	export let printEchartsConfig; // helper for custom chart development
@@ -99,46 +100,50 @@
 		{seriesOptions}
 		{seriesColors}
 	/>
-
-	<div class="chart-footer">
-		<DownloadData
-			text="Save image"
-			class="download-button"
-			downloadData={() => {
-				downloadChart = true;
-				setTimeout(() => {
-					downloadChart = false;
-				}, 0);
-			}}
-			display={hovering}
-			{queryID}
-		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="12"
-				height="12"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="#000"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<rect x="3" y="3" width="18" height="18" rx="2" />
-				<circle cx="8.5" cy="8.5" r="1.5" />
-				<path d="M20.4 14.5L16 10 4 20" />
-			</svg>
-		</DownloadData>
-		{#if data}
-			<DownloadData
-				text="Download data"
-				{data}
-				{queryID}
-				class="download-button"
-				display={hovering}
-			/>
-		{/if}
-	</div>
+	
+	{#if downloadableData || downloadableImage}
+		<div class="chart-footer">
+			{#if downloadableImage}	
+				<DownloadData
+					text="Save Image"
+					class="download-button"
+					downloadData={() => {
+						downloadChart = true;
+						setTimeout(() => {
+							downloadChart = false;
+						}, 0);
+					}}
+					display={hovering}
+					{queryID}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="12"
+						height="12"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="#000"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<rect x="3" y="3" width="18" height="18" rx="2" />
+						<circle cx="8.5" cy="8.5" r="1.5" />
+						<path d="M20.4 14.5L16 10 4 20" />
+					</svg>
+				</DownloadData>
+			{/if}
+			{#if data && downloadableData}
+				<DownloadData
+					text="Download Data"
+					{data}
+					{queryID}
+					class="download-button"
+					display={hovering}
+				/>
+			{/if}
+		</div>
+	{/if}
 
 	{#if printEchartsConfig && !printing}
 		<CodeBlock source={JSON.stringify(config, undefined, 3)} copyToClipboard={true}>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
@@ -100,10 +100,10 @@
 		{seriesOptions}
 		{seriesColors}
 	/>
-	
+
 	{#if downloadableData || downloadableImage}
 		<div class="chart-footer">
-			{#if downloadableImage}	
+			{#if downloadableImage}
 				<DownloadData
 					text="Save Image"
 					class="download-button"

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -155,6 +155,10 @@
 	export let chartAreaHeight;
 
 	export let renderer = undefined; // can be canvas (default) or SVG
+	export let downloadableData = true;
+	$: downloadableData = downloadableData === 'true' || downloadableData === true;
+	export let downloadableImage = true;
+	$: downloadableImage = downloadableImage === 'true' || downloadableImage === true;
 
 	export let connectGroup = undefined; // string represent name of group for connected charts. Charts with same connectGroup will have connected interactions
 
@@ -1062,6 +1066,8 @@
 			{seriesOptions}
 			{printEchartsConfig}
 			{renderer}
+			{downloadableData}
+			{downloadableImage}
 			{connectGroup}
 			{seriesColors}
 		/>

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/CalendarHeatmap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/CalendarHeatmap.stories.svelte
@@ -50,6 +50,12 @@
 			renderer: {
 				control: 'select',
 				options: ['canvas', 'svg']
+			},
+			downloadableData: {
+				control: 'boolean'
+			},
+			downloadableImage: {
+				control: 'boolean'
 			}
 		}
 	};

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_CalendarHeatmap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_CalendarHeatmap.svelte
@@ -52,6 +52,8 @@
 	$: printEchartsConfig = printEchartsConfig === 'true' || printEchartsConfig === true;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
 
@@ -363,6 +365,8 @@
 		{config}
 		{printEchartsConfig}
 		{renderer}
+		{downloadableData}
+		{downloadableImage}
 		{connectGroup}
 		{echartsOptions}
 		{seriesOptions}

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
@@ -76,6 +76,8 @@
 	export let cellHeight = 30;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
 
@@ -353,6 +355,8 @@
 		{printEchartsConfig}
 		evidenceChartTitle={title}
 		{renderer}
+		{downloadableData}
+		{downloadableImage}
 		{connectGroup}
 	/>
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
@@ -40,6 +40,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
 </script>
@@ -73,6 +75,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 >
 	<Hist {fillColor} {fillOpacity} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.stories.svelte
@@ -31,7 +31,15 @@
 	component={LineChart}
 	argTypes={{
 		title: { control: 'text' },
-		series: { control: 'text' }
+		series: { control: 'text' },
+		downloadableData: {
+			control: 'boolean',
+			options: [true, false]
+		},
+		downloadableImage: {
+			control: 'boolean',
+			options: [true, false]
+		}
 	}}
 	args={{
 		data: Query.create('select * from series_demo_source.numeric_series', query)

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
@@ -91,6 +91,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let seriesColors = undefined;
 
 	export let connectGroup = undefined;
@@ -144,6 +146,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
@@ -1,6 +1,6 @@
 <script context="module">
 	/** @type {import("@storybook/svelte").Meta}*/
-	export const meta = { 
+	export const meta = {
 		title: 'Charts/USMap',
 		argTypes: {
 			downloadableData: {
@@ -10,7 +10,7 @@
 			downloadableImage: {
 				control: 'boolean',
 				options: [true, false]
-			},
+			}
 		}
 	};
 </script>
@@ -24,6 +24,5 @@
 
 <Story name="Basic Usage" let:args>
 	{@const data = Query.create(`SELECT * from state_sales`, query)}
-	<USMap {data} {...args}
-		state="state" value="sales" />
+	<USMap {data} {...args} state="state" value="sales" />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
@@ -1,6 +1,18 @@
 <script context="module">
 	/** @type {import("@storybook/svelte").Meta}*/
-	export const meta = { title: 'Charts/USMap' };
+	export const meta = { 
+		title: 'Charts/USMap',
+		argTypes: {
+			downloadableData: {
+				control: 'boolean',
+				options: [true, false]
+			},
+			downloadableImage: {
+				control: 'boolean',
+				options: [true, false]
+			},
+		}
+	};
 </script>
 
 <script>
@@ -10,7 +22,8 @@
 	import { query } from '@evidence-dev/universal-sql/client-duckdb';
 </script>
 
-<Story name="Basic Usage">
+<Story name="Basic Usage" let:args>
 	{@const data = Query.create(`SELECT * from state_sales`, query)}
-	<USMap {data} state="state" value="sales" />
+	<USMap {data} {...args}
+		state="state" value="sales" />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
@@ -29,6 +29,10 @@
 	export let seriesOptions = undefined;
 	export let printEchartsConfig = false;
 	export let renderer = undefined;
+	export let downloadableData = true;
+	$: downloadableData = downloadableData === 'true' || downloadableData === true;
+	export let downloadableImage = true;
+	$: downloadableImage = downloadableImage === 'true' || downloadableImage === true;
 
 	export let connectGroup = undefined;
 
@@ -95,45 +99,49 @@
 		{extraHeight}
 	/>
 
-	<div class="chart-footer">
-		<DownloadData
-			text="Save image"
-			class="download-button"
-			downloadData={() => {
-				downloadChart = true;
-				setTimeout(() => {
-					downloadChart = false;
-				}, 0);
-			}}
-			display={hovering}
-			{queryID}
-		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="12"
-				height="12"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="#000"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<rect x="3" y="3" width="18" height="18" rx="2" />
-				<circle cx="8.5" cy="8.5" r="1.5" />
-				<path d="M20.4 14.5L16 10 4 20" />
-			</svg>
-		</DownloadData>
-		{#if data}
-			<DownloadData
-				text="Download data"
-				{data}
-				{queryID}
-				class="download-button"
-				display={hovering}
-			/>
-		{/if}
-	</div>
+	{#if downloadableImage || downloadableData}
+		<div class="chart-footer">
+			{#if downloadableImage}
+				<DownloadData
+					text="Save Image"
+					class="download-button"
+					downloadData={() => {
+						downloadChart = true;
+						setTimeout(() => {
+							downloadChart = false;
+						}, 0);
+					}}
+					display={hovering}
+					{queryID}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="12"
+						height="12"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="#000"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<rect x="3" y="3" width="18" height="18" rx="2" />
+						<circle cx="8.5" cy="8.5" r="1.5" />
+						<path d="M20.4 14.5L16 10 4 20" />
+					</svg>
+				</DownloadData>
+			{/if}
+			{#if data && downloadableData}
+				<DownloadData
+					text="Download Data"
+					{data}
+					{queryID}
+					class="download-button"
+					display={hovering}
+				/>
+			{/if}
+		</div>
+	{/if}
 
 	{#if printEchartsConfig && !printing}
 		<CodeBlock>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
@@ -134,6 +134,8 @@
 	export let printEchartsConfig = false;
 	$: printEchartsConfig = printEchartsConfig === 'true' || printEchartsConfig === true;
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
 
@@ -335,6 +337,8 @@
 		{seriesOptions}
 		{printEchartsConfig}
 		{renderer}
+		{downloadableData}
+		{downloadableImage}
 		{connectGroup}
 	/>
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -60,6 +60,8 @@
 	export let emptyMessage = undefined;
 
 	export let renderer = undefined;
+	export let downloadableData = undefined;
+	export let downloadableImage = undefined;
 	export let seriesColors = undefined;
 
 	export let connectGroup = undefined;
@@ -103,6 +105,8 @@
 	{emptySet}
 	{emptyMessage}
 	{renderer}
+	{downloadableData}
+	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
 >

--- a/sites/docs/pages/components/area-chart.md
+++ b/sites/docs/pages/components/area-chart.md
@@ -463,6 +463,21 @@ queries:
     options={["canvas", "svg"]}
     defaultValue="canvas"
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+    
 
 
 ### Custom Echarts Options

--- a/sites/docs/pages/components/bar-chart.md
+++ b/sites/docs/pages/components/bar-chart.md
@@ -651,6 +651,20 @@ queries:
     options={['canvas', 'svg']}
     defaultValue=canvas
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/box-plot.md
+++ b/sites/docs/pages/components/box-plot.md
@@ -353,6 +353,20 @@ from ${sales_distribution_by_channel}
     options={['canvas', 'svg']}
     defaultValue="canvas"
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/bubble-chart.md
+++ b/sites/docs/pages/components/bubble-chart.md
@@ -338,6 +338,20 @@ queries:
     options="canvas | svg"
     defaultValue='canvas'
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/calendar-heatmap.md
+++ b/sites/docs/pages/components/calendar-heatmap.md
@@ -195,6 +195,20 @@ queries:
     options={['canvas', 'svg']}
     defaultValue="canvas"
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/heatmap.md
+++ b/sites/docs/pages/components/heatmap.md
@@ -385,6 +385,21 @@ order by state asc, item asc
     options={['canvas', 'svg']}
     defaultValue="canvas"
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/histogram.md
+++ b/sites/docs/pages/components/histogram.md
@@ -254,6 +254,20 @@ Minimum height of the chart area (excl. header and footer) in pixels. Adjusting 
     options={['canvas', 'svg']}
     defaultValue="canvas"
 >
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 Which chart renderer type (canvas or SVG) to use. See ECharts' [documentation on renderers](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/).
 

--- a/sites/docs/pages/components/line-chart.md
+++ b/sites/docs/pages/components/line-chart.md
@@ -606,6 +606,20 @@ group by all
     options={["canvas", "svg"]}
     defaultValue="canvas"
 />
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 ### Custom Echarts Options
 

--- a/sites/docs/pages/components/mixed-type-charts.md
+++ b/sites/docs/pages/components/mixed-type-charts.md
@@ -339,6 +339,20 @@ Apply a specific color to each series in your chart. Unspecified series will rec
     options={['canvas', 'svg']}
     defaultValue="canvas"
 >
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 Which chart renderer type (canvas or SVG) to use. See ECharts' [documentation on renderers](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/).
 

--- a/sites/docs/pages/components/scatter-plot.md
+++ b/sites/docs/pages/components/scatter-plot.md
@@ -410,6 +410,20 @@ Minimum height of the chart area (excl. header and footer) in pixels. Adjusting 
     options='canvas | svg'
     defaultValue='canvas'
 >
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 Which chart renderer type (canvas or SVG) to use. See ECharts' [documentation on renderers](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/).
 

--- a/sites/docs/pages/components/us-map.md
+++ b/sites/docs/pages/components/us-map.md
@@ -293,6 +293,20 @@ Text to display when an empty dataset is received - only applies when `emptySet`
     options={['canvas','svg']}
     defaultValue='canvas'
 >
+<PropListing
+    name="downloadableData"
+    description="Whether to show the download button to allow users to download the data"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
+<PropListing
+    name="downloadableImage"
+    description="Whether to show the button to allow users to save the chart as an image"
+    required=false
+    options={["true", "false"]}
+    defaultValue="true"
+/>
 
 Which chart renderer type (canvas or SVG) to use. See ECharts' [documentation on renderers](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/).
 

--- a/sites/docs/pages/core-concepts/exports/index.md
+++ b/sites/docs/pages/core-concepts/exports/index.md
@@ -20,7 +20,7 @@ The PDF reflects the current state of the page - for example if queries are show
 
 ## CSV
 
-Data can be exported as CSV files, using the "Download data" option in the bottom right of a component.
+Data can be exported as CSV files, using the "Download Data" option in the bottom right of a component.
 
 To see the download option, hover over the component. The following components support CSV downloads:
 

--- a/sites/example-project/src/pages/charts/area-chart/+page.md
+++ b/sites/example-project/src/pages/charts/area-chart/+page.md
@@ -95,6 +95,17 @@ stepPosition=middle
     yLogBase=2
 />
 
+## Area - Disable Downloads
+
+<AreaChart
+    data={orders_by_category.filter(d => d.category === "Sinister Toys")}
+    x=month
+    y=sales_usd0k 
+    downloadableData=false
+    downloadableImage=false
+/>
+
+
 ## Not allowed Log charts: No Y axis
 
 <AreaChart

--- a/tests/UI/areaChart.spec.ts
+++ b/tests/UI/areaChart.spec.ts
@@ -62,8 +62,8 @@ test.describe('Charts: Area', () => {
 		await page.waitForTimeout(300);
 
 		// grab the save and download button
-		const saveImageButton: Locator = await page.getByRole('button', { name: 'Save image' });
-		const downloadDataButton: Locator = await page.getByRole('button', { name: 'Download data' });
+		const saveImageButton: Locator = await page.getByRole('button', { name: 'Save Image' });
+		const downloadDataButton: Locator = await page.getByRole('button', { name: 'Download Data' });
 
 		// button should be visible
 		await expect(saveImageButton).toBeVisible();


### PR DESCRIPTION
Fixes #2274 

### Description

- This PR adds the ability for developers to disable downloading data or saving images from charts.
  - `downloadableData=false` removes the download data option
  - `downloadableImage=false` removes the saveImage option
  - The two are independent.
  - In the case where both are disabled, the whole footer is removed
- Also Title Cases the labels for these buttons, (a long standing gripe of mine)

### Not Addressed

Project level config for this setting

#### Neither

![CleanShot 2024-07-26 at 20 14 43@2x](https://github.com/user-attachments/assets/ac573591-ebf0-460a-b7fd-0e37b6ce2546)


#### Just `downloadableData=false`

![CleanShot 2024-07-26 at 20 14 17@2x](https://github.com/user-attachments/assets/28661e4f-677c-44bd-a118-bdf13fbd70f0)


#### Both
![CleanShot 2024-07-26 at 20 11 37@2x](https://github.com/user-attachments/assets/b884f7dd-d542-408e-b69f-b45ee35fa511)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
