### PR TITLE
hide manifest warning toast in prod

### DIFF
--- a/.changeset/wild-cats-teach.md
+++ b/.changeset/wild-cats-teach.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Hide manifest toast in prod

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -38,7 +38,7 @@ const loadDB = async () => {
 					id: 'MissingManifest',
 					status: 'warning',
 					title: 'No Sources Found',
-					message: 'Without a manifest file, no data is available'
+					message: 'Configure and run sources to include data in your project.'
 				},
 				10000
 			);

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -32,15 +32,17 @@ const loadDB = async () => {
 
 	if (Object.keys(renderedFiles ?? {}).length === 0) {
 		console.warn(`Unable to load manifest, do you need to generate sources?`.trim());
-		toasts.add(
-			{
-				id: 'MissingManifest',
-				status: 'warning',
-				title: 'Missing Manifest',
-				message: 'Without a manifest file, no data is available'
-			},
-			10000
-		);
+		if (dev) {
+			toasts.add(
+				{
+					id: 'MissingManifest',
+					status: 'warning',
+					title: 'Missing Manifest',
+					message: 'Without a manifest file, no data is available'
+				},
+				10000
+			);
+		}
 	} else {
 		await profile(setParquetURLs, renderedFiles);
 		await profile(updateSearchPath, Object.keys(renderedFiles));

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -31,7 +31,7 @@ const loadDB = async () => {
 	await profile(initDB);
 
 	if (Object.keys(renderedFiles ?? {}).length === 0) {
-		console.warn(`Unable to load manifest, do you need to generate sources?`.trim());
+		console.warn(`No sources found, execute "npm run sources" to generate`.trim());
 		if (dev) {
 			toasts.add(
 				{

--- a/sites/example-project/src/pages/+layout.js
+++ b/sites/example-project/src/pages/+layout.js
@@ -37,7 +37,7 @@ const loadDB = async () => {
 				{
 					id: 'MissingManifest',
 					status: 'warning',
-					title: 'Missing Manifest',
+					title: 'No Sources Found',
 					message: 'Without a manifest file, no data is available'
 				},
 				10000


### PR DESCRIPTION
### Description

Hides this warning in prod

![CleanShot 2024-10-24 at 14 40 10@2x](https://github.com/user-attachments/assets/f1811758-32c0-4030-8d04-9e6dde2e6133)

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
