### PR TITLE
fixed rendering layers Bubbles + Points

### DIFF
--- a/.changeset/rare-singers-tease.md
+++ b/.changeset/rare-singers-tease.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed bubbles + points layering issue

--- a/.changeset/soft-plums-repeat.md
+++ b/.changeset/soft-plums-repeat.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fixes layering issue and allows for layering control of bubbles and points

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -61,7 +61,7 @@
 </Story>
 <Story name="Multiple Points">
 	<BaseMap title="My Map" height="300">
-		<Points data={la_locations} lat="lat" long="long" color="red" />
-		<Points data={la_locations} lat="lat" long="long" color="blue" />
+		<Points data={la_locations} lat="lat" long="long" color="red" paneType="red Points" z="1" />
+		<Points data={la_locations} lat="lat" long="long" color="blue" paneType="blue Points" z="2" />
 	</BaseMap>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -59,3 +59,9 @@
 		<Points data={la_locations} lat="lat" long="long" color="red" />
 	</BaseMap>
 </Story>
+<Story name="Multiple Points">
+	<BaseMap title="My Map" height="300">
+		<Points data={la_locations} lat="lat" long="long" color="red" />
+		<Points data={la_locations} lat="lat" long="long" color="blue" />
+	</BaseMap>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -44,7 +44,6 @@
 			tooltipType="hover"
 			opacity="1"
 		/>
-
 		<Bubbles
 			data={la_locations}
 			lat="lat"
@@ -61,7 +60,37 @@
 </Story>
 <Story name="Multiple Points">
 	<BaseMap title="My Map" height="300">
-		<Points data={la_locations} lat="lat" long="long" color="red" paneType="red Points" z="1" />
-		<Points data={la_locations} lat="lat" long="long" color="blue" paneType="blue Points" z="2" />
+		<Points data={la_locations} lat="lat" long="long" color="red" />
+		<Points data={la_locations} lat="lat" long="long" color="purple" />
+		<Points data={la_locations} lat="lat" long="long" color="blue" />
+		<Points data={la_locations} lat="lat" long="long" color="green" />
+	</BaseMap>
+</Story>
+<Story name="multiple bubbles and points">
+	<BaseMap title="My Map" height="300">
+		<Bubbles
+			data={la_locations}
+			lat="lat"
+			long="long"
+			pointName="point_name"
+			value="sales"
+			size="sales"
+			tooltipType="hover"
+			opacity="0.6"
+			color="blue"
+		/>
+		<Bubbles
+			data={la_locations}
+			lat="lat"
+			long="long"
+			pointName="point_name"
+			value="sales"
+			size="sales"
+			tooltipType="hover"
+			opacity="0.6"
+			color="green"
+		/>
+		<Points data={la_locations} lat="lat" long="long" color="red" />
+		<Points data={la_locations} lat="lat" long="long" color="purple" />
 	</BaseMap>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -60,13 +60,13 @@
 </Story>
 <Story name="Multiple Points">
 	<BaseMap title="My Map" height="300">
-		<Points data={la_locations} lat="lat" long="long" color="red" />
-		<Points data={la_locations} lat="lat" long="long" color="purple" />
-		<Points data={la_locations} lat="lat" long="long" color="blue" />
+		<Points data={la_locations} lat="lat" long="long" color="red" z="3" />
+		<Points data={la_locations} lat="lat" long="long" color="purple" z="2" />
+		<Points data={la_locations} lat="lat" long="long" color="blue" z="1" />
 		<Points data={la_locations} lat="lat" long="long" color="green" />
 	</BaseMap>
 </Story>
-<Story name="multiple bubbles and points">
+<Story name="bubbles on top of points">
 	<BaseMap title="My Map" height="300">
 		<Bubbles
 			data={la_locations}
@@ -78,19 +78,8 @@
 			tooltipType="hover"
 			opacity="0.6"
 			color="blue"
+			z="2"
 		/>
