### PR TITLE
Feat/2565 ensure client side navigation when following a rowlink in a table

### DIFF
--- a/.changeset/heavy-radios-brush.md
+++ b/.changeset/heavy-radios-brush.md
@@ -1,0 +1,7 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Table rows with links preload data on hover
+Table rows with links have a chevron icon on the right side
+Table rows dont have link styling if the link value is falsey

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
@@ -152,7 +152,8 @@
 	{@const data = Query.create(
 		`
 		SELECT 'Internal' as type, '?bingbong=true' as link UNION ALL
-		SELECT 'External' as type, 'https://example.com' as link
+		SELECT 'External' as type, 'https://example.com' as link UNION ALL
+		SELECT 'No link' as type, null as link
 		`,
 		query
 	)}

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -9,6 +9,8 @@
 	import TableCell from './TableCell.svelte';
 	import chroma from 'chroma-js';
 	import { uiColours } from '@evidence-dev/component-utilities/colours';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { ChevronRight } from '@steeze-ui/tabler-icons';
 
 	export let displayedData = undefined;
 	export let rowShading = undefined;
@@ -195,6 +197,13 @@
 				{/if}
 			</TableCell>
 		{/each}
+
+		{#if link && row[link]}
+			<TableCell {compact} width="16px">
+				<Icon src={ChevronRight} class="w-4 h-4" />
+				<a href={row[link]} class="sr-only">See more</a>
+			</TableCell>
+		{/if}
 	</tr>
 {/each}
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { goto, preloadData } from '$app/navigation';
 	import { safeExtractColumn } from './datatable.js';
 	import Delta from '../core/Delta.svelte';
 	import {
@@ -24,18 +25,38 @@
 	export let orderedColumns = undefined;
 	export let compact = undefined;
 
-	function handleRowClick(url) {
-		if (link) {
+	const isUrlExternal = (url) =>
+		new URL(url, window.location.origin).origin !== window.location.origin;
+
+	const preloadLink = async (row) => {
+		if (!link || !row[link]) return;
+		const url = row[link];
+
+		if (isUrlExternal(url)) return;
+
+		await preloadData(url);
+	};
+
+	const navigateToLink = async (row) => {
+		if (!link || !row[link]) return;
+		const url = row[link];
+
+		if (isUrlExternal(url)) {
 			window.location = url;
+			return;
 		}
-	}
+
+		await goto(row[link]);
+	};
 </script>
 
 {#each displayedData as row, i}
 	<tr
 		class:shaded-row={rowShading && i % 2 === 1}
 		class:row-link={link != undefined}
-		on:click={() => handleRowClick(row[link])}
+		on:mouseover={() => preloadLink(row)}
+		on:focus={() => preloadLink(row)}
+		on:click={() => navigateToLink(row)}
 		class:row-lines={rowLines}
 	>
 		{#if rowNumbers && groupType !== 'section'}

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -55,7 +55,7 @@
 {#each displayedData as row, i}
 	<tr
 		class:shaded-row={rowShading && i % 2 === 1}
-		class:row-link={link != undefined}
+		class:row-link={link && row[link]}
 		on:mouseover={() => preloadLink(row)}
 		on:focus={() => preloadLink(row)}
 		on:click={() => navigateToLink(row)}


### PR DESCRIPTION
### Description

*hovering on the first row*
![image](https://github.com/user-attachments/assets/77fcf757-28b8-4428-b8e2-f7ed741291a9)

`test-env` orders demo

https://github.com/user-attachments/assets/a35d996a-a740-43e0-b95c-d17dd26b6099



### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
~~- I have added to the docs where applicable~~
~~- I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
