### PR TITLE
fix: set 644 permissions on output parquet files

### DIFF
--- a/.changeset/fast-otters-perform.md
+++ b/.changeset/fast-otters-perform.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/universal-sql': patch
+---
+
+Set 644 permissions when writing parquet files

--- a/packages/lib/universal-sql/src/build-parquet.js
+++ b/packages/lib/universal-sql/src/build-parquet.js
@@ -167,6 +167,8 @@ export async function buildMultipartParquet(
 
 	await query(copy);
 
+	await fs.chmod(outputFilepath, 0o644);
+
 	const { size } = await fs.stat(outputFilepath);
 	if (size > 100 * 1024 * 1024) {
 		console.warn(


### PR DESCRIPTION
Resolves https://github.com/evidence-dev/evidence/issues/2463

### Description

Running the following commands:
`rm -rf .evidence build && pnpm sources && pnpm build && ls -al build/dat
a/needful_things/orders/`

Before this fix:
```
drwxr-xr-x 2 zach zach   4096 Sep  3 13:09 ./
drwxr-xr-x 3 zach zach   4096 Sep  3 13:09 ../
-rw------- 1 zach zach 450914 Sep  3 13:09 orders.parquet
-rw-r--r-- 1 zach zach   1032 Sep  3 13:09 orders.schema.json
```

After this fix:
```
drwxr-xr-x 2 zach zach   4096 Sep  3 13:04 ./
drwxr-xr-x 3 zach zach   4096 Sep  3 13:04 ../
-rw-r--r-- 1 zach zach 450914 Sep  3 13:04 orders.parquet
-rw-r--r-- 1 zach zach   1032 Sep  3 13:04 orders.schema.json
```

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
