### PR TITLE
Add parquet building logs + profiling to `evidence *` commands

### DIFF
--- a/.changeset/mean-crabs-rescue.md
+++ b/.changeset/mean-crabs-rescue.md
@@ -1,6 +1,6 @@
 ---
-'@evidence-dev/sdk': minor
-'@evidence-dev/universal-sql': minor
+'@evidence-dev/sdk': patch
+'@evidence-dev/universal-sql': patch
 ---
 
 add --profile flag to sdk-handled cli commands, add debugging profiling and logs to build-parquet

--- a/.changeset/mean-crabs-rescue.md
+++ b/.changeset/mean-crabs-rescue.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/sdk': minor
+'@evidence-dev/universal-sql': minor
+---
+
+add --profile flag to sdk-handled cli commands, add debugging profiling and logs to build-parquet

--- a/packages/lib/sdk/src/cli.root.js
+++ b/packages/lib/sdk/src/cli.root.js
@@ -6,6 +6,7 @@ import { enableDebug } from './lib/debug.js';
 import { datasourcesCli } from './plugins/datasources/cli/index.js';
 import { pluginsCli } from './plugins/cli/index.js';
 import { defineCommand } from '@brianmd/citty';
+import { writeFile } from 'node:fs/promises';
 
 // This is split into it's own file so that we can import it elsewhere without running the CLI twice
 
@@ -20,10 +21,15 @@ export const rootCli = defineCommand({
 			type: 'boolean',
 			default: false,
 			description: 'Enable additional debug logging'
+		},
+		profile: {
+			type: 'boolean',
+			default: false,
+			description: 'Enable profiling'
 		}
 	},
 
