### PR TITLE
Revert "Version Packages", fix changeset

### DIFF
--- a/.changeset/chatty-feet-raise.md
+++ b/.changeset/chatty-feet-raise.md
@@ -1,5 +1,5 @@
 ---
-'@evidence-dev/core-components': patch
+'@evidence-dev/evidence': patch
 '@evidence-dev/components': patch
 ---
 

--- a/.changeset/chatty-feet-raise.md
+++ b/.changeset/chatty-feet-raise.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/core-components': patch
+'@evidence-dev/components': patch
+---
+
+Disable windows cache service worker with VITE_EVIDENCE_DISABLE_WINDOWS_CACHE_SERVICE_WORKER

--- a/e2e/spa/CHANGELOG.md
+++ b/e2e/spa/CHANGELOG.md
@@ -1,13 +1,5 @@
 # e2e-spa
 
-## 0.0.11
-
-### Patch Changes
-
-- Updated dependencies [163ff7a33]
-  - @evidence-dev/core-components@4.8.7
-  - @evidence-dev/evidence@39.1.10
-
 ## 0.0.10
 
 ### Patch Changes

--- a/e2e/spa/package.json
+++ b/e2e/spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-spa",
-  "version": "0.0.11",
+  "version": "0.0.10",
   "scripts": {
     "build": "cross-env VITE_EVIDENCE_SPA=true evidence build",
     "build:strict": "cross-env VITE_EVIDENCE_SPA=true evidence build:strict",

--- a/e2e/themes/CHANGELOG.md
+++ b/e2e/themes/CHANGELOG.md
@@ -1,13 +1,5 @@
 # e2e-themes
 
-## 0.0.7
-
-### Patch Changes
-
-- Updated dependencies [163ff7a33]
-  - @evidence-dev/core-components@4.8.7
-  - @evidence-dev/evidence@39.1.10
-
 ## 0.0.6
 
 ### Patch Changes

--- a/e2e/themes/package.json
+++ b/e2e/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-themes",
-  "version": "0.0.7",
+  "version": "0.0.6",
   "scripts": {
     "build": "cross-env VITE_EVIDENCE_THEMES=true evidence build",
     "build:strict": "cross-env VITE_EVIDENCE_THEMES=true evidence build:strict",

--- a/packages/ui/core-components/CHANGELOG.md
+++ b/packages/ui/core-components/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evidence-dev/core-components
 
-## 4.8.7
-
-### Patch Changes
-
-- 163ff7a33: Disable windows cache service worker with VITE_EVIDENCE_DISABLE_WINDOWS_CACHE_SERVICE_WORKER
-
 ## 4.8.6
 
 ### Patch Changes

--- a/packages/ui/core-components/package.json
+++ b/packages/ui/core-components/package.json
@@ -24,7 +24,7 @@
 	"main": "./dist/index.js",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"version": "4.8.7",
+	"version": "4.8.6",
 	"evidence": {
 		"components": true
 	},

--- a/sites/docs/CHANGELOG.md
+++ b/sites/docs/CHANGELOG.md
@@ -1,13 +1,5 @@
 # evidence-docs
 
-## 0.0.35
-
-### Patch Changes
-
-- Updated dependencies [163ff7a33]
-  - @evidence-dev/core-components@4.8.7
-  - @evidence-dev/evidence@39.1.10
-
 ## 0.0.34
 
 ### Patch Changes

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "my-evidence-project",
-	"version": "0.0.35",
+	"version": "0.0.34",
 	"scripts": {
 		"build": "evidence build",
 		"build:strict": "evidence build:strict",

--- a/sites/example-project/CHANGELOG.md
+++ b/sites/example-project/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @evidence-dev/components
 
-## 3.5.30
-
-### Patch Changes
-
-- 163ff7a33: Disable windows cache service worker with VITE_EVIDENCE_DISABLE_WINDOWS_CACHE_SERVICE_WORKER
-- Updated dependencies [163ff7a33]
-  - @evidence-dev/core-components@4.8.7
-
 ## 3.5.29
 
 ### Patch Changes

--- a/sites/example-project/package.json
+++ b/sites/example-project/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evidence-dev/components",
-	"version": "3.5.30",
+	"version": "3.5.29",
 	"scripts": {
 		"dev": "cross-env EVIDENCE_PAGES_DIR=./src/pages EVIDENCE_DATA_DIR=./static/data EVIDENCE_DATA_URL_PREFIX=static/data vite dev --port 3000",
 		"build": "cross-env EVIDENCE_PAGES_DIR=./src/pages NODE_OPTIONS=--max-old-space-size=8192 vite build",

--- a/sites/test-env/CHANGELOG.md
+++ b/sites/test-env/CHANGELOG.md
@@ -1,13 +1,5 @@
 # evidence-test-environment
 
-## 3.0.63
-
-### Patch Changes
-
-- Updated dependencies [163ff7a33]
-  - @evidence-dev/core-components@4.8.7
-  - @evidence-dev/evidence@39.1.10
-
 ## 3.0.62
 
 ### Patch Changes

--- a/sites/test-env/package.json
+++ b/sites/test-env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "evidence-test-environment",
-	"version": "3.0.63",
+	"version": "3.0.62",
 	"private": true,
 	"scripts": {
 		"build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 evidence build",


### PR DESCRIPTION
Reverts evidence-dev/evidence#2640

`@evidence-dev/components` (`example-project`) was mistakenly included in a changeset instead of `@evidence-dev/evidence`. This PR fixes that.