-		<Bubbles
-			data={la_locations}
-			lat="lat"
-			long="long"
-			pointName="point_name"
-			value="sales"
-			size="sales"
-			tooltipType="hover"
-			opacity="0.6"
-			color="green"
-		/>
-		<Points data={la_locations} lat="lat" long="long" color="red" />
-		<Points data={la_locations} lat="lat" long="long" color="purple" />
+		<Points data={la_locations} lat="lat" long="long" color="purple" z="1" />
 	</BaseMap>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -60,9 +60,19 @@
 </Story>
 <Story name="Multiple Points">
 	<BaseMap title="My Map" height="300">
-		<Points data={la_locations} lat="lat" long="long" color="red" z="3" />
-		<Points data={la_locations} lat="lat" long="long" color="purple" z="2" />
-		<Points data={la_locations} lat="lat" long="long" color="blue" z="1" />
+		<Points data={la_locations} lat="lat" long="long" color="purple" />
+		<Points data={la_locations} lat="lat" long="long" color="blue" />
+		<Points data={la_locations} lat="lat" long="long" color="red" />
+		<Bubbles
+			data={la_locations}
+			lat="lat"
+			long="long"
+			pointName="point_name"
+			value="sales"
+			size="sales"
+			tooltipType="hover"
+			opacity="0.6"
+		/>
 		<Points data={la_locations} lat="lat" long="long" color="green" />
 	</BaseMap>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -59,6 +59,8 @@
 			}
 		}
 	});
+
+	$: console.log(mapElement);
 </script>
 
 {#if error}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -59,8 +59,6 @@
 			}
 		}
 	});
