### PR TITLE
Fix `DateRange` flicker, `Slider` default value

### DIFF
--- a/.changeset/chilled-lobsters-sing.md
+++ b/.changeset/chilled-lobsters-sing.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix daterange flickering, slider default

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
@@ -48,6 +48,7 @@
 			exec,
 			{
 				initialData: $page?.data?.data[`DateRange-${name}_data`],
+				knownColumns: $page?.data?.data[`DateRange-${name}_columns`],
 				disableCache: true,
 				noResolve: false,
 				id: `DateRange-${name}`

--- a/packages/ui/core-components/src/lib/atoms/inputs/slider/Slider.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/slider/Slider.svelte
@@ -64,7 +64,7 @@
 	$: hideDuringPrint = hideDuringPrint === 'true' || hideDuringPrint === true;
 
 	/** @type {number} */
-	export let defaultValue = 0;
+	export let defaultValue = min;
 
 	/** @type {[number]} */
 	let value = [defaultValue];


### PR DESCRIPTION
### Description

`DateRange` wasn't properly receiving its prerendered columns, so it threw away its SSR'd data
`Slider` was flickering from 0 to its true minimum when there's no specified default value, now goes straight to min

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
