### PR TITLE
Fix frontmatter on home page

### DIFF
--- a/.changeset/tidy-timers-smell.md
+++ b/.changeset/tidy-timers-smell.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+fix frontmatter on home page

--- a/e2e/basic/pages/index.md
+++ b/e2e/basic/pages/index.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome to Evidence
+sidebar: hide
 ---
 
 <Details title='How to edit this page'>

--- a/e2e/basic/tests/tests.spec.js
+++ b/e2e/basic/tests/tests.spec.js
@@ -8,3 +8,10 @@ test('has title', async ({ page }) => {
 
 	await expect(page).toHaveTitle(/Welcome to Evidence/);
 });
+
+test('has hidden sidebar', async ({ page }) => {
+	await page.goto('/');
+	await waitForDevModeToLoad(page);
+
+	expect(page.getByText('Open sidebar')).toBeVisible();
+});

--- a/e2e/basic/tests/tests.spec.js
+++ b/e2e/basic/tests/tests.spec.js
@@ -13,5 +13,5 @@ test('has hidden sidebar', async ({ page }) => {
 	await page.goto('/');
 	await waitForDevModeToLoad(page);
 
-	expect(page.getByText('Open sidebar')).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Open sidebar' })).toBeVisible();
 });

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -54,7 +54,7 @@ export function _buildPageManifest(pages) {
 }
 
 // Import pages and create an object structure corresponding to the file structure
-const pages = import.meta.glob('/src/pages/*/**/+page.md', {
+const pages = import.meta.glob('/src/pages/**/+page.md', {
 	import: 'default',
 	query: 'raw',
 	eager: true


### PR DESCRIPTION
### Description

Fixes #2326

`src/pages/+page.md` was (accidentally?) being skipped in the `import.meta.glob` that generates the page manifest which was causing the home page to not get any of those options

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
