### PR TITLE
fix: dev tools keybind

### DIFF
--- a/.changeset/silent-sloths-begin.md
+++ b/.changeset/silent-sloths-begin.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix dev tools keybind on windows

--- a/packages/ui/core-components/src/lib/devtools/_DevTools.svelte
+++ b/packages/ui/core-components/src/lib/devtools/_DevTools.svelte
@@ -31,7 +31,7 @@
 				open = false;
 				e.stopPropagation();
 			}
-			if (e.key === 'e' && e.shiftKey && (e.ctrlKey || e.metaKey)) {
+			if (e.key.toLowerCase() === 'e' && e.shiftKey && (e.ctrlKey || e.metaKey)) {
 				open = true;
 				e.stopPropagation();
 			}


### PR DESCRIPTION
On windows the key comes through as `E`, not `e` when `Shift` is held