### PR TITLE
Group component

### DIFF
--- a/.changeset/happy-carrots-invite.md
+++ b/.changeset/happy-carrots-invite.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Add Group component for Grids

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "evidence-vscode",
 	"displayName": "Evidence",
 	"description": "Build polished data products with SQL and Markdown",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"private": true,
 	"engines": {
 		"vscode": "^1.52.0"

--- a/packages/extension/snippets/emd.code-snippets
+++ b/packages/extension/snippets/emd.code-snippets
@@ -349,6 +349,11 @@
 		"body": ["<Grid cols=2>\n\t${1:Grid Content}\n</Grid>\n\n"],
 		"description": "Insert Grid"
 	},
+	"Group": {
+		"prefix": "/Group",
+		"body": ["<Group>\n\t${1:Group Content}\n</Group>\n\n"],
+		"description": "Insert Group to combine items in a Grid cell"
+	},
 	"LineBreak": {
 		"prefix": "/LineBreak",
 		"body": "<LineBreak lines=1/>\n\n",

--- a/packages/ui/core-components/src/lib/unsorted/ui/Group.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Group.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export const evidenceInclude = true;
+</script>
+
+<div>
+	<slot></slot>
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/ui/index.js
+++ b/packages/ui/core-components/src/lib/unsorted/ui/index.js
@@ -5,6 +5,7 @@ export { default as CodeBlock } from './CodeBlock.svelte';
 export { default as Details } from './Details.svelte';
 export { default as DownloadData } from './DownloadData.svelte';
 export { default as EmailSignup } from './EmailSignup.svelte';
+export { default as Group } from './Group.svelte';
 export { default as LastRefreshed } from './LastRefreshed.svelte';
 export { default as LineBreak } from './LineBreak.svelte';
 export { default as LoadingIndicator } from './LoadingIndicator.svelte';

--- a/sites/docs/pages/components/grid.md
+++ b/sites/docs/pages/components/grid.md
@@ -24,6 +24,24 @@ group by all
 </Grid>
 ```
 
+## Group Component
+
+To include multiple items inside one grid cell, use the `Group` component to wrap the items you want to include in that cell.
+
+For example:
+
+```html
+<Grid cols=2>
+   <LineChart/>
+   <Group>
+      Some text
+      <BarChart/>
+   </Group>
+</Grid>
+```
+
+This will stack "some text" above the bar chart, rather than giving it it's own cell.
+
 ## Options
 
 <PropListing


### PR DESCRIPTION
### Description
Adds a Group component for stacking items inside a Grid. If you want multiple items inside the same Group cell, you can now wrap them in a Group component like so:

```html
<Grid cols=2>
   <LineChart/>
   <Group>
      Some text
      <BarChart/>
   </Group>
</Grid>
```

#### Before
![CleanShot 2024-09-19 at 10 24 48@2x](https://github.com/user-attachments/assets/320f9ab0-c1b6-45b5-9c49-776d02a8ca7f)


#### After
![CleanShot 2024-09-19 at 10 25 04@2x](https://github.com/user-attachments/assets/6956fa3a-55e3-44b4-95f2-b266fd3b9308)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
