### PR TITLE
Environment variable fixes

### DIFF
--- a/.changeset/wild-dingos-hug.md
+++ b/.changeset/wild-dingos-hug.md
@@ -1,0 +1,8 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Allows environment variables to be used in custom components in development mode
+Loads .env file in cli and keeps VITE\_ prefixed variables
+
+Fixes #2550

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -18,7 +18,7 @@ const increaseNodeMemoryLimit = () => {
 };
 
 const loadEnvFile = () => {
-	const envFile = loadEnv('', '.', ['EVIDENCE_']);
+	const envFile = loadEnv('', '.', ['EVIDENCE_', 'VITE_']);
 	Object.assign(process.env, envFile);
 };
 
@@ -204,6 +204,8 @@ prog
 			enableDebug();
 			delete args.debug;
 		}
+
+		loadEnvFile();
 
 		const manifestExists = fs.lstatSync(
 			path.join('.evidence', 'template', 'static', 'data', 'manifest.json'),


### PR DESCRIPTION
Allows environment variables to be used in custom components in development mode, loads .env file in cli and keeps VITE_ prefixed variables.  Fixes #2550 