### PR TITLE
Rename project -> app throughout docs

### DIFF
--- a/MONOREPO_ROADMAP.md
+++ b/MONOREPO_ROADMAP.md
@@ -154,7 +154,7 @@ Allows Evidence to collect anonymous information about product usage
 
 #### `@evidence-dev/vite`
 
-Responsible for providing a Vite plugin for converting a Vite app into an [Evidence App](#evidence-application)
+Responsible for providing a Vite plugin for converting a Vite app into an [Evidence App](#evidence-app)
 
 ##### Does:
 
@@ -167,13 +167,13 @@ Responsible for providing a Vite plugin for converting a Vite app into an [Evide
 
 #### `@evidence-dev/sdk`
 
-Responsible for encapsulating all Evidence framework logic, contains the needed interfaces to create an [Evidence Appliction](#evidence-application).
+Responsible for encapsulating all Evidence framework logic, contains the needed interfaces to create an [Evidence App](#evidence-app).
 
 ##### Does:
 
 - Implement stores using Svelte's store contract (without referencing Svelte directly)
   - Consider using a tool like [nanostores](https://github.com/nanostores/nanostores)
-- Provides everything needed to turn a Vite project into an [Evidence Application](#evidence-application)
+- Provides everything needed to turn a Vite project into an [Evidence App](#evidence-app)
   - This does not include framework-specific ergonomics such as those in [@evidence-dev/lang-svelte](#evidence-devlang-svelte)
 
 ##### Does Not:
@@ -235,7 +235,7 @@ This functionality was previously provided by `@evidence-dev/component-utilities
   - Injects [Component Plugins](#component-plugin)
   - Initializes [USQL](#evidence-devusql-duckdb)
 - Provide an interface to ease the use of [sdk](#evidence-devsdk) functionality in Svelte (e.g. using Svelte's context or lifecycle functions)
-  - Includes making SSR in an [Application Shell (plugin)](#application-shell-plugin) or [Evidence App](#evidence-application) trivial
+  - Includes making SSR in an [Application Shell (plugin)](#application-shell-plugin) or [Evidence App](#evidence-app) trivial
 
 ##### Does Not:
 
@@ -271,7 +271,7 @@ This functionality was previously provided by `@evidence-dev/core-components` an
 #### `@evidence-dev/ui-svelte`
 
 Responsible for providing Visualization and UI Components for building
-[Evidence Apps](#evidence-application) and [Evidence Projects](#evidence-project)
+[Evidence Apps](#evidence-app)
 
 This functionality was previously provided by `@evidence-dev/core-components` and `@evidence-dev/component-utilities`
 
@@ -362,9 +362,9 @@ This functionality was previously provided by `evidence-vscode`
 - Contains known directories (e.g. `pages`, `sources`, etc.), and is copied into an [Application Shell](#application-shell) to create the final site.
 - Used to abstract away the complexity of modern web development to make it accessible for data professionals.
 
-#### Evidence Application
+#### Evidence App
 
-- Any web project that introduced the [SDK](#evidence-devsdk) and [Datasources](#datasource-plugin) to leverage [Headless Evidence](#headless-evidence).
+- The browser based rendering of an [Evidence Project](#evidence-project), either locally in development, or deployed online.
 
 #### Application Shell
 
@@ -384,7 +384,7 @@ This functionality was previously provided by `evidence-vscode`
 
 #### Component Plugin
 
-- A standalone Javascript package that contains components for [Authors](#authors) to use in their projects.
+- A standalone Javascript package that contains components for [Authors](#authors) to use in their apps.
 - The components specified in this package are implicitly loaded and do not need to be specified on each page.
 
 #### Datasource Plugin
@@ -395,19 +395,18 @@ This functionality was previously provided by `evidence-vscode`
 
 - Provides a shell application (in any framework) that creates
   a destination for the files in an [Evidence Project](#evidence-project).
-- It is implicitly also an [Evidence App](#evidence-application).
 - Includes an initial project state
 
 ### Types of Users
 
 #### Developers
 
-- A user that is writing plugins, components, or customizing an application shell (i.e. writing Javascript)
+- Creates plugins, components, or customizes an application shell (i.e. writing Javascript)
 
 #### Authors
 
-- A user that is writing [Evidence Projects](#evidence-project) without directly interfacing with the [SDK](#evidence-devsdk)
+- Creates and maintains [Evidence Projects](#evidence-project) without directly interfacing with the [SDK](#evidence-devsdk)
 
 #### Viewers
 
-- A user that is reading a completed, built Evidence project
+- Reads a completed, built [Evidence App](#evidence-app)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See docs for [other install options](https://docs.evidence.dev/getting-started/i
 
 # Publish
 
-- [Evidence Cloud](https://evidence.dev/cloud) is the easiest way to securely host your project. It's free to get started.
+- [Evidence Cloud](https://evidence.dev/cloud) is the easiest way to securely host your app. It's free to get started.
 - [Self-hosted](https://docs.evidence.dev/deployment/overview) options include Netlify, Vercel, your own infra, and other static site hosting platforms.
 
 # Join the Evidence Community

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -107,7 +107,6 @@ You can access the VS Code shortcut commands from the command palette (`Cmd/Ctrl
 | `viewSettings`        | VS Code Extension Settings | View Evidence extension settings in the built-in VS Code Settings editor.                           |
 | `copyProject`         | Copy Existing Project      | Provide a URL of a Github repo to pull from                                                         |
 
-
 ## Settings
 
 Create [User or Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings) to change default Evidence VS Code extension Settings.

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -107,19 +107,6 @@ You can access the VS Code shortcut commands from the command palette (`Cmd/Ctrl
 | `viewSettings`        | VS Code Extension Settings | View Evidence extension settings in the built-in VS Code Settings editor.                           |
 | `copyProject`         | Copy Existing Project      | Provide a URL of a Github repo to pull from                                                         |
 
-## Deployment
-
-You can self-host or deploy on Evidence Cloud, with a public project or behind user authentication.
-
-Evidence projects utlize a scheduled build process, which runs the queries in your project and builds all of your pages. The output of this process is a pre-built, self-contained static web application.
-
-This results in near instant page loads for your users and means that they are not hitting your data warehouse by interacting with their reports.
-
-Despite this static output, you can still deliver fully interactive and exporable data products through our most recent release for [Universal SQL](https://evidence.dev/universal-sql)
-
-[Sign up for Evidence Cloud here](https://evidence.dev/cloud)
-
-[Learn more about deployment here](https://docs.evidence.dev/deployment/overview)
 
 ## Settings
 

--- a/sites/docs/pages/components/area-map.md
+++ b/sites/docs/pages/components/area-map.md
@@ -494,7 +494,7 @@ options="URL"
 
 Path to source geoJSON data from - can be a URL (see [Map Resources](#map-resources)) or a file in your project. 
 
-If the file is in your project, store it in a `static` folder in the root of your project, and reference it as `geoJsonUrl="/your_file.geojson"`
+If the file is in your `static` directory in the root of your project, reference it as `geoJsonUrl="/your_file.geojson"`
 
 </PropListing>
 

--- a/sites/docs/pages/components/base-map.md
+++ b/sites/docs/pages/components/base-map.md
@@ -306,7 +306,7 @@ required
 options="URL"
 >
 
-Path to source geoJSON data from - can be a URL (see [Map Resources](#map-resources)) or a file in your app's `static` directory. 
+Path to source geoJSON data from - can be a URL (see [Map Resources](#map-resources)) or a file in your project.
 
 If the file is in your `static` directory in the root of your project, reference it as `geoJsonUrl="/your_file.geojson"`
 

--- a/sites/docs/pages/components/base-map.md
+++ b/sites/docs/pages/components/base-map.md
@@ -306,9 +306,9 @@ required
 options="URL"
 >
 
-Path to source geoJSON data from - can be a URL (see [Map Resources](#map-resources)) or a file in your project. 
+Path to source geoJSON data from - can be a URL (see [Map Resources](#map-resources)) or a file in your app's `static` directory. 
 
-If the file is in your project, store it in a `static` folder in the root of your project, and reference it as `geoJsonUrl="/your_file.geojson"`
+If the file is in your `static` directory in the root of your project, reference it as `geoJsonUrl="/your_file.geojson"`
 
 </PropListing>
 

--- a/sites/docs/pages/components/big-link.md
+++ b/sites/docs/pages/components/big-link.md
@@ -16,5 +16,5 @@ sidebar_position: 1
 
 <PropListing name="href" required options='string'>
 
-Renders a link that, when clicked, navigates to the specified URL. It can accept either a full external link (e.g. `https://google.com`) or link to another page within your evidence project (e.g. `/sales/performance`).
+Renders a link that, when clicked, navigates to the specified URL. It can accept either a full external link (e.g. `https://google.com`) or link to another page within your evidence app (e.g. `/sales/performance`).
 </PropListing>

--- a/sites/docs/pages/components/custom-components.md
+++ b/sites/docs/pages/components/custom-components.md
@@ -96,7 +96,7 @@ If you have built custom components that you would like other Evidence users to 
 ## Utility Functions
 Evidence provides a collection of helpful utility functions to use within custom components, for things like error handling, data manipulation, and value formatting.
 
-To use these in your app, you must import them explicitly in the script tag portion of your component. The import line for each utlity function is included for reference below:
+To use these utilities, you must import them explicitly in the script tag portion of your component. The import line for each utlity function is included for reference below:
 
 ### Error Handling
 

--- a/sites/docs/pages/components/custom-components.md
+++ b/sites/docs/pages/components/custom-components.md
@@ -5,7 +5,7 @@ title: Custom Components
 
 Custom components allow you to extend the functionality of Evidence, as well as to make your code more reusable.
 
-In Evidence, you can build your own components and use them anywhere in your project. This is made possible through Svelte, the JavaScript framework Evidence is built on. These components can include the charts used for visualization, custom components created completely from scratch, or adaptations of existing UI components such as the header, sidebar, menu, etc.
+In Evidence, you can build your own components and use them anywhere in your app. This is made possible through Svelte, the JavaScript framework Evidence is built on. These components can include the charts used for visualization, custom components created completely from scratch, or adaptations of existing UI components such as the header, sidebar, menu, etc.
 
 [Evidence Labs](https://labs.evidence.dev) contains several good examples of custom components.
 
@@ -68,7 +68,7 @@ select 'UK' as country, 300 as sales_usd
 
 <p>
 	Here is a BarChart in a Component, with some accompanying text. Components stored in the
-	/components/ folder will be included in your project.
+	/components/ folder will be included in your app.
 </p>
 
 <BarChart data={myData} />
@@ -91,12 +91,12 @@ In the custom component:
 1. **Import any [Evidence components](https://github.com/evidence-dev/evidence/tree/main/sites/example-project/src/components)** you want to use in the custom component
 
 ## Optional: Publishing Your Components as a Plugin
-If you have built custom components that you would like other Evidence users to be able to use in their projects, you can publish them as an Evidence plugin. See the [Plugin section](/plugins/create-component-plugin/) for more details.
+If you have built custom components that you would like other Evidence users to be able to use in their apps, you can publish them as an Evidence plugin. See the [Plugin section](/plugins/create-component-plugin/) for more details.
 
 ## Utility Functions
 Evidence provides a collection of helpful utility functions to use within custom components, for things like error handling, data manipulation, and value formatting.
 
-To use these in your project, you must import them explicitly in the script tag portion of your component. The import line for each utlity function is included for reference below:
+To use these in your app, you must import them explicitly in the script tag portion of your component. The import line for each utlity function is included for reference below:
 
 ### Error Handling
 

--- a/sites/docs/pages/components/data-table.md
+++ b/sites/docs/pages/components/data-table.md
@@ -609,9 +609,9 @@ Click on a row to navigate using the row link:
 	<Column id=value_usd />
 </DataTable>
 
-#### Link to Pages in Your Project
+#### Link to Pages in Your App
 
-In this example, the SQL query contains a column with links to parameterized pages in the project. Below is an example of the SQL that could be used to generate such links:
+In this example, the SQL query contains a column with links to parameterized pages in the app. Below is an example of the SQL that could be used to generate such links:
 
 ```sql
 select

--- a/sites/docs/pages/components/link-button.md
+++ b/sites/docs/pages/components/link-button.md
@@ -18,5 +18,5 @@ sidebar_position: 1
 
 <PropListing name="url" required options='string'>
 
-Renders a button that, when clicked, navigates to the specified URL. It can accept either a full external link (e.g. `https://google.com`) or link to another page within your evidence project (e.g. `/sales/performance`).
+Renders a button that, when clicked, navigates to the specified URL. It can accept either a full external link (e.g. `https://google.com`) or link to another page within your evidence app (e.g. `/sales/performance`).
 </PropListing>

--- a/sites/docs/pages/core-concepts/data-sources/index.md
+++ b/sites/docs/pages/core-concepts/data-sources/index.md
@@ -30,7 +30,7 @@ More information about the architecture design can be found in [this article](ht
 
 To connect your local development environment to a database:
 
-1. Run your evidence project with `npm run dev`
+1. Run your evidence app with `npm run dev`
 1. Navigate to [localhost:3000/settings](http://localhost:3000/settings)
 1. Select your data source, name it, and enter required credentials
 1. (If required) Open the `connections.yaml` file inside `/sources/[source_name]` and add any additional configuration options
@@ -198,7 +198,7 @@ gcloud auth application-default print-access-token
 ```
 > *Note: This token will expire after 1 hour.*
 
-Now you can copy the access token and use it in your Evidence project.
+Now you can copy the access token and use it in your Evidence app.
 
 
 ### Snowflake
@@ -353,7 +353,7 @@ To create a service account, see the [BigQuery instructions](#bigquery).
 
 1. Create a service account, and download the JSON key file
 2. Give the service account access to your Google Sheet by sharing the sheet with the service account's email address.
-4. Add the JSON key file to your Evidence project via the [Settings page](localhost:3000/settings)
+4. Add the JSON key file to your Evidence app via the [Settings page](localhost:3000/settings)
 5. In the connections.yaml file, add the sheet id (which can be found in the URL of the Google Sheet, after `https://docs.google.com/spreadsheets/d/`).
 
 ```yaml
@@ -378,7 +378,7 @@ Where `[your_tab_name]` is the name of the tab in your Google Sheet, with spaces
 
 In Evidence, you can query local CSV files directly in SQL.
 
-Get started by selecting the `CSV` connector on the Settings page in your project, naming it and then clicking "confirm changes". 
+Get started by selecting the `CSV` connector on the Settings page in your app, naming it and then clicking "confirm changes". 
 
 Then copy any CSV files you want to query into `sources/[your_csv_source_name]/`. Your source names and csv files can only contain letters, numbers and underscores eg `/my_source/my_csv_2024.csv`
 
@@ -386,7 +386,7 @@ The section below applies to both CSV and Parquet files.
 
 #### How to Query a CSV File
 
-Evidence looks for CSV files stored in a `sources/[your_csv_source_name]/` folder in the root of your Evidence project. You can query them using this syntax:
+Evidence looks for CSV files stored in a `sources/[your_csv_source_name]/` folder in the root of your Evidence app. You can query them using this syntax:
 
 ```sql
 select * from your_csv_source_name.csv_file_name

--- a/sites/docs/pages/core-concepts/data-sources/index.md
+++ b/sites/docs/pages/core-concepts/data-sources/index.md
@@ -386,7 +386,7 @@ The section below applies to both CSV and Parquet files.
 
 #### How to Query a CSV File
 
-Evidence looks for CSV files stored in a `sources/[your_csv_source_name]/` folder in the root of your Evidence app. You can query them using this syntax:
+Evidence looks for CSV files stored in a `sources/[your_csv_source_name]/` folder in the root of your Evidence project. You can query them using this syntax:
 
 ```sql
 select * from your_csv_source_name.csv_file_name

--- a/sites/docs/pages/core-concepts/formatting/index.md
+++ b/sites/docs/pages/core-concepts/formatting/index.md
@@ -41,7 +41,7 @@ Formatting does not apply to the date axis of a chart. For example, if you set `
 #### Reusable Formats
 For a more reusable approach, you can use [SQL format tags](#sql-format-tags), which let you define formats within your SQL. This guarantees that your columns will be formatted in the same way wherever they are used in Evidence.
 
-You can also create your own [custom formats](#custom-formats), which are format codes you can reuse across your project.
+You can also create your own [custom formats](#custom-formats), which are format codes you can reuse across your app.
 
 #### Formatting Directly in Markdown
 If you need to format values outside of components, [the format function](#format-function) can be used directly. For example, when using [expressions](/core-concepts/syntax#expressions) it is not possible to use component props or format tags.

--- a/sites/docs/pages/core-concepts/formatting/index.md
+++ b/sites/docs/pages/core-concepts/formatting/index.md
@@ -41,7 +41,7 @@ Formatting does not apply to the date axis of a chart. For example, if you set `
 #### Reusable Formats
 For a more reusable approach, you can use [SQL format tags](#sql-format-tags), which let you define formats within your SQL. This guarantees that your columns will be formatted in the same way wherever they are used in Evidence.
 
-You can also create your own [custom formats](#custom-formats), which are format codes you can reuse across your app.
+You can also create your own [custom formats](#custom-formats), which are format codes you can reuse across your project.
 
 #### Formatting Directly in Markdown
 If you need to format values outside of components, [the format function](#format-function) can be used directly. For example, when using [expressions](/core-concepts/syntax#expressions) it is not possible to use component props or format tags.

--- a/sites/docs/pages/core-concepts/queries/index.md
+++ b/sites/docs/pages/core-concepts/queries/index.md
@@ -95,7 +95,7 @@ To use sql file queries, you need to place them in the `queries` directory, and 
 An example setup could be:
 
 ```
-my-evidence-app/
+my-evidence-project/
   pages/
     my_page.md
   queries/

--- a/sites/docs/pages/core-concepts/queries/index.md
+++ b/sites/docs/pages/core-concepts/queries/index.md
@@ -95,7 +95,7 @@ To use sql file queries, you need to place them in the `queries` directory, and 
 An example setup could be:
 
 ```
-my-evidence-project/
+my-evidence-app/
   pages/
     my_page.md
   queries/

--- a/sites/docs/pages/core-concepts/templated-pages/index.md
+++ b/sites/docs/pages/core-concepts/templated-pages/index.md
@@ -13,7 +13,7 @@ Templated pages allow you to use a single markdown file as a template for many p
 
 In example 1 above, www.example.com/customers/acme would display information for Acme, while www.example.com/customers/contoso would display information for Contoso.
 
-A useful reference can be found in the [Needful Things example project](https://github.com/evidence-dev/demo/tree/main/pages/operations/pick_lists).
+A useful reference can be found in the [Needful Things example app](https://github.com/evidence-dev/demo/tree/main/pages/operations/pick_lists).
 
 
 ## Quickstart: VS Code Extension
@@ -85,7 +85,7 @@ Adding this to a `<Value/>` component:
 
 So far, we've created the template for a set of pages, but haven't specified what specific pages to create, or to put it another way, what values we want the parameter to take.
 
-For a page to be built, there must be links to it somewhere in your project.
+For a page to be built, there must be links to it somewhere in your app.
 
 Whilst you could add markdown style links for each parameter value, it is easier to programmatically generate them. Two easy options are:
 

--- a/sites/docs/pages/deployment/environments.md
+++ b/sites/docs/pages/deployment/environments.md
@@ -30,7 +30,7 @@ Add your dev database credentials for your dev environment via the **settings pa
 
 ### Prod environment
 
-Add your prod database credentials as environment variables. The specific instructions depend on how you are deploying Evidence. Instructions can be be found in the deployment section of the settings page of your local project.
+Add your prod database credentials as environment variables. The specific instructions depend on how you are deploying Evidence. Instructions can be be found in the deployment section of the settings page of your app running locally.
 
 <Alert status=info>
 

--- a/sites/docs/pages/deployment/evidence-cloud.md
+++ b/sites/docs/pages/deployment/evidence-cloud.md
@@ -2,22 +2,22 @@
 sidebar_position: 2
 hide_table_of_contents: false
 title: Evidence Cloud
-description: Evidence Cloud is a hosting service that allows you to securely host Evidence projects. It's the easiest way to host an Evidence project, without having to worry about maintaining your own infrastructure.
+description: Evidence Cloud is a hosting service that allows you to securely host Evidence apps. It's the easiest way to host an Evidence app, without having to worry about maintaining your own infrastructure.
 ---
 
 ## What is Evidence Cloud?
 
-Evidence Cloud is our hosting service that allows you to securely host Evidence projects.
+Evidence Cloud is our hosting service that allows you to securely host Evidence apps.
 
-It's the easiest way to host an Evidence project, without having to worry about maintaining your own infrastructure.
+It's the easiest way to host an Evidence app, without having to worry about maintaining your own infrastructure.
 
 ### Key Features
 
 - **Easy to set up:** Deploy in 5 minutes without configuring any infrastructure.
 - **Secure:** Manage access for users in your team.
-- **Organizational domain:** Host your project at `[organisation].evidence.app`.
-- **Scheduled refreshes:** Daily (or more frequent) data updates to your project.
-- **Re-build on push:** Merge to your target branch to rebuild your project.
+- **Organizational domain:** Host your app at `[organisation].evidence.app`.
+- **Scheduled refreshes:** Daily (or more frequent) data updates to your app.
+- **Re-build on push:** Merge to your target branch to rebuild your app.
 
 ## Sign Up
 
@@ -34,10 +34,10 @@ Setting up Evidence Cloud takes less than 5 minutes.
 
 1. Go to [evidence.app](https://evidence.app) and sign in with GitHub
 1. Choose an option to get started:
-   1. **If you have an existing project:** click `Deploy Evidence Project`
-   1. **If you don't have a project yet**, select `Create New Project from Template`, then return to [evidence.app](https://evidence.app) after creating your template project in GitHub
+   1. **If you have an existing app:** click `Deploy Evidence Project`
+   1. **If you don't have a app yet**, select `Create New Project from Template`, then return to [evidence.app](https://evidence.app) after creating your template app in GitHub
 1. Enter your deployment details, including the GitHub repo you want to use, and the domain you want to deploy it to
-1. Add your credentials, either from your local project or from the template
+1. Add your credentials, either from your local app or from the template
 1. Click `Deploy your project`
 
 
@@ -58,9 +58,9 @@ Setting up Evidence Cloud takes less than 5 minutes.
 You can set up data refreshes as regularly as you need on the Team and Enterprise plans.
 </Details>
 
-<Details title="How does authentication work for my private project?">
+<Details title="How does authentication work for my private app?">
 
-    Each viewer account is provided with a unique login to access the project. You can manage viewers in the Evidence Cloud UI.
+    Each viewer account is provided with a unique login to access the app. You can manage viewers in the Evidence Cloud UI.
 </Details>
 
 <Details title="Can I create a public Evidence Cloud site?">
@@ -70,7 +70,7 @@ You can set up data refreshes as regularly as you need on the Team and Enterpris
 
 <Details title="How do I set up development previews?">
 
-Alongside your `main` branch, set up a secondary project targeting a development branch (e.g. `dev`) whenever you merge changes into `dev`, you will get a preview. When you are ready to release changes, merge these into `main`.
+Alongside your `main` branch, set up a secondary app targeting a development branch (e.g. `dev`) whenever you merge changes into `dev`, you will get a preview. When you are ready to release changes, merge these into `main`.
 
 You can set up different database credentials for development deployments, which allows 
 you to use development data before it is in your production db.
@@ -83,7 +83,7 @@ you to use development data before it is in your production db.
 
 <Details title="Is Evidence Cloud free?">
 
-Evidence Cloud's Free tier offers unlimited public projects. For authentication and scheduled updates, [paid plans](https://evidence.dev/cloud) are available.
+Evidence Cloud's Free tier offers unlimited public apps. For authentication and scheduled updates, [paid plans](https://evidence.dev/cloud) are available.
 
 </Details>
 
@@ -95,7 +95,7 @@ Email us: [archie@evidence.dev](mailto:archie@evidence.dev), or reach out on Evi
 
 ### Account Management
 
-<Details title="How do I add a new developer to my Evidence project?">
+<Details title="How do I add a new developer to my Evidence app?">
 
 Give them access to your [Github repository](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/managing-an-individuals-access-to-an-organization-repository). All Evidence Cloud plans come with unlimited developer accounts.
 
@@ -109,7 +109,7 @@ We support GitHub by default. If your team needs another git provider, reach out
 
 ### Troubleshooting
 
-<Details title="I've successfully deployed the template project. How do I edit it?">
+<Details title="I've successfully deployed the template app. How do I edit it?">
 
 Clone the git repository to your local machine (the repo URL is shown in the cloud UI), make edits to the code and/or database settings, and merge the edits to your target branch.
 
@@ -125,7 +125,7 @@ Most builds will be completed in under 2 minutes, and you can track progress in 
 
 <Details title="When can I expect build failures?">
 
-Evidence will not deploy sites with errors to prevent users from seeing broken reports. Usually, this is caused by an error with your project code.  Enter `npm run build` in your editor to test if the build succeeds locally. If you are still having issues, reach out on [Slack](https://slack.evidence.dev).
+Evidence will not deploy sites with errors to prevent users from seeing broken reports. Usually, this is caused by an error with your code.  Enter `npm run build` in your editor to test if the build succeeds locally. If you are still having issues, reach out on [Slack](https://slack.evidence.dev).
 
 </Details>
 

--- a/sites/docs/pages/deployment/netlify.md
+++ b/sites/docs/pages/deployment/netlify.md
@@ -2,12 +2,12 @@
 sidebar_position: 3
 hide_table_of_contents: false
 title: Netlify
-description: Deploy your project to Netlify, which offers free hosting for public projects and password-protected hosting for paid plans.
+description: Deploy your app to Netlify, which offers free hosting for public apps and password-protected hosting for paid plans.
 ---
 
 <Alert status=warning>
 
-All URLs on Netlify are converted to lowercase. This can cause issues if you're using `{params.my_param}` to filter data in your project. It's recommended to use lowercase any time you're using a URL parameter to filter data, like this:
+All URLs on Netlify are converted to lowercase. This can cause issues if you're using `{params.my_param}` to filter data in your markdown. It's recommended to use lowercase any time you're using a URL parameter to filter data, like this:
 
 ```sql
 SELECT * FROM source_name.my_table 
@@ -16,15 +16,15 @@ WHERE LOWER(my_column) = LOWER('${params.my_param}')
 
 </Alert>
 
-Netlify lets you host a public version of your project for free, or you can create and host a password-protected version with Netlify's $15/month plan.
+Netlify lets you host a public version of your app for free, or you can create and host a password-protected version with Netlify's $15/month plan.
 
 ## Deploy to Netlify
 
-1. Run your project in development mode
+1. Run your app in development mode
 1. Visit the [settings page](http://localhost:3000/settings)
 1. Open the deployment panel, and select 'netlify', then follow the provided instructions
 
-## Optional: Set a site-wide password for your project (Requires Paid Plan)
+## Optional: Set a site-wide password for your app (Requires Paid Plan)
 
 Follow the directions provided by Netlify to set up a password for your site:
 https://docs.netlify.com/visitor-access/password-protection/

--- a/sites/docs/pages/deployment/overview.md
+++ b/sites/docs/pages/deployment/overview.md
@@ -10,25 +10,25 @@ description: Evidence is a static site generator, so can be deployed to any stat
 
 In production, Evidence is a [static site generator](https://www.netlify.com/blog/2020/04/14/what-is-a-static-site-generator-and-3-ways-to-find-the-best-one/) by default. This means it doesn't run queries when someone visits your site, but pre-builds all possible pages as HTML beforehand.
 
-You can host your Evidence project using Evidence Cloud, cloud services like Netlify or Vercel, or your own infrastructure. Evidence does not currently support Github Pages, there is more information on [GitHub](https://github.com/evidence-dev/evidence/issues/603).
+You can host your Evidence app using Evidence Cloud, cloud services like Netlify or Vercel, or your own infrastructure. Evidence does not currently support Github Pages, there is more information on [GitHub](https://github.com/evidence-dev/evidence/issues/603).
 
 You can also configure Evidence as a [Single Page App (SPA)](/deployment/rendering-modes). In SPA mode Evidence will not pre-build all the pages in your application. This can be preferrable if your app has many pages (>1,000) causing long build times.
 
 ## Evidence Cloud
 
-The easiest way to deploy Evidence is on [Evidence Cloud](/deployment/evidence-cloud). Evidence Cloud is free for public projects, and has paid plans for private projects.
+The easiest way to deploy Evidence is on [Evidence Cloud](/deployment/evidence-cloud). Evidence Cloud is free for public apps, and has paid plans for private apps.
 
 ## Build Process
 
 Evidence doesn't run new queries each time someone visits one of your reports.
 
-Instead, Evidence runs your queries once, at build time, and statically generates _all_ of the pages in your project. This includes all possible permutations of any paramaterized pages.
+Instead, Evidence runs your queries once, at build time, and statically generates _all_ of the pages in your app. This includes all possible permutations of any paramaterized pages.
 
 You can schedule (or trigger) regular builds of your site to keep it up-to-date with your data warehouse.
 
 This has two benefits for you and your users:
 
-1. If something goes wrong with your SQL, Evidence just stops building your project, and continues to serve older results.
+1. If something goes wrong with your SQL, Evidence just stops building your app, and continues to serve older results.
 2. Your site will be exceptionally fast. Under most conditions, pages will load in milliseconds.
 
 ## Build Commands
@@ -55,9 +55,9 @@ This command will fail if:
 
 In production, Evidence expects to find your database credentials in **environment variables**.
 
-To find the environment variables that you'll need to set for your project:
+To find the environment variables that you'll need to set for your app:
 
-1. Run your project in development mode
+1. Run your app in development mode
 1. Visit the [settings page](http://localhost:3000/settings)
 1. Open the deployment panel, and select your deployment target
 

--- a/sites/docs/pages/deployment/vercel.md
+++ b/sites/docs/pages/deployment/vercel.md
@@ -2,7 +2,7 @@
 sidebar_position: 4
 hide_table_of_contents: false
 title: Vercel
-description: Deploy a public project to Vercel for free or a password-protected project with the pro plan.
+description: Deploy a public app to Vercel for free or a password-protected app with the pro plan.
 ---
 
 
@@ -14,15 +14,15 @@ Note that because of missing dependencies, Vercel cannot be used with DuckDB sou
 
 </Alert>
 
-Vercel lets you host a public version of your project for free, or you can create and host a password-protected version with Vercel's $150/month pro plan. [Netlify](/deployment/netlify) offers the same option for $15/month.
+Vercel lets you host a public version of your app for free, or you can create and host a password-protected version with Vercel's $150/month pro plan. [Netlify](/deployment/netlify) offers the same option for $15/month.
 
 ## Deploy to Vercel
 
-1. Run your project in development mode
+1. Run your app in development mode
 1. Visit the [settings page](http://localhost:3000/settings)
 1. Open the deployment panel, and select 'Vercel', then follow the provided instructions
 
-## Optional: Set a site-wide password for your project (Requires Paid Plan)
+## Optional: Set a site-wide password for your app (Requires Paid Plan)
 
 Follow the directions provided by Vercel to set up a password for your site:
 https://vercel.com/blog/protecting-deployments

--- a/sites/docs/pages/guides/troubleshooting.md
+++ b/sites/docs/pages/guides/troubleshooting.md
@@ -19,7 +19,7 @@ select '<code>npm view @evidence-dev/evidence version</code>' as "Command", 'Che
 select '<code>node -v</code>' as "Command", 'Check NodeJS version' as "Description"
 ```
 
-Run these commands in your terminal to see which versions your project is using
+Run these commands in your terminal to see which versions your app is using
 
 <DataTable data={commands} formatColumnTitles=false>
     <Column id="Description" wrap/>
@@ -31,20 +31,20 @@ Run these commands in your terminal to see which versions your project is using
 ## Installation
 
 ### Not able to run `npm install`
-This is often related to the version of NodeJS your project is using. See [system requirements](/guides/system-requirements) for more information
+This is often related to the version of NodeJS your app is using. See [system requirements](/guides/system-requirements) for more information
 
 ### Installation taking a long time
-On Windows, the initial installation can take up to a few minutes. If it has been longer than 10 minutes and your project hasn't started, [reach out in the Slack community for help](https://slack.evidence.dev)
+On Windows, the initial installation can take up to a few minutes. If it has been longer than 10 minutes and your app hasn't started, [reach out in the Slack community for help](https://slack.evidence.dev)
 
 
 ## Data Sources
 
 ### Data is not available for querying
 Ensure that you've done the following:
-- Add `.sql` files to your `sources/my-source` directory to define which data to bring into your Evidence project (does not apply to the CSV connector, which does not require `.sql` files)
+- Add `.sql` files to your `sources/my-source` directory to define which data to bring into Evidence (does not apply to the CSV connector, which does not require `.sql` files)
 - Run `npm run sources` to load the data
 
-To check whether your data has been successfully loaded into your project, go to the `/explore/schema` page to see which data is in your app.
+To check whether your data has been successfully loaded into your app, go to the `/explore/schema` page to see which data is in your app.
 
 ### Failure in `npm run sources` 
 If you're having problems loading data with `npm run sources`, try using `npm run sources -- --debug` to display additional logs
@@ -60,7 +60,7 @@ To open your browser console:
 This is helpful information to provide when asking questions in slack or creating issues on Github.
 
 ## Deployment
-If you have issues when building or deploying your project, try running `npm run build` locally to see if the behaviour is the same as in your deployment environment.
+If you have issues when building or deploying your app, try running `npm run build` locally to see if the behaviour is the same as in your deployment environment.
 
 If the build works locally, but not in your deployment environment, check that the NodeJS version used in your deployment environment fits within the [system requirements](/guides/system-requirements).
 
@@ -68,6 +68,3 @@ If the build works locally, but not in your deployment environment, check that t
 # Known Issues
 
 See [our open Github issues](https://github.com/evidence-dev/evidence/issues) for a full list of known issues
-
-## Windows Cache Issue (TProtocolException Error)
-See [this Github Issue](https://github.com/evidence-dev/evidence/issues/1693) for description, status, and workarounds

--- a/sites/docs/pages/guides/updating-your-app.md
+++ b/sites/docs/pages/guides/updating-your-app.md
@@ -1,12 +1,12 @@
 ---
-title: Updating Your Project
+title: Updating Your App
 sidebar_position: 3
-description: Update your project using the CLI or the VS Code extension.
+description: Update your app using the CLI or the VS Code extension.
 ---
 
 When new versions of Evidence are released, we post release notes in [Slack](https://slack.evidence.dev). You can also take a look at our pull requests on GitHub to see which changes are being made.
 
-We recommend updating regularly to get the latest features and bug fixes. Evidence's is being actively developed, and major releases may introduce breaking changes. We therefore recommend testing updates by running your project in development mode.
+We recommend updating regularly to get the latest features and bug fixes. Evidence's is being actively developed, and major releases may introduce breaking changes. We therefore recommend testing updates by running your app in development mode.
 
 ## CLI
 

--- a/sites/docs/pages/guides/usql-migration-guide.md
+++ b/sites/docs/pages/guides/usql-migration-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Universal SQL Migration Guide
 sidebar_position: 3
-description: Migrate your < v24 Evidence project to Universal SQL (v24+)
+description: Migrate your < v24 Evidence app to Universal SQL (v24+)
 ---
 
 Universal SQL is Evidence's latest release, and fundamentally changes how Evidence queries data in order to bring support for three big new features:
@@ -9,11 +9,11 @@ Universal SQL is Evidence's latest release, and fundamentally changes how Eviden
 2. **Inputs and Filters:** Use input components to dynamically update your queries and charts based on user input. Filter data using parameterized queries rather than Javascript filter syntax
 3. **Adapter Plugins:** Create your own adapter to enable connecting to any data source
 
-This is a big release and contains several breaking changes. This guide will help you migrate your existing projects to USQL.
+This is a big release and contains several breaking changes. This guide will help you migrate your existing apps to USQL.
 
 The following sections explain what is changing in Evidence with Universal SQL. To jump straight to the migration steps, [click here](#migration-steps).
 
-## Do I need to migrate my project?
+## Do I need to migrate my app?
 - If your `@evidence-dev/evidence` package version is `&lt; v24` then it has not yet been migrated, and we encourage you to do so as soon as is practical
 - `v23` will continue to be supported for now (sunset date TBC) and will receive critical bugfixes during this period
 - If you're unsure what you need to do, or if you need help, [reach out to us on Slack](https://slack.evidence.dev) in the `#migration` channel
@@ -123,7 +123,7 @@ Issues and errors in the migration command can be related to npm or NodeJS versi
 8. Configure your data source in the Settings menu
     - In your browser, click the 3-dot menu at the top right of the page and click Settings
     - In the Data Sources section, click to add a new connection
-    - Select the data source type your project uses and provide the name you set when going through the VS Code prompts earlier (e.g., `needful_things` to continue the example from above)
+    - Select the data source type your app uses and provide the name you set when going through the VS Code prompts earlier (e.g., `needful_things` to continue the example from above)
     - Click to test your connection
     - Click to confirm the changes
 9. Navigate back to the home page in your browser and refresh the page
@@ -131,7 +131,7 @@ Issues and errors in the migration command can be related to npm or NodeJS versi
 
 
 ### Completing the Migration Steps Manually
-The easiest way to migrate your project is to create a project using the latest version of the template, and copy over your markdown pages and queries. These steps will guide you through doing that in the same project folder so that you can track the changes in version control.
+The easiest way to migrate your app is to create a app using the latest version of the template, and copy over your markdown pages and queries. These steps will guide you through doing that in the same project so that you can track the changes in version control.
 
 1. In your Evidence project directory, create a new folder called `_legacy_project`
 2. Copy all of the files from your existing project into the `_legacy_project` folder - this will serve as a backup, and you will need to reference these in the following steps to copy content back into your project
@@ -189,7 +189,7 @@ The easiest way to migrate your project is to create a project using the latest 
 11. Configure your data source in the Settings menu
     - Click the 3-dot menu at the top right of the page and click Settings
     - In the Data Sources section, click to add a new connection
-    - Select the data source type your project uses and provide a name for your data source. This will appear as a folder within the `sources` directory in your project (e.g., you could use `needful_things` if using the Evidence demo database)
+    - Select the data source type your app uses and provide a name for your data source. This will appear as a folder within the `sources` directory in your project (e.g., you could use `needful_things` if using the Evidence demo database)
     - Click to test your connection
     - Click to confirm the changes
 12. Navigate back to the home page in your browser and refresh the page
@@ -198,23 +198,23 @@ The easiest way to migrate your project is to create a project using the latest 
 ## Deployment Changes
 
 ### Evidence Cloud
-1. Copy environment variables for your project from your local dev environment (Settings page > Deployment)
+1. Copy environment variables for your app from your local dev environment (Settings page > Deployment)
     ![env vars](/img/settings-vars.png)
 
-2. Update the environment variables for your Evidence Cloud project by pasting the environment variables from Step 1
+2. Update the environment variables for your Evidence Cloud app by pasting the environment variables from Step 1
     ![cloud vars](/img/cloud-settings-edit.png)
 
-3. Click to redeploy your project
+3. Click to redeploy your app
 
 
 ### Self-Hosting
 You will need to update 2 things in your deployment setup to complete the migration to USQL:
 1. Update your environment variables
     - See links in the Resources section for Netlify and Vercel docs
-    - Find the new environment variables in your project's settings menu in your browser (click 3-dot menu at top right > Settings) - then scroll down to Deployment and select your deployment provider
+    - Find the new environment variables in your app's settings menu in your browser (click 3-dot menu at top right > Settings) - then scroll down to Deployment and select your deployment provider
     - Copy your variables and change them in the configuration for your deployment provider
 2. Update the build command
-    - USQL introduces the new `run sources` step to load data into your project from your data sources
+    - USQL introduces the new `run sources` step to load data into your app from your data sources
     - Replace the build command in your deployment provider to `npm run sources && npm run build:strict`
     - See Netlify and Vercel docs in the Resources section
 
@@ -268,7 +268,7 @@ This means that any query chains included in `sources` will need to be replaced 
 If you use the VS Code migration command, chained queries found on markdown pages are left on the page rather than being moved to the `sources` directory like other queries. This is because we assume that most chained queries are simple enough for the syntax of your source database to match with the DuckDB syntax they will need to move to. In some cases, the syntax will not line up and you will need to make an adjustment.
 
 ### Evidence Plugins
-If your project includes an Evidence plugin (e.g., [Evidence Labs](https://labs.evidence.dev)):
+If your app includes an Evidence plugin (e.g., [Evidence Labs](https://labs.evidence.dev)):
 1. Find the `evidence.plugins.yaml` file in your `_legacy_project` folder and copy the line(s) containing the plugin(s) you're using
 2. Paste those lines into the `evidence.plugins.yaml` file in your new project
 3. Install the plugin(s) in your project. E.g.,:

--- a/sites/docs/pages/index.md
+++ b/sites/docs/pages/index.md
@@ -11,7 +11,7 @@ og:
 
 Evidence is an open source framework for building data products with SQL - things like reports, decision-support tools, and embedded dashboards. It's a code-driven alternative to drag-and-drop BI tools.
 
-This docs site is an Evidence project.
+This docs site is an Evidence app.
 
 Install Evidence with the [VSCode Extension](vscode:extension/Evidence.evidence-vscode), or see other [installation options](/install-evidence).
 

--- a/sites/docs/pages/install-evidence.md
+++ b/sites/docs/pages/install-evidence.md
@@ -22,7 +22,7 @@ The easiest way to get started with Evidence is to use the [VSCode Extension](vs
 4. Make changes to a markdown file and **save the file** to see the updates in your browser window
 
 
-The template project running in your browser contains a tutorial on how to use Evidence.
+The template app running in your browser contains a tutorial on how to use Evidence.
 
 <LinkButton url="https://marketplace.visualstudio.com/items?itemName=Evidence.evidence-vscode">Install VSCode Extension</LinkButton>
 
@@ -86,4 +86,4 @@ See [system requirements page](/guides/system-requirements).
 
 ## Updating Evidence
 
-See [updating your project](/guides/updating-your-project).
+See [updating your app](/guides/updating-your-app).

--- a/sites/docs/pages/motivation.md
+++ b/sites/docs/pages/motivation.md
@@ -15,7 +15,7 @@ Evidence combines the best of modern web frameworks with the best parts of BI:
 - **Code-driven workflows:** Use your IDE, version control, and CI/CD tools
 - **First-class text support:** Add context, explanation and insight to your reports
 - **Programmatic features:** Use loops, conditionals, and templated pages to generate content from data
-- **High performance:** Evidence projects build into fast and reliable web application
+- **High performance:** Evidence apps are fast, reliable, and scalable
 - **Lightweight setup:** Install locally and start building reports in just a few minutes
 
 To get started, [install Evidence](/install-evidence).

--- a/sites/docs/pages/plugins/component-plugins.md
+++ b/sites/docs/pages/plugins/component-plugins.md
@@ -2,14 +2,14 @@
 sidebar_position: 1
 hide_table_of_contents: false
 title: Component Plugins
-description: Evidence includes a plugin system which can be used to add components and data sources to your project.
+description: Evidence includes a plugin system which can be used to add components and data sources to your app.
 ---
 
-Evidence includes a plugin system which can be used to add components and data sources to your project. 
+Evidence includes a plugin system which can be used to add components and data sources to your app. 
 
 All Evidence projects include the Evidence `core-components` plugin by default. `core-components` has everything you need to build most use cases. 
 
-Component plugins are Svelte component packages which include one or more additional components which you can use in your project. Once you have installed and registered a component plugin, the included components will be available to use in your markdown files. 
+Component plugins are Svelte component packages which include one or more additional components which you can use in your markdown. Once you have installed and registered a component plugin, the included components will be available to use in your markdown files. 
 
 To use a plugin, you need to **install** and **register** it in your project.
 
@@ -34,8 +34,7 @@ components:
 
 If a plugin provides a component that you want to reference with another name, you can set up `aliases` when registering the component. 
 
-In this example, the `@acme/charting` plugin provides some component `LongNameForAChart`. After setting up `aliases`, it will be 
-made available in the Evidence project as `AcmeChart`
+In this example, the `@acme/charting` plugin provides some component `LongNameForAChart`. After setting up `aliases`, it will be made available in the Evidence markdown as `AcmeChart`
 
 ```yaml
 components:

--- a/sites/docs/pages/plugins/create-component-plugin.md
+++ b/sites/docs/pages/plugins/create-component-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Create Component Plugin
-description: You can create a component plugin to publish your own custom components for use across multiple Evidence projects.
+description: You can create a component plugin to publish your own custom components for use across multiple Evidence apps.
 sidebar_position: 3
 ---
 
@@ -22,7 +22,7 @@ The easiest way to get started is from the example component library [**on GitHu
 
 ## Component Exporting
 
-Plugins must "export" their components to make them available to your Evidence project.
+Plugins must "export" their components to make them available to your Evidence apps.
 
 There are 2 ways to set up component exporting in your plugin:
 1. [Module Exports](#module-exports) (recommended)

--- a/sites/docs/pages/plugins/source-plugins.md
+++ b/sites/docs/pages/plugins/source-plugins.md
@@ -2,12 +2,12 @@
 sidebar_position: 2
 hide_table_of_contents: false
 title: Data Source Plugins
-description: Source plugins enable you to add new data source types to your project. 
+description: Source plugins enable you to add new data source types to your app. 
 ---
 
-Evidence includes a plugin system which can be used to add components and data sources to your project. 
+Evidence includes a plugin system which can be used to add components and data sources to your app. 
 
-Source plugins enable you to add new data source types to your project. Once you have installed and registered a source plugin, you will be able to configure any associated connection settings in the settings UI.  
+Source plugins enable you to add new data source types to your app. Once you have installed and registered a source plugin, you will be able to configure any associated connection settings in the settings UI.  
 
 To use a plugin, you need to **install** and **register** it in your project.
 

--- a/sites/docs/pages/reference/cli.md
+++ b/sites/docs/pages/reference/cli.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 title: CLI
 hide_title: true
-description: Commands to start, install, develop, and build Evidence projects from the command line.
+description: Commands to start, install, develop, and build Evidence apps from the command line.
 ---
 
 # CLI Reference
@@ -13,7 +13,7 @@ description: Commands to start, install, develop, and build Evidence projects fr
 select '<code>npx degit evidence-dev/template my-project</code>' as "CLI", '<code>Evidence: New Evidence Project</code>' as "VS Code", 'Create a new project from the template' as "Description", 0 as row_num UNION ALL
 select '<code>npm run sources</code>' as "CLI", '<code>Evidence: Run Sources</code>' as "VS Code", 'Extract data from sources' as "Description", 1 as row_num UNION ALL
 select '<code>npm run dev</code>' as "CLI", '<code>Evidence: Start Server</code>' as "VS Code", 'Start the development server in the current directory' as "Description", 2 as row_num UNION ALL
-select '<code>npm run build</code>' as "CLI", '<code>Evidence: Build</code>' as "VS Code", 'Build the project for production' as "Description", 3 as row_num UNION ALL
+select '<code>npm run build</code>' as "CLI", '<code>Evidence: Build</code>' as "VS Code", 'Build the app for production' as "Description", 3 as row_num UNION ALL
 select '<code>npm run build:strict</code>' as "CLI", '<code>Evidence: Built Strict</code>' as "VS Code", 'Build, but fails on query or component errors' as "Description", 4 as row_num UNION ALL
 select '<code>npm run preview</code>' as "CLI", 'N/A' as "VS Code", 'Preview the built site' as "Description", 5 as row_num UNION ALL
 select '<code>Ctrl / Cmd</code> + <code>C</code>' as "CLI", '<code>Evidence: Stop Server</code>' as "VS Code", 'Stop the dev server (when running)' as "Description", 6 as row_num UNION ALL

--- a/sites/docs/pages/reference/markdown.md
+++ b/sites/docs/pages/reference/markdown.md
@@ -240,4 +240,4 @@ This is some content in the partial.
 
 Evidence supports re-using chunks of Evidence markdown using Partials.
 
-Partials are placed in the `./partials` folder, and can be referenced in your project with `&#123;@partial "path/to/partial.md"&#125;` (do not include the `/partial` folder in the path).
+Partials are placed in the `./partials` folder, and can be referenced in your markdown with `&#123;@partial "path/to/partial.md"&#125;` (do not include the `/partial` folder in the path).

--- a/sites/docs/pages/reference/themes-and-layouts.md
+++ b/sites/docs/pages/reference/themes-and-layouts.md
@@ -2,10 +2,10 @@
 sidebar_position: 4
 hide_table_of_contents: false
 title: Themes and Layouts
-description: Evidence supports customizing the look and feel of your project using CSS, and by overwriting or modifying the default layout.
+description: Evidence supports customizing the look and feel of your app using CSS, and by overwriting or modifying the default layout.
 ---
 
-Evidence supports customizing the look and feel of your project using CSS, and by overwriting or modifying the default layout.
+Evidence supports customizing the look and feel of your app using CSS, and by overwriting or modifying the default layout.
 
 ## Custom Layout 
 
@@ -33,7 +33,7 @@ The `EvidenceDefaultLayout` component accepts the following properties for commo
     defaultValue=""
 >
 
-Project title that will replace the Evidence Logo.
+App title that will replace the Evidence Logo.
 
 </PropListing>
 <PropListing
@@ -42,7 +42,7 @@ Project title that will replace the Evidence Logo.
     defaultValue=""
 >
 
-Link to an image which will replace the Evidence logo. This will also override any project title in the header. If the image is in your project's static directory, the link should be relative to the static directory.
+Link to an image which will replace the Evidence logo. This will also override any app title in the header. If the image is in your project's static directory, the link should be relative to the static directory.
 
 </PropListing>
 <PropListing
@@ -51,7 +51,7 @@ Link to an image which will replace the Evidence logo. This will also override a
     defaultValue=false
 >
 
-Removes the option to show queries when the project is deployed. Has no effect in development.
+Removes the option to show queries when the app is deployed. Has no effect in development.
 
 </PropListing>
 <PropListing
@@ -60,7 +60,7 @@ Removes the option to show queries when the project is deployed. Has no effect i
     defaultValue=""
 >
 
-Sets the width of the project in pixels. The default layout is about 1,280 px wide.
+Sets the width of the app content in pixels. The default layout is about 1,280 px wide.
 
 </PropListing>
 <PropListing
@@ -69,7 +69,7 @@ Sets the width of the project in pixels. The default layout is about 1,280 px wi
     defaultValue=false
 >
 
-Sets the width of the project to full
+Sets the width of the app content to full
 
 </PropListing>
 <PropListing
@@ -190,13 +190,13 @@ This is the default text style, which is used when you write text in a markdown 
 
 ## Base Styles
 
-Include an `app.css` file in your project root directory to customize the base styles of your project.
+Include an `app.css` file in your project root directory to customize the base styles of your app.
 
 _The recommended approach is to copy and edit the default css file from `[my-project]/.evidence/template/src/app.css`, also found in the [Evidence Github repo](https://github.com/evidence-dev/evidence/blob/main/sites/example-project/src/app.css)._
 
 ### What can be customized with app.css?
 
-You can customize the default styles (font, size, color etc) of most HTML elements, by adjusting the default css for the project, e.g.
+You can customize the default styles (font, size, color etc) of most HTML elements, by adjusting the default css for the app, e.g.
 
 - Headers
 - Body text

--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,16 @@
 			"source": "/plugins/creating-a-plugin",
 			"destination": "/plugins/create-component-plugin/",
 			"permanent": true
+		},
+		{
+			"source": "/guides/updating-your-project/",
+			"destination": "/guides/updating-your-app/",
+			"permanent": true
+		},
+		{
+			"source": "/guides/updating-your-project",
+			"destination": "/guides/updating-your-app/",
+			"permanent": true
 		}
 	]
 }


### PR DESCRIPTION
### Description

We now refer to Evidence sites as apps, not projects. 
This updates the docs site for this change. 

There are places we also need to make this change:
- [x] Marketing site (httos://evidence.dev) https://github.com/evidence-dev/marketing-site/pull/267
- [ ] ~~VS Code extension (Commands)~~ https://github.com/evidence-dev/evidence/pull/2633
- [ ] ~~Template repo (package.json, instructions, readme)~~ https://github.com/evidence-dev/template/pull/173
- [ ] ~~Evidence Cloud UI~~

**Note: post agreement that projects refer to the "collection of code files on your computer", the PRs for the extension and template are not needed. The Cloud UI can be addressed separately.**

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
