### PR TITLE
Change `showPercent` param in Funnel Chart to calculate % based upon initial value instead of total

### DIFF
--- a/.changeset/cold-beds-drop.md
+++ b/.changeset/cold-beds-drop.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Funnel chart's showPercent param should calculate based upon initial value, not total

--- a/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
@@ -169,7 +169,9 @@
 				formatter: function (params) {
 					let output;
 					if (showPercent) {
-						output = `${formatValue(params.value, valueColFormat)} (${params.percent}%)`;
+						const initialValue = data[0][valueCol];
+						const percentOfInitial = ((params.value / initialValue) * 100).toFixed(1); // one decimal place by default
+						output = `${formatValue(params.value, valueColFormat)} (${percentOfInitial}%)`;
 					} else {
 						output = formatValue(params.value, valueColFormat);
 					}

--- a/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/funnel/_FunnelChart.svelte
@@ -170,7 +170,7 @@
 					let output;
 					if (showPercent) {
 						const initialValue = data[0][valueCol];
-						const percentOfInitial = ((params.value / initialValue) * 100).toFixed(1); // one decimal place by default
+						const percentOfInitial = ((params.value / initialValue) * 100).toFixed(2);
 						output = `${formatValue(params.value, valueColFormat)} (${percentOfInitial}%)`;
 					} else {
 						output = formatValue(params.value, valueColFormat);


### PR DESCRIPTION
### Description

- `params.percent` in the formatter function by default is calculated based upon the total, not the initial value (which is most often desired when using funnel charts) docs are not very clear on this https://echarts.apache.org/en/option.html#series-funnel.label.formatter
- fixes https://github.com/evidence-dev/evidence/issues/2469

Before

<img width="779" alt="Screenshot 2024-08-29 at 11 47 07 AM" src="https://github.com/user-attachments/assets/ba369367-4c01-4cb4-938c-1b2beb41fff2">

After

<img width="822" alt="Screenshot 2024-08-29 at 11 44 32 AM" src="https://github.com/user-attachments/assets/68f47db4-8d70-453f-b0e5-cce2baa10aa0">


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
