### PR TITLE
Fix/2323 tab styling button groups

### DIFF
--- a/.changeset/wise-bees-type.md
+++ b/.changeset/wise-bees-type.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Added button groups with tab styles prop

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.stories.svelte
@@ -129,3 +129,39 @@
 
 	Current Value: {$inputStore[args.name]}
 </Story>
+
+<Story name="Button Group Styled as Tabs" let:args>
+	<div class="mb-8">
+		<ButtonGroup
+			{...args}
+			preset="dates"
+			title="Default Button Style"
+			name="defaultStyle"
+			color="red"
+		/>
+	</div>
+	Current Value: {$inputStore['defaultStyle']}
+	<div class="mb-8 mt-4">
+		<ButtonGroup
+			{...args}
+			preset="dates"
+			display="tabs"
+			title="Buttons Styled as Tabs"
+			name="tabsStyle"
+		/>
+	</div>
+	Current Value: {$inputStore['tabsStyle']}
+</Story>
+
+<Story name="Hard Coded Entries with Tab Stylings" let:args>
+	<div class="mb-8">
+		<ButtonGroup {...args} display="tabs">
+			<ButtonGroupItem valueLabel="Option 1" value={1} />
+			<ButtonGroupItem valueLabel="Option 2" value={2} />
+			<ButtonGroupItem valueLabel="Option 3" value={3} />
+			<ButtonGroupItem valueLabel="Option 4" value={4} />
+		</ButtonGroup>
+	</div>
+
+	Current Value: {$inputStore[args.name]}
+</Story>

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -6,7 +6,7 @@
 	import { presets, setButtonGroupContext } from './lib.js';
 	import { writable, readonly } from 'svelte/store';
 	import { INPUTS_CONTEXT_KEY } from '@evidence-dev/component-utilities/globalContexts';
-	import { getContext } from 'svelte';
+	import { getContext, setContext } from 'svelte';
 	import { buildReactiveInputQuery } from '@evidence-dev/component-utilities/buildQuery';
 	import ButtonGroupItem from './ButtonGroupItem.svelte';
 	import { page } from '$app/stores';
@@ -21,6 +21,13 @@
 
 	/** @type {keyof typeof presets | undefined} */
 	export let preset = undefined;
+
+	// for Tabs styling
+	export let display;
+
+	setContext('button-display', display);
+
+	export let color = 'hsla(207, 65%, 39%, 1)';
 
 	const inputs = getContext(INPUTS_CONTEXT_KEY);
 