-
-	$: console.log(mapElement);
 </script>
 
 {#if error}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -6,6 +6,7 @@ import { initSmoothZoom } from './LeafletSmoothZoom';
 import { writable, derived, readonly } from 'svelte/store';
 import chroma from 'chroma-js';
 import { uiColours } from '@evidence-dev/component-utilities/colours';
+import { toNumber } from '../../../utils.js';
 
 /** @template T @typedef {import('svelte/store').Writable<T>} Writable<T> */
 /** @template T @typedef {import('svelte/store').Readable<T>} Readable<T> */
@@ -239,10 +240,6 @@ export class EvidenceMap {
 		return geoJsonLayer;
 	}
 
-	#bubbleLayer;
-
-	#pointsLayer;
-
 	/**
 	 * Adds a circle marker to the map.
 	 * @param {object} item - The data item associated with the marker.
@@ -277,7 +274,11 @@ export class EvidenceMap {
 			} else if (circleOptions.pane === 'points' && circleOptions.z === undefined) {
 				this.#map.getPane('points').style.zIndex = 401; // Higher zIndex for points
 			} else if (circleOptions.z !== undefined) {
-				this.#map.getPane(circleOptions.pane).style.zIndex = 400 + circleOptions.z;
+				if (toNumber(circleOptions.z)) {
+					this.#map.getPane(circleOptions.pane).style.zIndex = 400 + toNumber(circleOptions.z);
+				} else {
+					this.#map.getPane(circleOptions.pane).style.zIndex = 400;
+				}
 			}
 		}
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -270,17 +270,25 @@ export class EvidenceMap {
 		if (!this.#map.getPane(circleOptions.pane)) {
 			this.#map.createPane(circleOptions.pane);
 
-			if (circleOptions.pane.includes('bubbles') && circleOptions.z === undefined) {
-				this.#map.getPane(circleOptions.pane).style.zIndex = 400; // Lower zIndex for bubbles
-			} else if (circleOptions.pane.includes('points') && circleOptions.z === undefined) {
-				this.#map.getPane(circleOptions.pane).style.zIndex = 401; // Higher zIndex for points
-			} else if (circleOptions.z !== undefined) {
-				if (toNumber(circleOptions.z)) {
-					this.#map.getPane(circleOptions.pane).style.zIndex = 400 + toNumber(circleOptions.z);
-				} else {
-					this.#map.getPane(circleOptions.pane).style.zIndex = 400;
+			console.log(this.#paneArray, circleOptions.pane);
+
+			this.#paneArray.forEach((pane, index) => {
+				if (pane === circleOptions.pane) {
+					this.#map.getPane(pane).style.zIndex = 400 + index;
 				}
-			}
+			});
+
+			// if (circleOptions.pane.includes('bubbles') && circleOptions.z === undefined) {
+			// 	this.#map.getPane(circleOptions.pane).style.zIndex = 400; // Lower zIndex for bubbles
+			// } else if (circleOptions.pane.includes('points') && circleOptions.z === undefined) {
+			// 	this.#map.getPane(circleOptions.pane).style.zIndex = 401; // Higher zIndex for points
+			// } else if (circleOptions.z !== undefined) {
+			// 	if (toNumber(circleOptions.z)) {
+			// 		this.#map.getPane(circleOptions.pane).style.zIndex = 400 + toNumber(circleOptions.z);
+			// 	} else {
+			// 		this.#map.getPane(circleOptions.pane).style.zIndex = 400;
+			// 	}
+			// }
 		}
 
 		// Create the marker with the appropriate pane

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -270,25 +270,11 @@ export class EvidenceMap {
 		if (!this.#map.getPane(circleOptions.pane)) {
 			this.#map.createPane(circleOptions.pane);
 
-			console.log(this.#paneArray, circleOptions.pane);
-
 			this.#paneArray.forEach((pane, index) => {
 				if (pane === circleOptions.pane) {
 					this.#map.getPane(pane).style.zIndex = 400 + index;
 				}
 			});
-
-			// if (circleOptions.pane.includes('bubbles') && circleOptions.z === undefined) {
-			// 	this.#map.getPane(circleOptions.pane).style.zIndex = 400; // Lower zIndex for bubbles
-			// } else if (circleOptions.pane.includes('points') && circleOptions.z === undefined) {
-			// 	this.#map.getPane(circleOptions.pane).style.zIndex = 401; // Higher zIndex for points
-			// } else if (circleOptions.z !== undefined) {
-			// 	if (toNumber(circleOptions.z)) {
-			// 		this.#map.getPane(circleOptions.pane).style.zIndex = 400 + toNumber(circleOptions.z);
-			// 	} else {
-			// 		this.#map.getPane(circleOptions.pane).style.zIndex = 400;
-			// 	}
-			// }
 		}
 
 		// Create the marker with the appropriate pane

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -6,7 +6,6 @@ import { initSmoothZoom } from './LeafletSmoothZoom';
 import { writable, derived, readonly } from 'svelte/store';
 import chroma from 'chroma-js';
 import { uiColours } from '@evidence-dev/component-utilities/colours';
-import { toNumber } from '../../../utils.js';
 
 /** @template T @typedef {import('svelte/store').Writable<T>} Writable<T> */
 /** @template T @typedef {import('svelte/store').Readable<T>} Readable<T> */

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -254,7 +254,16 @@ export class EvidenceMap {
 		link
 	) {
 		if (!Leaflet) throw new Error('Leaflet is not yet available');
-		const marker = Leaflet.circleMarker(coords, circleOptions).addTo(this.#map);
+		const pointsLayer = Leaflet.layerGroup().addTo(this.#map);
+		const bubblesLayer = Leaflet.layerGroup().addTo(this.#map);
+		const marker = Leaflet.circleMarker(coords, circleOptions);
+		// handle layering
+		if (circleOptions.markerType === 'points') {
+			marker.addTo(pointsLayer);
+		} else if (circleOptions.markerType === 'bubbles') {
+			marker.addTo(bubblesLayer);
+			marker.bringToBack();
+		}
 		this.updateMarkerStyle(marker, circleOptions); // Initial style setting and storage
 
 		marker.on('click', () => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -151,6 +151,7 @@ export class EvidenceMap {
 		this.#bounds = Leaflet.latLngBounds(); // Reset bounds to recalculate
 
 		this.#map.eachLayer((layer) => {
+			console.log(layer);
 			if (
 				layer instanceof Leaflet.Marker ||
 				layer instanceof Leaflet.CircleMarker ||
@@ -264,14 +265,10 @@ export class EvidenceMap {
 		link
 	) {
 		if (!Leaflet) throw new Error('Leaflet is not yet available');
-		const pointsLayer = Leaflet.layerGroup().addTo(this.#map);
-		const bubblesLayer = Leaflet.layerGroup().addTo(this.#map);
 		const marker = Leaflet.circleMarker(coords, circleOptions);
 		// handle layering
-		if (circleOptions.markerType === 'points') {
-			marker.addTo(pointsLayer);
-		} else if (circleOptions.markerType === 'bubbles') {
-			marker.addTo(bubblesLayer);
+		marker.addTo(this.#map);
+		if (circleOptions.markerType === 'bubbles') {
 			marker.bringToBack();
 		}
 		this.updateMarkerStyle(marker, circleOptions); // Initial style setting and storage

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -533,19 +533,4 @@ export class EvidenceMap {
 
 	/**@type {[string]} */
 	#paneArray = [];
-
-	checkPanes(paneType) {
-		let newPaneType = paneType;
-		let suffix = 1;
-
-		// Continue appending "-suffix" until a unique paneType is found
-		while (this.#paneArray.includes(newPaneType)) {
-			newPaneType = `${paneType}-${suffix}`;
-			suffix += 1;
-		}
-
-		// Add the unique paneType to the array
-		this.#paneArray.push(newPaneType);
-		return newPaneType;
-	}
 }

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -533,4 +533,11 @@ export class EvidenceMap {
 
 	/**@type {[string]} */
 	#paneArray = [];
+
+	registerPane(paneId) {
+		// Add the unique paneType to the array
+		this.#paneArray.push(paneId);
+
+		return paneId;
+	}
 }

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/EvidenceMap.js
@@ -269,10 +269,11 @@ export class EvidenceMap {
 		//other panes start at z-index 400
 		if (!this.#map.getPane(circleOptions.pane)) {
 			this.#map.createPane(circleOptions.pane);
-			if (circleOptions.pane === 'bubbles' && circleOptions.z === undefined) {
-				this.#map.getPane('bubbles').style.zIndex = 400; // Lower zIndex for bubbles
-			} else if (circleOptions.pane === 'points' && circleOptions.z === undefined) {
-				this.#map.getPane('points').style.zIndex = 401; // Higher zIndex for points
+
+			if (circleOptions.pane.includes('bubbles') && circleOptions.z === undefined) {
+				this.#map.getPane(circleOptions.pane).style.zIndex = 400; // Lower zIndex for bubbles
+			} else if (circleOptions.pane.includes('points') && circleOptions.z === undefined) {
+				this.#map.getPane(circleOptions.pane).style.zIndex = 401; // Higher zIndex for points
 			} else if (circleOptions.z !== undefined) {
 				if (toNumber(circleOptions.z)) {
 					this.#map.getPane(circleOptions.pane).style.zIndex = 400 + toNumber(circleOptions.z);
@@ -519,7 +520,7 @@ export class EvidenceMap {
 
 	async initializeData(
 		data,
-		{ corordinates, value, checkInputs, min, max, colorPalette, legendType }
+		{ corordinates, value, checkInputs, min, max, colorPalette, legendType, paneType }
 	) {
 		await data.fetch();
 		checkInputs(data, corordinates);
@@ -532,7 +533,26 @@ export class EvidenceMap {
 			values = this.handleLegendValues(colorPalette, values, legendType);
 			this.buildLegend(colorPalette, values, minValue, maxValue);
 		}
+
 		// Return the values, minValue, and maxValue for sharing with other functions
-		return { values, minValue, maxValue, colorScale, colorPalette };
+		return { values, minValue, maxValue, colorScale, colorPalette, paneType };
+	}
+
+	/**@type {[string]} */
+	#paneArray = [];
+
+	checkPanes(paneType) {
+		let newPaneType = paneType;
+		let suffix = 1;
+
+		// Continue appending "-suffix" until a unique paneType is found
+		while (this.#paneArray.includes(newPaneType)) {
+			newPaneType = `${paneType}-${suffix}`;
+			suffix += 1;
+		}
+
+		// Add the unique paneType to the array
+		this.#paneArray.push(newPaneType);
+		return newPaneType;
 	}
 }

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Bubbles.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Bubbles.svelte
@@ -9,6 +9,8 @@
 	export let size = undefined; // column containing size data
 	/** @type {number} */
 	export let opacity = 0.8;
+	/** @type {'bubble' | 'points' }*/
+	export let pointStyle = 'bubbles';
 </script>
 
-<Points sizeCol={size} {opacity} {...$$restProps} />
+<Points sizeCol={size} {opacity} {pointStyle} {...$$restProps} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Bubbles.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Bubbles.svelte
@@ -15,5 +15,4 @@
 	export let legendType = undefined;
 </script>
 
-<Points sizeCol={size} {opacity} {pointStyle} {...$$restProps} />
-
+<Points sizeCol={size} {opacity} {pointStyle} {legendType} {...$$restProps} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -294,7 +294,7 @@
 	}
 
 	/** @type {string}*/
-	let paneType = nanoid();
+	let paneType = map.registerPane(nanoid());
 </script>
 
 <!-- Additional data.fetch() included in await to trigger reactivity. Should ideally be handled in init() in the future. -->

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -227,10 +227,14 @@
 			min,
 			max,
 			colorPalette,
-			legendType
+			legendType,
+			paneType
 		};
 		if (data) {
-			({ values, colorScale, colorPalette } = await map.initializeData(data, initDataOptions));
+			({ values, colorScale, colorPalette, paneType } = await map.initializeData(
+				data,
+				initDataOptions
+			));
 
 			if (sizeCol) {
 				sizeExtents = getColumnExtentsLegacy(data, sizeCol);
@@ -288,8 +292,8 @@
 		setInputDefault(item, name);
 	}
 
-	/** @type {'points' | 'bubbles' | 'string'}*/
-	export let paneType = pointStyle;
+	/** @type {string}*/
+	let paneType = map.checkPanes(pointStyle);
 
 	/** @type {number | undefined} */
 	export let z = undefined;

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -294,9 +294,6 @@
 
 	/** @type {string}*/
 	let paneType = map.checkPanes(pointStyle);
-
-	/** @type {number | undefined} */
-	export let z = undefined;
 </script>
 
 <!-- Additional data.fetch() included in await to trigger reactivity. Should ideally be handled in init() in the future. -->
@@ -315,8 +312,7 @@
 				color: borderColor,
 				className: `outline-none ${pointClass}`,
 				markerType: pointStyle,
-				pane: paneType,
-				z: z
+				pane: paneType
 			}}
 			selectedOptions={{
 				fillColor: selectedColor,

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -17,6 +17,7 @@
 	if (!map) throw new Error('Evidence Map Context has not been set. Points will not function');
 
 	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
+	import { nanoid } from 'nanoid';
 	const inputs = getInputContext();
 
 	/** @type {import("@evidence-dev/sdk/usql").QueryValue} */
@@ -293,7 +294,7 @@
 	}
 
 	/** @type {string}*/
-	let paneType = map.checkPanes(pointStyle);
+	let paneType = nanoid();
 </script>
 
 <!-- Additional data.fetch() included in await to trigger reactivity. Should ideally be handled in init() in the future. -->

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -210,6 +210,9 @@
 
 	let values, minValue, maxValue, colorScale, sizeExtents, maxData, maxSizeSq;
 
+	/** @type {'bubble' | 'points' }*/
+	export let pointStyle = 'points';
+
 	/**
 	 * Initialize the component.
 	 * @returns {Promise<void>}
@@ -293,7 +296,8 @@
 				opacity: opacity,
 				weight: borderWidth,
 				color: borderColor,
-				className: `outline-none ${pointClass}`
+				className: `outline-none ${pointClass}`,
+				markerType: pointStyle
 			}}
 			selectedOptions={{
 				fillColor: selectedColor,

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -287,6 +287,12 @@
 		});
 		setInputDefault(item, name);
 	}
+
+	/** @type {'points' | 'bubbles' | 'string'}*/
+	export let paneType = pointStyle;
+
+	/** @type {number | undefined} */
+	export let z = undefined;
 </script>
 
 <!-- Additional data.fetch() included in await to trigger reactivity. Should ideally be handled in init() in the future. -->
@@ -304,7 +310,9 @@
 				weight: borderWidth,
 				color: borderColor,
 				className: `outline-none ${pointClass}`,
-				markerType: pointStyle
+				markerType: pointStyle,
+				pane: paneType,
+				z: z
 			}}
 			selectedOptions={{
 				fillColor: selectedColor,

--- a/sites/docs/pages/components/base-map.md
+++ b/sites/docs/pages/components/base-map.md
@@ -390,6 +390,21 @@ options="column name"
 Column containing the names/labels of the points - by default, this is shown as the title of the tooltip.
 </PropListing>
 
+<PropListing
+    name="paneType"
+    options="text"
+>
+    Specifies the type of pane where the points will be rendered.
+</PropListing>
+
+<PropListing
+    name="z"
+    options="number"
+>
+    Represents the z-index value for the pane, controlling its stacking order relative to other panes (higher values are on top, e.g., z=2 is above z=1).
+</PropListing>
+
+
 ### Bubbles
 Use the `<Bubbles/>` component to add an area layer
 
@@ -459,6 +474,20 @@ name="pointName"
 options="column name"
 >
 Column containing the names/labels of the points - by default, this is shown as the title of the tooltip.
+</PropListing>
+
+<PropListing
+    name="paneType"
+    options="text"
+>
+    Specifies the type of pane where the bubbles will be rendered.
+</PropListing>
+
+<PropListing
+    name="z"
+    options="number"
+>
+    Represents the z-index value for the pane, controlling its stacking order relative to other panes (higher values are on top, e.g., z=2 is above z=1).
 </PropListing>
 
 ### Common Layer Options

--- a/sites/docs/pages/components/base-map.md
+++ b/sites/docs/pages/components/base-map.md
@@ -390,20 +390,6 @@ options="column name"
 Column containing the names/labels of the points - by default, this is shown as the title of the tooltip.
 </PropListing>
 
-<PropListing
-    name="paneType"
-    options="text"
->
-    Specifies the type of pane where the points will be rendered.
-</PropListing>
-
-<PropListing
-    name="z"
-    options="number"
->
-    Represents the z-index value for the pane, controlling its stacking order relative to other panes (higher values are on top, e.g., z=2 is above z=1).
-</PropListing>
-
 
 ### Bubbles
 Use the `<Bubbles/>` component to add an area layer


### PR DESCRIPTION
### Description
Points + Bubbles Layering inconsistency affecting chromatic checks.
This PR seperates Points and Bubbles into separate layers, ensuring Points layers on top of bubbles 

Video:
1. Multiple storybook refreshes showing points layered above bubbles
2. 2 browser refreshes showing points layered above bubbles

https://github.com/user-attachments/assets/39435e78-941e-408c-b064-09f38553e45a

--------------------------------------------------------------------------------------------------------------------------------------------

_**UPDATE**_

**-Example**
The order of layering from bottom - top = [bubbles (yellow), points (green), points(red)]

	`<BaseMap title="My Map" height="300">
		<Bubbles {...$$restProps} color="yellow"/>
		<Points {...$$restProps} color="green" />
		<Points {...$$restProps} color="red" />
	</BaseMap>`
	
**-How it Works**

1. We first register the components in the order they are  written in an `array`
2. We create seperate panes for each component and add their points/bubbles to their pane
3. We give those Panes a z-index based on their order in the `array`

**-Changes**

1. Removed paneType and z prop
2. No longer handle points over bubbles (up to user design)
3. Panes solve onClick layering issue




### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- ~~[ ] I have added to the docs where applicable~~
- ~~[ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
