### PR TITLE
Fix/2314 tab url persists

### DIFF
--- a/.changeset/two-carrots-argue.md
+++ b/.changeset/two-carrots-argue.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+selected tabs with id prop selection persist on refresh/link shared

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
@@ -54,14 +54,22 @@
 </Story>
 
 <Story name="Tabs w/ id">
-	<Tabs>
+	<Tabs id>
+		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
+		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
+		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
+	</Tabs>
+</Story>
+
+<Story name="Tabs w/ multiple id">
+	<Tabs id>
 		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
 		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
 		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
 	</Tabs>
 	<Tabs id>
-		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
-		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
-		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
+		<Tab label="Tab 4" id="tab4">Tab 4 content</Tab>
+		<Tab label="Tab 4" id="tab5">Tab 5 content</Tab>
+		<Tab label="Tab 6" id="tab6">Tab 6 content</Tab>
 	</Tabs>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
@@ -62,12 +62,12 @@
 </Story>
 
 <Story name="Tabs w/ multiple id">
-	<Tabs id>
+	<Tabs id="first-set">
 		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
 		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
 		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
 	</Tabs>
-	<Tabs id>
+	<Tabs id="second-set">
 		<Tab label="Tab 4" id="tab4">Tab 4 content</Tab>
 		<Tab label="Tab 4" id="tab5">Tab 5 content</Tab>
 		<Tab label="Tab 6" id="tab6">Tab 6 content</Tab>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.stories.svelte
@@ -52,3 +52,16 @@
 		{/each}
 	</Tabs>
 </Story>
+
+<Story name="Tabs w/ id">
+	<Tabs>
+		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
+		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
+		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
+	</Tabs>
+	<Tabs id>
+		<Tab label="Tab 1" id="tab1">Tab 1 content</Tab>
+		<Tab label="Tab 2" id="tab2">Tab 2 content</Tab>
+		<Tab label="Tab 3" id="tab3">Tab 3 content</Tab>
+	</Tabs>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
@@ -62,9 +62,12 @@
 		const url = new URL(window.location.href);
 		const urlActive = url.searchParams.get(id);
 		if (urlActive) {
-			$context.activeId = urlActive;
-		} else {
-			$context.activeId = $context.tabs[0]?.id;
+			//search for urlActive in $context.activeId, if not found, set it to the first tab
+			if (!$context.tabs.find((t) => t.id === urlActive)) {
+				$context.activeId = $context.tabs[0]?.id;
+			} else {
+				$context.activeId = urlActive;
+			}
 		}
 	});
 

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
@@ -68,6 +68,8 @@
 			} else {
 				$context.activeId = urlActive;
 			}
+		} else {
+			$context.activeId = $context.tabs[0]?.id;
 		}
 	});
 

--- a/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Tabs/Tabs.svelte
@@ -56,23 +56,25 @@
 	}
 
 	/** @type {import('./index.d.ts').TabsContext} */
-	const context = writable({ tabs: [], active: null });
+	const context = writable({ tabs: [], activeId: null });
 
 	onMount(() => {
 		const url = new URL(window.location.href);
 		const urlActive = url.searchParams.get(id);
 		if (urlActive) {
-			$context.active = urlActive;
+			$context.activeId = urlActive;
+		} else {
+			$context.activeId = $context.tabs[0]?.id;
 		}
 	});
 
 	// Select the first tab by default