@@ -49,21 +56,28 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="inline-flex w-fit max-w-full flex-col mt-2 mb-4 ml-0 mr-2">
+	<div
+		class={display === 'tabs' ? '' : 'inline-flex w-fit max-w-full flex-col mt-2 mb-4 ml-0 mr-2'}
+	>
 		{#if title}
 			<span class="text-gray-900 text-sm block mb-1">{title}</span>
 		{/if}
-		<div class="inline-flex rounded-md shadow-sm overflow-auto border no-scrollbar" role="group">
+		<div
+			class={display === 'tabs'
+				? 'my-6 flex flex-wrap gap-x-1 gap-y-1'
+				: 'inline-flex rounded-md shadow-sm overflow-auto border no-scrollbar'}
+			role="group"
+		>
 			{#if preset}
 				{#if presets[preset]}
 					{#each presets[preset] as { value, valueLabel }}
-						<ButtonGroupItem {value} {valueLabel} />
+						<ButtonGroupItem {value} {valueLabel} {color} {display} />
 					{/each}
 				{:else}
 					<span class="text-red-500 font-bold text-sm">{preset} is not a valid preset</span>
 				{/if}
 			{:else}
-				<slot />
+				<slot {display} />
 				{#if hasQuery}
 					<QueryLoad data={query} let:loaded>
 						<svelte:fragment slot="skeleton">
@@ -71,7 +85,7 @@
 						</svelte:fragment>
 						<svelte:fragment>
 							{#each loaded as { label, value }}
-								<ButtonGroupItem {value} valueLabel={label} />
+								<ButtonGroupItem {value} valueLabel={label} {color} {display} />
 							{/each}
 						</svelte:fragment>
 					</QueryLoad>

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
@@ -4,10 +4,15 @@
 
 <script>
 	import { getButtonGroupContext } from './lib.js';
+	import { getContext } from 'svelte';
 	/** @type {string} */
+	import TabDisplay from '../../../unsorted/ui/Tabs/TabDisplay.svelte';
 	export let valueLabel;
 	/** @type {string | boolean | number | Date} */
 	export let value;
+	export let color = 'hsla(207, 65%, 39%, 1)';
+
+	let display = getContext('button-display');
 
 	const { update, value: currentValue } = getButtonGroupContext();
 
@@ -20,16 +25,26 @@
 	}
 </script>
 
-<button
-	type="button"
-	class=" flex-none py-1 font-medium h-8 px-3 text-xs truncate
-                                border-r last:border-none
-                                hover:bg-gray-100 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-400
-                                {$currentValue?.value === value
-		? 'z-10 border-gray-200 bg-gray-100 text-blue-700'
-		: 'z-0 bg-white text-gray-900 border-gray-200'}
+{#if display === 'tabs'}
+	<TabDisplay
+		id={value}
+		label={valueLabel}
+		{color}
+		on:click={() => update({ valueLabel, value })}
+		activeId={$currentValue?.value}
+	/>
+{:else}
+	<button
+		type="button"
+		class=" flex-none py-1 font-medium h-8 px-3 text-xs truncate
+		border-r last:border-none
+		hover:bg-gray-100 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-400
+		{$currentValue?.value === value
+			? 'z-10 border-gray-200 bg-gray-100 text-blue-700'
+			: 'z-0 bg-white text-gray-900 border-gray-200'}
                                 "
-	on:click={() => update({ valueLabel, value })}
->
-	{valueLabel}
-</button>
+		on:click={() => update({ valueLabel, value })}
+	>
+		{valueLabel}
+	</button>
+{/if}

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/TabDisplay.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/TabDisplay.svelte
@@ -1,0 +1,63 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	export let color = 'hsla(207, 65%, 39%, 1)';
+	export let id;
+	export let label;
+	export let activeId;
+
+	const dispatch = createEventDispatcher();
+
+	function handleClick(id) {
+		dispatch('click', { id: id });
+	}
+
+	const classes = {
+		notActive:
+			'border-gray-100 text-gray-600 border-b-2 bg-gray-50 border-b-gray-200 hover:text-gray-800 hover:bg-gray-200 hover:border-b-gray-400',
+		active: 'text-black border-b-2 border-[--borderColor] bg-[--bgColor]'
+	};
+
+	color = color.replace(/\s+/g, ''); // clean string
+
+	const bgColor = isValidColorString(color) ? addOpacityToColor(color) : 'hsla(207, 65%, 39%, 0.1)';
+	const borderColor = isValidColorString(color) ? color : 'hsla(207, 65%, 39%, 1)';
+
+	function isHex(inputColor) {
+		const hexRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/i;
+		return hexRegex.test(inputColor);
+	}
+
+	function isRGB(inputColor) {
+		const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i;
+		return rgbRegex.test(inputColor);
+	}
+
+	function isHSL(inputColor) {
+		const hslRegex = /^hsl\(\s*(\d{1,3}%)\s*,\s*(\d{1,3}%)\s*,\s*(\d{1,3}%)\s*\)$/i;
+		return hslRegex.test(inputColor);
+	}
+
+	function isValidColorString(inputColor) {
+		return isHex(inputColor) || isRGB(inputColor) || isHSL(inputColor);
+	}
+
+	function addOpacityToColor(colorString) {
+		if (isHex(colorString)) {
+			return colorString + '1a';
+		} else if (isRGB(colorString) || isHSL(colorString)) {
+			return colorString.replace(/(\)|\s|$)/, ', 0.1$1');
+		}
+	}
+</script>
+
+<button
+	style:--bgColor={bgColor}
+	style:--borderColor={borderColor}
+	on:click={handleClick(id)}
+	class="mt-2 p-2 rounded-t flex-1 text-sm font-sans whitespace-nowrap transition ease-in duration-200 active:bg-gray-100 {activeId ===
+	id
+		? classes.active
+		: classes.notActive}"
+>
+	{label}
+</button>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
@@ -5,55 +5,10 @@
 <script>
 	import { onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+	import TabDisplay from './TabDisplay.svelte';
 
-	const classes = {
-		notActive:
-			'border-gray-100 text-gray-600 border-b-2 bg-gray-50 border-b-gray-200 hover:text-gray-800 hover:bg-gray-200 hover:border-b-gray-400',
-		active: 'text-black border-b-2 border-[--borderColor] bg-[--bgColor]'
-	};
-
-	/**
-	 * id can be provided to enable tab selection to persist across reloads (e.g. with query params)
-	 * @type {string}
-	 */
 	export let id;
-
-	/**
-	 * color can be provided to set custom background color for active tab.
-	 * @type {string}
-	 */
 	export let color = 'hsla(207, 65%, 39%, 1)';
-	color = color.replace(/\s+/g, ''); // clean string
-
-	const bgColor = isValidColorString(color) ? addOpacityToColor(color) : 'hsla(207, 65%, 39%, 0.1)';
-	const borderColor = isValidColorString(color) ? color : 'hsla(207, 65%, 39%, 1)';
-
-	function isHex(inputColor) {
-		const hexRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/i;
-		return hexRegex.test(inputColor);
-	}
-
-	function isRGB(inputColor) {
-		const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i;
-		return rgbRegex.test(inputColor);
-	}
-
-	function isHSL(inputColor) {
-		const hslRegex = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3}%)\s*,\s*(\d{1,3}%)\s*\)$/i;
-		return hslRegex.test(inputColor);
-	}
-
-	function isValidColorString(inputColor) {
-		return isHex(inputColor) || isRGB(inputColor) || isHSL(inputColor);
-	}
-
-	function addOpacityToColor(colorString) {
-		if (isHex(colorString)) {
-			return colorString + '1a';
-		} else if (isRGB(colorString) || isHSL(colorString)) {
-			return colorString.replace(/(\)|\s|$)/, ', 0.1$1');
-		}
-	}
 
 	/** @type {import('./index.d.ts').TabsContext} */
 	const context = writable({ tabs: [], active: null });
@@ -66,40 +21,39 @@
 		}
 	});
 
