### PR TITLE
Prevent accordion focus ring from displaying on click in chrome

### DIFF
--- a/packages/ui/core-components/src/lib/atoms/shadcn/accordion/accordion-trigger.svelte
+++ b/packages/ui/core-components/src/lib/atoms/shadcn/accordion/accordion-trigger.svelte
@@ -15,7 +15,7 @@
 <AccordionPrimitive.Header {level} class="flex">
 	<AccordionPrimitive.Trigger
 		class={cn(
-			'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180 focus:outline-none focus:ring ring-gray-100 rounded',
+			'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180 rounded focus-visible:ring-gray-200 focus-visible:outline-none focus-visible:ring-2',
 			className
 		)}
 		{...$$restProps}


### PR DESCRIPTION
### Description

Prevents the accordion focus ring from displaying in Chrome when you click an accordion.  