-	$: if (!$context.activeId && $context.tabs.length) {
+	$: if (!$context.activeId && $context.tabs.length && !id) {
 		$context.activeId = $context.tabs[0].id;
 	}
 
 	// Select the first tab when the active tab no longer exists
-	$: if (!$context.tabs.find((t) => t.id === $context.activeId)) {
+	$: if (!$context.tabs.find((t) => t.id === $context.activeId) && !id) {
 		$context.activeId = $context.tabs[0]?.id;
 	}
 

--- a/sites/docs/pages/components/tabs.md
+++ b/sites/docs/pages/components/tabs.md
@@ -59,24 +59,24 @@ sidebar_position: 1
 </Tabs>
 ```
 
-### ID
+### Persist Selected Tab to URL
 
-<Tabs id="first tab set">
-    <Tab label="First Id tab">
+<Tabs id="example-tab">
+    <Tab label="One">
         Click Second id Tab and notice the the url updates!
     </Tab>
-    <Tab label="Second Id tab">
+    <Tab label="Two">
         Refresh the page and the tab you selected persists!
     </Tab>
 </Tabs>
 
 
 ```markdown
-<Tabs id="first tab set">
-    <Tab label="First Id tab">
+<Tabs id="example-tab">
+    <Tab label="One">
         Click Second id Tab and notice the the url updates!
     </Tab>
-    <Tab label="Second Id tab">
+    <Tab label="Two">
         Refresh the page and the tab you selected persists!
     </Tab>
 </Tabs>

--- a/sites/docs/pages/components/tabs.md
+++ b/sites/docs/pages/components/tabs.md
@@ -59,9 +59,9 @@ sidebar_position: 1
 </Tabs>
 ```
 
-### id
+### ID
 
-<Tabs id>
+<Tabs id="first tab set">
     <Tab label="First Id tab">
         Click Second id Tab and notice the the url updates!
     </Tab>
@@ -70,8 +70,9 @@ sidebar_position: 1
     </Tab>
 </Tabs>
 
+
 ```markdown
-<Tabs id>
+<Tabs id="first tab set">
     <Tab label="First Id tab">
         Click Second id Tab and notice the the url updates!
     </Tab>
@@ -87,6 +88,7 @@ sidebar_position: 1
 
 <PropListing
     name="id"
+    options="string"
 >
 
 Unique Id for this set of tabs. When set, the selected tab is included in the URL so it can be shared.

--- a/sites/docs/pages/components/tabs.md
+++ b/sites/docs/pages/components/tabs.md
@@ -62,20 +62,20 @@ sidebar_position: 1
 ### id
 
 <Tabs id>
-    <Tab label="Red Tabs">
-        Click Second Tab and notice the the url updates!
+    <Tab label="First Id tab">
+        Click Second id Tab and notice the the url updates!
     </Tab>
-    <Tab label="Second Tab">
+    <Tab label="Second Id tab">
         Refresh the page and the tab you selected persists!
     </Tab>
 </Tabs>
 
 ```markdown
 <Tabs id>
-    <Tab label="Red Tabs">
-        Click Second Tab and notice the the url updates!
+    <Tab label="First Id tab">
+        Click Second id Tab and notice the the url updates!
     </Tab>
-    <Tab label="Second Tab">
+    <Tab label="Second Id tab">
         Refresh the page and the tab you selected persists!
     </Tab>
 </Tabs>

--- a/sites/docs/pages/components/tabs.md
+++ b/sites/docs/pages/components/tabs.md
@@ -59,6 +59,28 @@ sidebar_position: 1
 </Tabs>
 ```
 
+### id
+
+<Tabs id>
+    <Tab label="Red Tabs">
+        Click Second Tab and notice the the url updates!
+    </Tab>
+    <Tab label="Second Tab">
+        Refresh the page and the tab you selected persists!
+    </Tab>
+</Tabs>
+
+```markdown
+<Tabs id>
+    <Tab label="Red Tabs">
+        Click Second Tab and notice the the url updates!
+    </Tab>
+    <Tab label="Second Tab">
+        Refresh the page and the tab you selected persists!
+    </Tab>
+</Tabs>
+```
+
 # Tabs
 
 ## Options


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~

Demo (3 examples):

- Selection of 0 indexed tab (first tab) on first page load
- Selection of second tab, refresh page, second tab selection persists
- If the User shares url with tab that does not exist, reverts to 0 indexed tab (first tab)

https://github.com/user-attachments/assets/226a7838-bee9-44c8-b394-f967d79c7b86

Future notes:

Currently, we cannot accept multiple tabs with id props, since they will be sharing + updating the same URL. A story was built to demonstrate this. 

1. Should we handle this? 
2. Should we warn users not to do this?

Future PR issue:

- Multiple tabs with ID props share same URL
- Last tab selection will persist and overrule sibling tabs component

https://github.com/user-attachments/assets/56c38908-150c-4aee-ac5a-c1a46ce57a78




