### PR TITLE
Fix: Flush telemetry events immediately to prevent sources command hanging

### DIFF
--- a/.changeset/healthy-spoons-mix.md
+++ b/.changeset/healthy-spoons-mix.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/telemetry': patch
+---
+
+Fixes issue causing sources to hang after running

--- a/packages/lib/telemetry/index.cjs
+++ b/packages/lib/telemetry/index.cjs
@@ -110,7 +110,7 @@ const logEvent = async (
 
 		if (usageStats === 'yes') {
 			const projectProfile = await getProfile();
-			const analytics = new Analytics({ writeKey: wK });
+			const analytics = new Analytics({ writeKey: wK, flushAt: 1 });
 			const payload = {
 				anonymousId: projectProfile.anonymousId,
 				event: eventName,


### PR DESCRIPTION
### Description

Fixes: https://github.com/evidence-dev/evidence/issues/1690

As per the [Segment Docs](https://segment.com/docs/connections/sources/catalog/libraries/server/node/#batching), Segment batches events to send them:

> By default, Segment’s library will flush:
>  - Every 15 messages (controlled by settings.flushAt).
>  - If 10 seconds has passed since the last flush

This causes segment to wait for a long time before flushing, and causes `npm run sources` to hang before the flush completes. The solution is to flush after every event, as recommended by the Segment docs.

(An alternative if we were sending lots more events, would be to decrease the flushInterval)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
