### PR TITLE
Multiline string connector options + Snowflake Key-Pair Fix

### DIFF
--- a/.changeset/six-apples-complain.md
+++ b/.changeset/six-apples-complain.md
@@ -1,0 +1,9 @@
+---
+'@evidence-dev/snowflake': patch
+'@evidence-dev/plugin-connector': patch
+'@evidence-dev/sdk': patch
+'@evidence-dev/core-components': patch
+---
+
+Adds support for Multiline strings as source config
+Moves snowflake private key to multi-line string field

--- a/packages/datasources/snowflake/index.cjs
+++ b/packages/datasources/snowflake/index.cjs
@@ -356,7 +356,8 @@ module.exports.options = {
 			snowflake_jwt: {
 				private_key: {
 					title: 'Private Key',
-					type: 'string',
+					type: 'multiline',
+					rows: 10,
 					secret: true,
 					required: true
 				},

--- a/packages/lib/plugin-connector/src/data-sources/schemas/query-runner.schema.js
+++ b/packages/lib/plugin-connector/src/data-sources/schemas/query-runner.schema.js
@@ -134,7 +134,7 @@ export const DatasourceConnectorFactorySchema = z
 /**
  * @typedef {Object} IDatasourceOptionSpecSchema
  * @property {string} title
- * @property {'string' | 'number' | 'boolean' | 'select' | 'file'} type
+ * @property {'string' | 'multiline' | 'number' | 'boolean' | 'select' | 'file'} type
  * @property {boolean} [secret]
  * @property {boolean} [shown]
  * @property {string} [description]
@@ -151,7 +151,7 @@ export const DatasourceOptionSpecSchema = z.record(
 	z.string(),
 	z.object({
 		title: z.string(),
-		type: z.enum(['string', 'number', 'boolean', 'select', 'file']),
+		type: z.enum(['string', 'multiline', 'number', 'boolean', 'select', 'file']),
 		secret: z.boolean().default(false),
 		shown: z.boolean().optional(),
 		/**

--- a/packages/lib/sdk/src/plugins/datasources/schemas/datasourcePluginOptions.schema.js
+++ b/packages/lib/sdk/src/plugins/datasources/schemas/datasourcePluginOptions.schema.js
@@ -4,7 +4,7 @@ import { z } from 'zod';
 /**
  * @typedef {Object} IDatasourceOptionSpecSchema
  * @property {string} title
- * @property {'string' | 'number' | 'boolean' | 'select' | 'file'} type
+ * @property {'string' | 'multiline' | 'number' | 'boolean' | 'select' | 'file'} type
  * @property {boolean} [secret]
  * @property {boolean} [shown]
  * @property {string} [description]
@@ -23,7 +23,7 @@ export const DatasourceOptionSpecSchema = z.record(
 	z.string(),
 	z.object({
 		title: z.string({ description: 'Title of the option (UI)' }),
-		type: z.enum(['string', 'number', 'boolean', 'select', 'file'], {
+		type: z.enum(['string', 'multiline', 'number', 'boolean', 'select', 'file'], {
 			description: 'Control type to show'
 		}),
 		secret: z.boolean({ description: 'If true, will not be source controlled' }).default(false),

--- a/packages/ui/core-components/src/lib/organisms/source-config/SourceConfigFormField.svelte
+++ b/packages/ui/core-components/src/lib/organisms/source-config/SourceConfigFormField.svelte
@@ -139,7 +139,7 @@
 </script>
 
 <div class="w-full">
-	<label class="flex justify-between w-full h-11 items-start">
+	<label class="flex justify-between w-full items-start {spec.type !== 'multiline' ? 'h-11' : 'h-auto'}" >
 		<div class="mr-2 inline-flex flex-col gap-1">
 			<p class="flex items-center gap-1">
 				{#if spec.description}
@@ -168,6 +168,14 @@
 					bind:value={fieldValue}
 				/>
 			{/if}
+		{:else if spec.type === 'multiline'}
+				<textarea
+					disabled={fieldDisabled}
+					required={spec.required}
+					bind:value={fieldValue}
+					rows=5
+					class="w-full p-2 mb-3.5"
+				></textarea>
 		{:else if spec.type === 'boolean'}
 			<input
 				class="!w-5"
@@ -213,7 +221,7 @@
 
 <style>
 	input,
-	select {
+	select, textarea {
 		@apply rounded border border-gray-300 p-1 ml-auto w-2/3 text-gray-950 align-middle text-sm;
 	}
 </style>


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/c746e2b6-9930-4ec5-82ac-31209bd13e69)

Some connection options are by nature "multi-line" but Evidence only allowed users to enter a single line option. 

This was causing Snowflake Keypair auth to fail as the newlines in the Private Key were being erroneously stripped during entry into the input field.

This PR adds support for multi-line strings with a textarea input field and updates the snowflake private key field to use it

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