-	// Select the first tab by default
 	$: if (!$context.activeId && $context.tabs.length) {
 		$context.activeId = $context.tabs[0].id;
 	}
 
-	// Select the first tab when the active tab no longer exists
 	$: if (!$context.tabs.find((t) => t.id === $context.activeId)) {
 		$context.activeId = $context.tabs[0]?.id;
 	}
 
 	$: if ($context.activeId && id) {
-		// Keep the Query in sync
 		const url = new URL(window.location.href);
 		url.searchParams.set(id, $context.activeId);
 		history.replaceState({}, '', url);
 	}
 
 	setContext('TABS_STORE', context);
+
+	const handleTabClick = (event) => {
+		$context.activeId = event.detail.id;
+	};
 </script>
 
 <section>
 	<nav class="my-6 flex flex-wrap gap-x-1 gap-y-1">
 		{#each $context.tabs as tab}
-			<button
-				style:--bgColor={bgColor}
-				style:--borderColor={borderColor}
-				on:click={() => ($context.activeId = tab.id)}
-				class="mt-2 p-2 rounded-t flex-1 text-sm font-sans whitespace-nowrap transition ease-in duration-200 active:bg-gray-100 {$context.activeId ===
-				tab.id
-					? classes.active
-					: classes.notActive}"
+			<TabDisplay
+				id={tab.id}
+				label={tab.label}
+				{color}
+				activeId={$context.activeId}
+				on:click={handleTabClick}
 			>
-				{tab.label}
-			</button>
+				<slot />
+			</TabDisplay>
 		{/each}
 	</nav>
 	<div class="text-base">

--- a/sites/docs/pages/components/button-group.md
+++ b/sites/docs/pages/components/button-group.md
@@ -269,7 +269,7 @@ Selected: {inputs.button_tabs_hardcoded_options}
 />
 <PropListing 
     name="display"
-    description="Displays tabs with button logic and funcitonality"
+    description="Displays tabs with button logic and functionality"
     options="tabs"
 />
 

--- a/sites/docs/pages/components/button-group.md
+++ b/sites/docs/pages/components/button-group.md
@@ -267,6 +267,11 @@ Selected: {inputs.button_tabs_hardcoded_options}
     description="SQL where fragment to filter options by (e.g., where sales > 40000)"
     options="SQL where clause"
 />
+<PropListing 
+    name="display"
+    description="Displays tabs with button logic and funcitonality"
+    options="tabs"
+/>
 
 # ButtonGroupItem
 

--- a/sites/docs/pages/components/button-group.md
+++ b/sites/docs/pages/components/button-group.md
@@ -177,6 +177,50 @@ group by all
 <DataTable data={filtered_query} emptySet=pass emptyMessage="No category selected"/>
 ````
 
+### Style Buttons as Tabs
+
+<ButtonGroup 
+    data={categories} 
+    name=buttons_as_tabs
+    value=category
+    display=tabs
+/>
+
+Selected: {inputs.buttons_as_tabs}
+
+```markdown
+<ButtonGroup 
+    data={categories} 
+    name=buttons_as_tabs 
+    value=category
+    display=tabs
+/>
+
+Selected: {inputs.buttons_as_tabs}
+```
+
+### Style Buttons as Tabs: With Hardcoded Options
+
+<ButtonGroup name=button_tabs_hardcoded_options display=tabs>
+    <ButtonGroupItem valueLabel="Option One" value="1" />
+    <ButtonGroupItem valueLabel="Option Two" value="2" />
+    <ButtonGroupItem valueLabel="Option Three" value="3" />
+</ButtonGroup>
+
+Selected: {inputs.button_tabs_hardcoded_options}
+
+
+````markdown
+<ButtonGroup name=button_tabs_hardcoded_options display=tabs>
+    <ButtonGroupItem valueLabel="Option One" value="1" />
+    <ButtonGroupItem valueLabel="Option Two" value="2" />
+    <ButtonGroupItem valueLabel="Option Three" value="3" />
+</ButtonGroup>
+
+Selected: {inputs.button_tabs_hardcoded_options}
+````
+
+
 # ButtonGroup
 
 ## Options


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~

![image](https://github.com/user-attachments/assets/b6ebfbeb-0998-4336-a6d0-ff31796a9cf3)

@archiewood Should `<ButtonGroup {display="tabs">` have a inherit default value, similar to the tabs component?

Tabs Component (default value):

![image](https://github.com/user-attachments/assets/81964c8e-8d80-48d8-a0a4-943597ed8954)


ButtonGroup styled as Tabs (No Default Value): 

![image](https://github.com/user-attachments/assets/45e4b9cc-86df-4139-bf89-4b7b7eca48f0)

fix #2323 

