### PR TITLE
Add connectionTimeout option to MSSQL connector

### DIFF
--- a/.changeset/wet-rats-flash.md
+++ b/.changeset/wet-rats-flash.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/mssql': patch
+---
+
+Add connectionTimeout option to mssql connector

--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -88,12 +88,14 @@ const runQuery = async (queryString, database = {}, batchSize = 100000) => {
 	try {
 		const trust_server_certificate = database.trust_server_certificate ?? 'false';
 		const encrypt = database.encrypt ?? 'true';
+		const connection_timeout = database.connection_timeout ?? 15000;
 		const credentials = {
 			user: database.user,
 			server: database.server,
 			database: database.database,
 			password: database.password,
 			port: parseInt(database.port ?? 1433),
+			connectionTimeout: parseInt(connection_timeout ?? 15000),
 			options: {
 				trustServerCertificate:
 					trust_server_certificate === 'true' || trust_server_certificate === true,
@@ -144,6 +146,7 @@ module.exports = runQuery;
  * @property {`${number}`} port
  * @property {`${boolean}`} trust_server_certificate
  * @property {`${boolean}`} encrypt
+ * @property {`${number}`} connection_timeout
  */
 
 /** @type {import('@evidence-dev/db-commons').GetRunner<MsSQLOptions>} */
@@ -207,5 +210,12 @@ module.exports.options = {
 		type: 'boolean',
 		default: false,
 		description: 'Should be true when using azure'
+	},
+	connection_timeout: {
+		title: 'Connection Timeout',
+		secret: false,
+		type: 'number',
+		required: false,
+		description: 'Connection timeout in ms'
 	}
 };

--- a/sites/docs/pages/core-concepts/data-sources/index.md
+++ b/sites/docs/pages/core-concepts/data-sources/index.md
@@ -305,7 +305,7 @@ The `encrypt` option indicates whether SQL Server uses SSL encryption for all da
 
 #### Connection Timeout
 
-The `connectionTimeout` option indicates the time, in milliseconds, that a query can run before it is terminated. It defaults to 15000 ms.
+The `connection_timeout` option indicates the time, in milliseconds, that a query can run before it is terminated. It defaults to 15000 ms.
 
 ### MySQL
 

--- a/sites/docs/pages/core-concepts/data-sources/index.md
+++ b/sites/docs/pages/core-concepts/data-sources/index.md
@@ -303,6 +303,10 @@ The `trustServerCertificate` option indicates whether the channel will be encryp
 
 The `encrypt` option indicates whether SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed. Necessary for Azure databases.
 
+#### Connection Timeout
+
+The `connectionTimeout` option indicates the time, in milliseconds, that a query can run before it is terminated. It defaults to 15000 ms.
+
 ### MySQL
 
 #### SSL


### PR DESCRIPTION
### Description

This pull request adds the connectionTimeout option to the MSSQL connector.

[connectionTimeout](https://tediousjs.github.io/node-mssql/#general-same-for-all-drivers) allows for the extension of the time that a query can run. The current value is left undefined, which leads to the connector defaulting to 15000 ms. This could cause some connections to be terminated if they take longer than 15 seconds to run.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