-	setup(ctx) {
+	async setup(ctx) {
 		process.on('uncaughtException', (e) => {
 			cmdFail(e);
 		});
@@ -40,9 +46,26 @@ export const rootCli = defineCommand({
 			// TODO: Check on this, it seems to leak debug once the dev server has started
 			/* Restore console.debug in a wrapped cleanup function */
 			const cleanup = this.cleanup;
-			this.cleanup = (_ctx) => {
-				cleanup?.(_ctx);
+			this.cleanup = async (_ctx) => {
+				await cleanup?.(_ctx);
 				console.debug = debug;
+			};
+		}
+
+		if (ctx.args.profile) {
+			const { Session } = await import('node:inspector/promises');
+			const session = new Session();
+			session.connect();
+			await session.post('Profiler.enable');
+			await session.post('Profiler.start');
+
+			const cleanup = this.cleanup;
+			this.cleanup = async (_ctx) => {
+				const { profile } = await session.post('Profiler.stop');
+				await writeFile(`${ctx.args._.join('-')}.cpuprofile`, JSON.stringify(profile));
+				await session.post('Profiler.disable');
+				session.disconnect();
+				await cleanup?.(_ctx);
 			};
 		}
 	},

--- a/packages/lib/sdk/src/cli.root.js
+++ b/packages/lib/sdk/src/cli.root.js
@@ -61,7 +61,7 @@ export const rootCli = defineCommand({
 
 			const cleanup = this.cleanup;
 			this.cleanup = async (_ctx) => {
-				const { resolve, dirname } = await import("node:path");
+				const { resolve, dirname } = await import('node:path');
 
 				const path = resolve(`./.evidence/template/profiles/${ctx.args._.join('-')}.cpuprofile`);
 				await mkdir(dirname(path), { recursive: true });

--- a/packages/lib/sdk/src/cli.root.js
+++ b/packages/lib/sdk/src/cli.root.js
@@ -6,7 +6,7 @@ import { enableDebug } from './lib/debug.js';
 import { datasourcesCli } from './plugins/datasources/cli/index.js';
 import { pluginsCli } from './plugins/cli/index.js';
 import { defineCommand } from '@brianmd/citty';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, mkdir } from 'node:fs/promises';
 
 // This is split into it's own file so that we can import it elsewhere without running the CLI twice
 
@@ -61,10 +61,16 @@ export const rootCli = defineCommand({
 
 			const cleanup = this.cleanup;
 			this.cleanup = async (_ctx) => {
+				const { resolve, dirname } = await import("node:path");
+
+				const path = resolve(`./.evidence/template/profiles/${ctx.args._.join('-')}.cpuprofile`);
+				await mkdir(dirname(path), { recursive: true });
 				const { profile } = await session.post('Profiler.stop');
-				await writeFile(`${ctx.args._.join('-')}.cpuprofile`, JSON.stringify(profile));
+				await writeFile(path, JSON.stringify(profile));
+
 				await session.post('Profiler.disable');
 				session.disconnect();
+
 				await cleanup?.(_ctx);
 			};
 		}

--- a/packages/lib/sdk/src/logger/EvidenceLogger.js
+++ b/packages/lib/sdk/src/logger/EvidenceLogger.js
@@ -126,6 +126,13 @@ export class EvidenceLogger {
 	 * @returns
 	 */
 	measure = (topic) => {
+		if (!isDebug()) {
+			return {
+				meta: () => {},
+				done: () => {}
+			};
+		}
+
 		// Start
 		const before = performance.now();
 		/** @type {Record<string, any>} */

--- a/packages/lib/universal-sql/package.json
+++ b/packages/lib/universal-sql/package.json
@@ -20,6 +20,7 @@
 		"cli-progress": "^3.12.0",
 		"lodash.chunk": "^4.2.0",
 		"parquet-wasm": "0.5.0",
+		"@evidence-dev/sdk": "workspace:*",
 		"web-worker": "^1.2.0"
 	},
 	"exports": {

--- a/packages/lib/universal-sql/src/build-parquet.js
+++ b/packages/lib/universal-sql/src/build-parquet.js
@@ -20,8 +20,8 @@ import { emptyDbFs, initDB, query } from './client-duckdb/node.js';
 import chunk from 'lodash.chunk';
 import { columnsToScore } from './calculateScore.js';
 import chalk from 'chalk';
-import { log } from "@evidence-dev/sdk/logger";
-import { isDebug } from "@evidence-dev/sdk/utils";
+import { log } from '@evidence-dev/sdk/logger';
+import { isDebug } from '@evidence-dev/sdk/utils';
 
 /**
  * @param {{name: string, evidenceType: string}} column
@@ -52,8 +52,8 @@ function convertArrayToVector(column, rawValues) {
 		default:
 			throw new Error(
 				'Unrecognized EvidenceType: ' +
-				column.evidenceType +
-				'\n This is likely an error in a datasource connector.'
+					column.evidenceType +
+					'\n This is likely an error in a datasource connector.'
 			);
 	}
 }
@@ -153,7 +153,7 @@ export async function buildMultipartParquet(
 
 	let meta, done;
 	if (isDebug()) {
-		log.debug("Reading rows from a generator object");
+		log.debug('Reading rows from a generator object');
 		({ meta, done } = log.measure('buildMultipartParquet'));
 		meta('batch number', batchNum);
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1205,6 +1205,9 @@ importers:
       '@duckdb/duckdb-wasm':
         specifier: 1.28.0
         version: 1.28.0
+      '@evidence-dev/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       apache-arrow:
         specifier: ^13.0.0
         version: 13.0.0
@@ -5350,6 +5353,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/cache@2.12.0(@parcel/core@2.12.0):
@@ -5363,6 +5367,8 @@ packages:
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
+    transitivePeerDependencies:
+      - '@swc/helpers'
     dev: true
 
   /@parcel/codeframe@2.12.0:
@@ -5379,6 +5385,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/config-default@2.12.0(@parcel/core@2.12.0)(postcss@8.4.47)(typescript@5.4.2):
@@ -5523,6 +5530,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/node-resolver-core@3.3.0(@parcel/core@2.12.0):
@@ -5553,6 +5561,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/optimizer-htmlnano@2.12.0(@parcel/core@2.12.0)(postcss@8.4.47)(typescript@5.4.2):
@@ -5566,6 +5575,7 @@ packages:
       svgo: 2.8.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
       - cssnano
       - postcss
       - purgecss
@@ -5588,6 +5598,8 @@ packages:
       '@parcel/rust': 2.12.0
       '@parcel/utils': 2.12.0
       '@parcel/workers': 2.12.0(@parcel/core@2.12.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
     dev: true
 
   /@parcel/optimizer-svgo@2.12.0(@parcel/core@2.12.0):
@@ -5600,6 +5612,7 @@ packages:
       svgo: 2.8.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/optimizer-swc@2.12.0(@parcel/core@2.12.0):
@@ -5649,6 +5662,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/packager-html@2.12.0(@parcel/core@2.12.0):
@@ -5662,6 +5676,7 @@ packages:
       posthtml: 0.16.6
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/packager-js@2.12.0(@parcel/core@2.12.0):
@@ -5678,6 +5693,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/packager-raw@2.12.0(@parcel/core@2.12.0):
@@ -5687,6 +5703,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/packager-svg@2.12.0(@parcel/core@2.12.0):
@@ -5699,6 +5716,7 @@ packages:
       posthtml: 0.16.6
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/packager-ts@2.12.0(@parcel/core@2.12.0):
@@ -5717,6 +5735,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/plugin@2.12.0(@parcel/core@2.12.0):
@@ -5758,6 +5777,7 @@ packages:
       '@parcel/utils': 2.12.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/reporter-tracer@2.12.0(@parcel/core@2.12.0):
@@ -5780,6 +5800,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/runtime-browser-hmr@2.12.0(@parcel/core@2.12.0):
@@ -5790,6 +5811,7 @@ packages:
       '@parcel/utils': 2.12.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/runtime-js@2.12.0(@parcel/core@2.12.0):
@@ -5802,6 +5824,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/runtime-react-refresh@2.12.0(@parcel/core@2.12.0):
@@ -5814,6 +5837,7 @@ packages:
       react-refresh: 0.9.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/runtime-service-worker@2.12.0(@parcel/core@2.12.0):
@@ -5825,6 +5849,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/rust@2.12.0:
@@ -5853,6 +5878,7 @@ packages:
       semver: 7.6.3
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-css@2.12.0(@parcel/core@2.12.0):
@@ -5868,6 +5894,7 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-html@2.12.0(@parcel/core@2.12.0):
@@ -5885,6 +5912,7 @@ packages:
       srcset: 4.0.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-image@2.12.0(@parcel/core@2.12.0):
@@ -5898,6 +5926,8 @@ packages:
       '@parcel/utils': 2.12.0
       '@parcel/workers': 2.12.0(@parcel/core@2.12.0)
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-inline-string@2.12.0(@parcel/core@2.12.0):
@@ -5937,6 +5967,7 @@ packages:
       json5: 2.2.3
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-postcss@2.12.0(@parcel/core@2.12.0):
@@ -5953,6 +5984,7 @@ packages:
       semver: 7.6.3
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-posthtml@2.12.0(@parcel/core@2.12.0):
@@ -5968,6 +6000,7 @@ packages:
       semver: 7.6.3
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-raw@2.12.0(@parcel/core@2.12.0):
@@ -5977,6 +6010,7 @@ packages:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-react-refresh-wrap@2.12.0(@parcel/core@2.12.0):
@@ -5988,6 +6022,7 @@ packages:
       react-refresh: 0.9.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-svg@2.12.0(@parcel/core@2.12.0):
@@ -6004,6 +6039,7 @@ packages:
       semver: 7.6.3
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
     dev: true
 
   /@parcel/transformer-typescript-types@2.12.0(@parcel/core@2.12.0)(typescript@5.4.2):
@@ -16033,6 +16069,9 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(postcss@8.4.47)(typescript@5.4.2)
       '@parcel/core': 2.12.0
@@ -17689,6 +17728,9 @@ packages:
   /sqlite3@5.1.6:
     resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       node-addon-api: 4.3.0


### PR DESCRIPTION
### Description

Adds logging to `build-parquet.js` (mainly to diagnose slow builds), also generically adds a `--profile` flag to all `evidence *` commands which profiles the duration of the command's execution

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
