### PR TITLE
Add sparkline and bar viz to DataTable

### DIFF
--- a/.changeset/six-bikes-thank.md
+++ b/.changeset/six-bikes-thank.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Add sparkline and bar viz to DataTable

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/Column.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/Column.svelte
@@ -103,6 +103,12 @@
 	export let chip = false;
 	$: chip = chip === 'true' || chip === true;
 
+	// Sparkline:
+	export let sparklineType = 'line'; // line, area, or bar
+	export let sparklineColor = undefined;
+	export let sparklineDateCol = undefined;
+	export let sparklineValueCol = undefined;
+
 	// Column Groups:
 	export let colGroup = undefined;
 
@@ -146,7 +152,11 @@
 		colorMid,
 		colorBreakpoints,
 		colorPalette,
-		redNegatives
+		redNegatives,
+		sparklineType,
+		sparklineColor,
+		sparklineDateCol,
+		sparklineValueCol
 	};
 
 	/**

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
@@ -34,6 +34,56 @@
 	<DataTable {data} />
 </Story>
 
+<Story name="Bar Viz">
+	{@const data = Query.create(
+		`
+	SELECT 'a' as category, 100 as value
+	union all
+	SELECT 'a' as category, 80 as value
+	union all
+	SELECT 'a' as category, 70 as value
+	union all
+	SELECT 'b' as category, 30 as value
+	union all
+	SELECT 'b' as category, 24 as value
+	union all
+	SELECT 'b' as category, 12 as value
+	`,
+		query
+	)}
+	<DataTable {data}>
+		<Column id="category" />
+		<Column id="value" contentType="bar" fmt="usd" align="center" />
+	</DataTable>
+</Story>
+
+<Story name="Sparkline">
+	{@const data = Query.create(
+		`
+	select category, array_agg({'date': date, 'value': value}) as sparkline from (
+	SELECT 'Grocery' as category, '2024-01-01'::date as date, 100 as value
+	union all
+	SELECT 'Grocery' as category, '2024-01-02'::date as date, 80 as value
+	union all
+	SELECT 'Grocery' as category, '2024-01-03'::date as date, 70 as value
+	union all
+	SELECT 'Retail' as category, '2024-01-01'::date as date, 30 as value
+	union all
+	SELECT 'Retail' as category, '2024-01-02'::date as date, 24 as value
+	union all
+	SELECT 'Retail' as category, '2024-01-03'::date as date, 12 as value
+	) group by all
+	`,
+		query
+	)}
+	<DataTable {data}>
+		<Column id="category" />
+		<Column id="sparkline" contentType="sparkline" sparklineType="area" sparklineColor="green" />
+		<Column id="sparkline" contentType="sparkline" sparklineType="bar" sparklineColor="navy" />
+		<Column id="sparkline" contentType="sparkline" sparklineType="line" />
+	</DataTable>
+</Story>
+
 <Story name="With Search">
 	{@const data = Query.create(`SELECT * from flights LIMIT 1000`, query)}
 	<DataTable {data} title="Flights" search>

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -11,6 +11,7 @@
 	import { uiColours } from '@evidence-dev/component-utilities/colours';
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { ChevronRight } from '@steeze-ui/tabler-icons';
+	import Sparkline from '../core/_Sparkline.svelte';
 
 	export let displayedData = undefined;
 	export let rowShading = undefined;
@@ -190,6 +191,27 @@
 						neutralMax={column.neutralMax}
 						chip={column.chip}
 					/>
+				{:else if column.contentType === 'bar' && row[column.id] !== undefined}
+					<div style="width: 100%; background-color: #f0f0f0; position: relative;">
+						<div
+							style="width: {(row[column.id] / column_max) *
+								100}%; height: 100%; background-color: #3498db; padding-right: 5px; padding-left: 5px;"
+						>
+							{formatValue(row[column.id], column_format, useCol.columnUnitSummary)}
+						</div>
+					</div>
+					<!-- <div style="background-color: red; max-width: '{row[column.id] / column_max * 100}%'">{row[column.id]}</div> -->
+				{:else if column.contentType === 'sparkline' && row[column.id] !== undefined}
+					<div>
+						<Sparkline
+							data={[...row[column.id]]}
+							dateCol={column.sparklineDateCol}
+							valueCol={column.sparklineValueCol}
+							type={column.sparklineType}
+							interactive="true"
+							color={column.sparklineColor}
+						/>
+					</div>
 				{:else if column.contentType === 'html' && row[column.id] !== undefined}
 					{@html row[column.id]}
 				{:else}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,52 +1514,6 @@ importers:
         specifier: ^2.0.5
         version: 2.1.1
 
-  packages/ui/core-components/static/data: {}
-
-  packages/ui/core-components/static/data/series_demo_source: {}
-
-  packages/ui/core-components/static/data/series_demo_source/blog_posts: {}
-
-  packages/ui/core-components/static/data/series_demo_source/comments: {}
-
-  packages/ui/core-components/static/data/series_demo_source/flights: {}
-
-  packages/ui/core-components/static/data/series_demo_source/follows: {}
-
-  packages/ui/core-components/static/data/series_demo_source/hashtags: {}
-
-  packages/ui/core-components/static/data/series_demo_source/la_locations: {}
-
-  packages/ui/core-components/static/data/series_demo_source/la_zip_sales: {}
-
-  packages/ui/core-components/static/data/series_demo_source/likes: {}
-
-  packages/ui/core-components/static/data/series_demo_source/locations: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_seriesgaps: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_xgaps: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_xgaps_seriesgaps: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_xgaps_ynulls: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_xgaps_ynulls_seriesgaps: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_ynulls: {}
-
-  packages/ui/core-components/static/data/series_demo_source/numeric_series_ynulls_seriesgaps: {}
-
-  packages/ui/core-components/static/data/series_demo_source/post_tags: {}
-
-  packages/ui/core-components/static/data/series_demo_source/posts: {}
-
-  packages/ui/core-components/static/data/series_demo_source/state_sales: {}
-
-  packages/ui/core-components/static/data/series_demo_source/users: {}
-
   packages/ui/icons:
     dependencies:
       '@steeze-ui/icons':
@@ -9010,6 +8964,7 @@ packages:
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
@@ -9985,6 +9940,7 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: false
 
   /cli-cursor@4.0.0:
@@ -11297,6 +11253,7 @@ packages:
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+    requiresBuild: true
     dev: false
 
   /error-ex@1.3.2:
@@ -13040,6 +12997,7 @@ packages:
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    requiresBuild: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -16100,6 +16058,9 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(postcss@8.4.47)(typescript@5.4.2)
       '@parcel/core': 2.12.0
@@ -17213,6 +17174,7 @@ packages:
   /retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+    requiresBuild: true
     dev: false
 
   /retry@0.13.1:
@@ -17756,6 +17718,9 @@ packages:
   /sqlite3@5.1.6:
     resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       node-addon-api: 4.3.0

--- a/sites/example-project/src/pages/tables/data-table/+page.md
+++ b/sites/example-project/src/pages/tables/data-table/+page.md
@@ -47,3 +47,40 @@ group by all
 	<Column id=orders/> 
 	<Column id=aov fmt=usd2 contentType=colorscale scaleColor={['#b52626','#FFFFFF','#2e9939']}/> 
  </DataTable>
+
+## Sparkline
+
+ ```sql cats
+WITH daily_sales AS (
+    SELECT 
+        category,
+        DATE_TRUNC('month', order_datetime) AS date,
+        SUM(sales) AS daily_sales
+    FROM 
+        needful_things.orders
+    GROUP BY 
+        category, DATE_TRUNC('month', order_datetime)
+)
+SELECT 
+    category,
+    ARRAY_AGG({'date': date, 'sales': daily_sales}) AS sales
+FROM 
+    daily_sales
+GROUP BY 
+    category;
+```
+
+<DataTable data={cats}>
+    <Column id=category/>
+    <Column id=sales contentType=sparkline sparklineDateCol=date sparklineValueCol=sales sparklineType=area/>
+</DataTable>
+
+## Bar Viz
+
+<DataTable data={summary}>
+  <Column id=category/>
+  <Column id=sales contentType=bar fmt=usd align=left/>
+  <Column id=orders/>
+  <Column id=aov contentType=colorscale fmt=usd/>
+</DataTable>
+


### PR DESCRIPTION
### Description
![CleanShot 2024-10-03 at 15 46 29@2x](https://github.com/user-attachments/assets/7ca968c5-8411-4f2e-8287-7fdc973d9078)


### To Do

#### Sparkline
- Fix spacing for sparkline - it sits on 'baseline', which looks worse than it being vertically centered
- Decide whether sparkline should allow `interactive=true`, since it affects spacing and labels can get cut off. Maybe enabling this should auto-add margin to the cell
- Decide on naming for sparkline props - simplest is to prepend 'sparkline' to everything, but then it's a bit verbose
- Include clear example of `array_agg` in docs for use with sparkline
- Add `array_agg` to duckdb autocomplete functions in VS Code extension
- Decide how to handle height adjustments to the sparkline - should this affect table row height?

#### Bar viz
- Add props to change:
   - bar color
   - background color
   - enable/disable background color
   - label alignment (possibly separate from column header alignment as set via `align` prop in `Column`)
- Need to figure out color contrast management
   - In some cases, the number label will overlap the edge of the bar, so may have a dark color on one side and light on the other - so luminosity calc won't help
   - One option is to apply a semi-transparent background to the label if it overlaps the bar edge, but that would require knowing if it will overlap (or adding the background to all labels, which would probably look bad)
   - Another option is to apply a text border to all labels. Could be white outline. Best is probably white font with outline color matching the bar color
- Need to figure out alignment of labels - left, center of bar, end of bar, right?
   - Where should column header go in these scenarios?
- Should we offer any control over column width? Imagining having 3 of these bar columns side by side - you want them to be identical width when doing a quick visual scan of the data   

### Checklist
- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
