### PR TITLE
Fix transitions between chart states w/ updated data

### DIFF
--- a/.changeset/six-waves-drop.md
+++ b/.changeset/six-waves-drop.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix transition animation in charts

--- a/e2e/prerender/tests/tests.spec.js
+++ b/e2e/prerender/tests/tests.spec.js
@@ -105,13 +105,16 @@ test('charts should render once', async ({ page }) => {
 	const received = await page.evaluate(async () => {
 		await new Promise((resolve) => setTimeout(resolve, 3000));
 
-		return window[Symbol.for('chart renders')];
+		return window[Symbol.for('chart renders')];	
 	});
 
-	// 3 renders is what is expected (creation -> update -> (deletion) -> creation)
-	// double loading makes 4 renders, adding another delete/create in
-	// TODO: why is 3 renders expected
-	const expected = 7;
+	// 4 renders is what is expected (creation -> update x3)
+	// double loading makes 6 renders, adding another 2 updates in
+	// TODO: why are 3 updates expected
+	// - first is for initial render w/o chart props
+	// - second is for render w/ chart props
+	// - third is for ???, fourth is for ???
+	const expected = 10;
 
 	expect(received).toEqual(expected);
 });

--- a/e2e/prerender/tests/tests.spec.js
+++ b/e2e/prerender/tests/tests.spec.js
@@ -105,7 +105,7 @@ test('charts should render once', async ({ page }) => {
 	const received = await page.evaluate(async () => {
 		await new Promise((resolve) => setTimeout(resolve, 3000));
 
-		return window[Symbol.for('chart renders')];	
+		return window[Symbol.for('chart renders')];
 	});
 
 	// 4 renders is what is expected (creation -> update x3)

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -1053,28 +1053,24 @@
 
 {#if !error}
 	<slot />
-	{#if !$config.series.length}
-		<EmptyChart emptySet="pass" />
-	{:else}
-		<ECharts
-			config={$config}
-			{height}
-			{width}
-			{data}
-			{queryID}
-			evidenceChartTitle={title}
-			{showAllXAxisLabels}
-			{swapXY}
-			{echartsOptions}
-			{seriesOptions}
-			{printEchartsConfig}
-			{renderer}
-			{downloadableData}
-			{downloadableImage}
-			{connectGroup}
-			{seriesColors}
-		/>
-	{/if}
+	<ECharts
+		config={$config}
+		{height}
+		{width}
+		{data}
+		{queryID}
+		evidenceChartTitle={title}
+		{showAllXAxisLabels}
+		{swapXY}
+		{echartsOptions}
+		{seriesOptions}
+		{printEchartsConfig}
+		{renderer}
+		{downloadableData}
+		{downloadableImage}
+		{connectGroup}
+		{seriesColors}
+	/>
 {:else}
 	<ErrorChart {error} {chartType} />
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -26,7 +26,6 @@
 	import ErrorChart from './ErrorChart.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import { chartColours, uiColours } from '@evidence-dev/component-utilities/colours';
-	import EmptyChart from './EmptyChart.svelte';
 
 	// ---------------------------------------------------------------------------------------
 	// Input Props


### PR DESCRIPTION
### Description

Broken:
![Broken](https://github.com/user-attachments/assets/33c4c328-3f08-4e86-84c0-8179c162d604)

Fixed:
![Fixed](https://github.com/user-attachments/assets/83d9922f-0a67-4e46-8b07-6a52eb500d1a)

Note: removes safeguard Brian put for [showing the empty chart error state when all rows in a series are null](https://github.com/evidence-dev/evidence/pull/2026) - I would think this PR takes higher priority, but would be nice to recover that error indication

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)