### PR TITLE
Reduce last x days selectors by 1 in DateRange component

### DIFF
--- a/.changeset/old-carpets-poke.md
+++ b/.changeset/old-carpets-poke.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Modified Last x Days selectors in the DateRange component so they select x days instead of x + 1 days

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
@@ -46,7 +46,7 @@
 			label: 'Last 7 Days',
 			group: 'Days',
 			range: {
-				start: calendarEnd.subtract({ days: 7 }),
+				start: calendarEnd.subtract({ days: 6 }),
 				end: calendarEnd
 			}
 		},
@@ -54,7 +54,7 @@
 			label: 'Last 30 Days',
 			group: 'Days',
 			range: {
-				start: calendarEnd.subtract({ days: 30 }),
+				start: calendarEnd.subtract({ days: 29 }),
 				end: calendarEnd
 			}
 		},
@@ -62,7 +62,7 @@
 			label: 'Last 90 Days',
 			group: 'Days',
 			range: {
-				start: calendarEnd.subtract({ days: 90 }),
+				start: calendarEnd.subtract({ days: 89 }),
 				end: calendarEnd
 			}
 		},


### PR DESCRIPTION
### Description

This reduces the start date calculation for the 'Last 7 Days', 'Last 30 Days', and 'Last 90 Days' DateRange presets by 1 (for example, 'Last 7 Days' now subtracts 6 days to get the end date instead of 7 days). Previously, selecting one of these presets would select 8 days, 31 days, and 91 days. For example, this is 'Last 7 Days':

Before:
![CleanShot 2024-10-28 at 19 48 00@2x](https://github.com/user-attachments/assets/9d593ae5-32ea-443e-9f18-017dd13847fc)

After:
![CleanShot 2024-10-28 at 19 41 33@2x](https://github.com/user-attachments/assets/6b053ee5-5494-476d-9d50-e573410d4aef)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] ~~I have added to the docs where applicable~~
- [ ] ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~


