### PR TITLE
support html in prop listing descriptions, adjust breakpoints

### DIFF
--- a/sites/docs/components/PropListing.svelte
+++ b/sites/docs/components/PropListing.svelte
@@ -68,7 +68,7 @@
 </script>
 
 <section
-	class="pt-4 pb-2 border-b text-sm flex flex-col lg:flex-row gap-4 scroll-mt-[3.5rem] transition-colors duration-300 {$hashLocation ===
+	class="pt-4 pb-2 border-b text-sm flex flex-col xl:flex-row gap-4 scroll-mt-[3.5rem] transition-colors duration-300 {$hashLocation ===
 	`#props-${idName}`
 		? 'bg-blue-50 border-blue-400 border-t'
 		: ''}"
@@ -88,8 +88,8 @@
 			<span class="text-red-500 uppercase tracking-wide">Required</span>
 		{/if}
 	</div>
-	<div class="ml-3.5 lg:ml-0">
-		<div id="markdown-slot"><slot>{description}</slot></div>
+	<div class="ml-3.5 xl:ml-0">
+		<div id="markdown-slot"><slot>{@html description}</slot></div>
 		{#if Array.isArray(options) && options.length > 0}
 			<div class="mt-1 select-none flex">
 				<span class="text-sm text-gray-400 mr-2">Options:</span>

--- a/sites/docs/components/PropListing.svelte
+++ b/sites/docs/components/PropListing.svelte
@@ -74,7 +74,7 @@
 		: ''}"
 	id="props-{idName}"
 >
-	<div class="min-w-48 flex justify-between mr-4 ml-3.5">
+	<div class="min-w-48 flex justify-between mr-4">
 		<div class="font-mono">
 			<a href="#props-{idName}">
 				<span
@@ -88,7 +88,7 @@
 			<span class="text-red-500 uppercase tracking-wide">Required</span>
 		{/if}
 	</div>
-	<div class="ml-3.5 xl:ml-0">
+	<div>
 		<div id="markdown-slot"><slot>{@html description}</slot></div>
 		{#if Array.isArray(options) && options.length > 0}
 			<div class="mt-1 select-none flex">


### PR DESCRIPTION
* Fixes ~50 cases where bare html is being printed when using the props listing `description` prop instead of a slot. 
* Adjusts the breakpoints on prop listing to get into the stacked mode a little earlier 
* Drops the left margin on the stacked prop listing 

Before 
![CleanShot 2024-10-30 at 14 47 05@2x](https://github.com/user-attachments/assets/8dfdcf4a-c7b1-4d81-8eb2-5c66b1bd1308)

After 
![CleanShot 2024-10-30 at 14 56 25@2x](https://github.com/user-attachments/assets/3935b5bf-9089-4364-b340-e72135afcfa0)

