### PR TITLE
Support digits 2-9 in env var names names

### DIFF
--- a/.changeset/dirty-taxis-warn.md
+++ b/.changeset/dirty-taxis-warn.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/sdk': patch
+---
+
+Support digits 2-9 in source names

--- a/packages/lib/sdk/src/plugins/datasources/loadSourceConfig.js
+++ b/packages/lib/sdk/src/plugins/datasources/loadSourceConfig.js
@@ -36,7 +36,7 @@ export const loadConnectionOptions = async (sourceDir) => {
 export const loadConnectionEnvironment = async (sourceName) => {
 	/** @type {any} */
 	const out = {};
-	const keyRegex = /^EVIDENCE_SOURCE__([a-zA-Z0-1_]+)$/;
+	const keyRegex = /^EVIDENCE_SOURCE__([a-zA-Z0-9_]+)$/;
 	for (const [key, value] of Object.entries(process.env)) {
 		const parts = keyRegex.exec(key);
 		if (!parts) continue;


### PR DESCRIPTION
### Description

The regex that loads the environment variables for the production environment only includes digits 0 and 1. 

This pull request updates the regex to include digits up to 9.

### Checklist

- [X] For UI or styling changes, I have added a screenshot or gif showing before & after
- [X] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [X] I have added to the docs where applicable
- [X] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
