### PR TITLE
Add requestTimeout to mssql connector

### DIFF
--- a/.changeset/chilled-kiwis-chew.md
+++ b/.changeset/chilled-kiwis-chew.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/mssql': patch
+---
+
+Add requestTimeout to mssql connector

--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -96,7 +96,7 @@ const buildConfig = function (database) {
 		password: database.password,
 		port: parseInt(database.port ?? 1433),
 		connectionTimeout: parseInt(connection_timeout),
-		reqyestTimeout: parseInt(request_timeout),
+		requestTimeout: parseInt(request_timeout),
 		options: {
 			trustServerCertificate:
 				trust_server_certificate === 'true' || trust_server_certificate === true,

--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -87,6 +87,7 @@ const buildConfig = function (database) {
 	const trust_server_certificate = database.trust_server_certificate ?? 'false';
 	const encrypt = database.encrypt ?? 'true';
 	const connection_timeout = database.connection_timeout ?? 15000;
+	const request_timeout = database.request_timeout ?? 15000;
 
 	const credentials = {
 		user: database.user,
@@ -95,6 +96,7 @@ const buildConfig = function (database) {
 		password: database.password,
 		port: parseInt(database.port ?? 1433),
 		connectionTimeout: parseInt(connection_timeout),
+		reqyestTimeout: parseInt(request_timeout),
 		options: {
 			trustServerCertificate:
 				trust_server_certificate === 'true' || trust_server_certificate === true,
@@ -345,5 +347,12 @@ module.exports.options = {
 		type: 'number',
 		required: false,
 		description: 'Connection timeout in ms'
+	},
+	request_timeout: {
+		title: 'Request Timeout',
+		secret: false,
+		type: 'number',
+		required: false,
+		description: 'Request timeout in ms'
 	}
 };

--- a/sites/docs/pages/core-concepts/data-sources/index.md
+++ b/sites/docs/pages/core-concepts/data-sources/index.md
@@ -305,7 +305,11 @@ The `encrypt` option indicates whether SQL Server uses SSL encryption for all da
 
 #### Connection Timeout
 
-The `connection_timeout` option indicates the time, in milliseconds, that a query can run before it is terminated. It defaults to 15000 ms.
+The `connection_timeout` option indicates the connection timeout limit, in milliseconds. It defaults to 15000 ms.
+
+#### Request Timeout
+
+The `request_timeout` option indicates the time, in milliseconds, that a query can run before it is terminated. It defaults to 15000 ms.
 
 ### MySQL
 


### PR DESCRIPTION
### Description

This PR adds the `requestTimeout` option to the MSSQL connector.

This request is the same as #2699, which I accidentally closed with a force push.

### Checklist

- [X] For UI or styling changes, I have added a screenshot or gif showing before & after
- [X] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [X] I have added to the docs where applicable
- [X] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
