### PR TITLE
Increase playwright preview timeout

### DIFF
--- a/e2e/playwright-config.js
+++ b/e2e/playwright-config.js
@@ -43,6 +43,7 @@ export const config = {
 	webServer: {
 		command: process.env.DEV ? 'pnpm dev' : 'pnpm preview',
 		port: 3000,
-		reuseExistingServer: !process.env.CI
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000
 	}
 };


### PR DESCRIPTION
### Description

Windows checks were failing here because the preview web server wasn't ready within 1 minute.
This PR increases the timeout to 2 minutes.
