### PR TITLE
Fix map loading screen layout shift

### DIFF
--- a/.changeset/cyan-sloths-train.md
+++ b/.changeset/cyan-sloths-train.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fix map loading state layout shift

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
@@ -4,12 +4,8 @@
 
 <script>
 	import Areas from './components/Areas.svelte';
-	import BaseMap from './BaseMap.svelte';
-	import ErrorChart from '../core/ErrorChart.svelte';
-	import EmptyChart from '../core/EmptyChart.svelte';
-	import { QueryLoad } from '../../../atoms/query-load';
+	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
-	import Skeleton from '../../../atoms/skeletons/Skeleton.svelte';
 
 	/** @type {'pass' | 'warn' | 'error' | undefined} */
 	export let emptySet = undefined;
@@ -72,29 +68,21 @@
 	$: isInitial = data?.hash === initialHash;
 </script>
 
-{#if title}
-	<h4 class="markdown mb-2">{title}</h4>
-{/if}
-
-<QueryLoad {data} let:loaded>
-	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
-	<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
-
-	<!-- Override default skeleton to match height of map -->
-	<div slot="skeleton" class="w-full" style="height: {height}px">
-		<Skeleton />
-	</div>
-
-	<BaseMap {startingLat} {startingLong} {startingZoom} {height} {basemap} {title} {legendPosition}>
-		<Areas
-			data={loaded}
-			{geoJsonUrl}
-			{geoId}
-			{areaCol}
-			{legendType}
-			{chartType}
-			{legend}
-			{...$$restProps}
-		/>
-	</BaseMap>
-</QueryLoad>
+<BaseMap
+	let:data
+	{data}
+	{startingLat}
+	{startingLong}
+	{startingZoom}
+	{height}
+	{basemap}
+	{title}
+	{legendPosition}
+	{isInitial}
+	{chartType}
+	{emptySet}
+	{emptyMessage}
+	{error}
+>
+	<Areas {data} {geoJsonUrl} {geoId} {areaCol} {legendType} {chartType} {legend} {...$$restProps} />
+</BaseMap>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
@@ -51,7 +51,7 @@
 	export let startingZoom = undefined;
 
 	/** @type {number} */
-	export let height = undefined; // height in pixels
+	export let height = 300; // height in pixels
 
 	/** @type {string} */
 	export let basemap = undefined;
@@ -71,6 +71,10 @@
 	const initialHash = Query.isQuery(data) ? data.hash : undefined;
 	$: isInitial = data?.hash === initialHash;
 </script>
+
+{#if title}
+	<h4 class="markdown mb-2">{title}</h4>
+{/if}
 
 <QueryLoad {data} let:loaded>
 	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -5,9 +5,7 @@
 		component: BaseMap,
 		parameters: {
 			chromatic: {
-				diffThreshold: 0.2,
-				// Disabled until https://github.com/evidence-dev/evidence/issues/2560 is resolved
-				disableSnapshot: true
+				diffThreshold: 0.2
 			}
 		}
 	};

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -35,6 +35,9 @@
 	export let basemap = undefined;
 
 	/** @type {string|undefined} */
+	export let title = undefined;
+
+	/** @type {string|undefined} */
 	let error = undefined;
 
 	const evidenceMap = new EvidenceMap();
@@ -78,6 +81,9 @@
 	<ErrorChart {error} chartType="Map" />
 {:else}
 	<div class="relative break-inside-avoid">
+		{#if title}
+			<h4 class="markdown mb-2">{title}</h4>
+		{/if}
 		<div
 			class="z-0 rounded-md focus:outline-none"
 			style="height: {height}px;"

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -35,9 +35,6 @@
 	export let basemap = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
 
 	/** @type {string|undefined} */
-	export let title = undefined;
-
-	/** @type {string|undefined} */
 	let error = undefined;
 
 	const evidenceMap = new EvidenceMap();
@@ -75,9 +72,6 @@
 	<ErrorChart {error} chartType="Map" />
 {:else}
 	<div class="relative break-inside-avoid">
-		{#if title}
-			<h4 class="markdown mb-2">{title}</h4>
-		{/if}
 		<div
 			class="z-0 rounded-md focus:outline-none"
 			style="height: {height}px;"

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -32,7 +32,7 @@
 	export let height = 300; // height in pixels
 
 	/** @type {string} */
-	export let basemap = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+	export let basemap = undefined;
 
 	/** @type {string|undefined} */
 	let error = undefined;
@@ -58,7 +58,13 @@
 				const initCoords =
 					(startingLat ?? false) ? [startingLat, startingLong] : [defaultLat, defaultLong];
 
-				await evidenceMap.init(mapElement, basemap, initCoords, startingZoom, userDefinedView);
+				await evidenceMap.init(
+					mapElement,
+					basemap ?? 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+					initCoords,
+					startingZoom,
+					userDefinedView
+				);
 				return () => evidenceMap.cleanup();
 			} catch (e) {
 				error = e.message;

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
@@ -50,7 +50,7 @@
 	export let startingZoom = undefined;
 
 	/** @type {number} */
-	export let height = undefined; // height in pixels
+	export let height = 300; // height in pixels
 
 	/** @type {string} */
 	export let basemap = undefined;
@@ -72,6 +72,10 @@
 	const initialHash = Query.isQuery(data) ? data.hash : undefined;
 	$: isInitial = data?.hash === initialHash;
 </script>
+
+{#if title}
+	<h4 class="markdown mb-2">{title}</h4>
+{/if}
 
 <QueryLoad {data} let:loaded>
 	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
@@ -4,10 +4,7 @@
 
 <script>
 	import Bubbles from './components/Bubbles.svelte';
-	import BaseMap from './BaseMap.svelte';
-	import ErrorChart from '../core/ErrorChart.svelte';
-	import EmptyChart from '../core/EmptyChart.svelte';
-	import { QueryLoad } from '../../../atoms/query-load';
+	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
 
 	/** @type {'pass' | 'warn' | 'error' | undefined} */
@@ -73,24 +70,21 @@
 	$: isInitial = data?.hash === initialHash;
 </script>
 
-{#if title}
-	<h4 class="markdown mb-2">{title}</h4>
-{/if}
-
-<QueryLoad {data} let:loaded>
-	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
-	<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
-
-	<BaseMap {startingLat} {startingLong} {startingZoom} {height} {basemap} {title} {legendPosition}>
-		<Bubbles
-			data={loaded}
-			{lat}
-			{long}
-			{size}
-			{colorPalette}
-			{legendType}
-			{legend}
-			{...$$restProps}
-		/>
-	</BaseMap>
-</QueryLoad>
+<BaseMap
+	let:data
+	{data}
+	{startingLat}
+	{startingLong}
+	{startingZoom}
+	{height}
+	{basemap}
+	{title}
+	{legendPosition}
+	{isInitial}
+	{chartType}
+	{emptySet}
+	{emptyMessage}
+	{error}
+>
+	<Bubbles {data} {lat} {long} {size} {colorPalette} {legendType} {legend} {...$$restProps} />
+</BaseMap>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
@@ -44,7 +44,7 @@
 	export let startingZoom = undefined;
 
 	/** @type {number} */
-	export let height = undefined; // height in pixels
+	export let height = 300; // height in pixels
 
 	/** @type {string} */
 	export let basemap = undefined;
@@ -68,6 +68,10 @@
 	const initialHash = Query.isQuery(data) ? data.hash : undefined;
 	$: isInitial = data?.hash === initialHash;
 </script>
+
+{#if title}
+	<h4 class="markdown mb-2">{title}</h4>
+{/if}
 
 <QueryLoad {data} let:loaded>
 	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
@@ -4,10 +4,7 @@
 
 <script>
 	import Points from './components/Points.svelte';
-	import BaseMap from './BaseMap.svelte';
-	import ErrorChart from '../core/ErrorChart.svelte';
-	import EmptyChart from '../core/EmptyChart.svelte';
-	import { QueryLoad } from '../../../atoms/query-load';
+	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
 
 	/** @type {'pass' | 'warn' | 'error' | undefined} */
@@ -69,34 +66,21 @@
 	$: isInitial = data?.hash === initialHash;
 </script>
 
-{#if title}
-	<h4 class="markdown mb-2">{title}</h4>
-{/if}
-
-<QueryLoad {data} let:loaded>
-	<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
-	<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
-
-	<div class="relative">
-		<BaseMap
-			{startingLat}
-			{startingLong}
-			{startingZoom}
-			{height}
-			{basemap}
-			{title}
-			{legendPosition}
-		>
-			<Points
-				data={loaded}
-				{lat}
-				{long}
-				{colorPalette}
-				{legendType}
-				{chartType}
-				{...$$restProps}
-				{legend}
-			/>
-		</BaseMap>
-	</div>
-</QueryLoad>
+<BaseMap
+	let:data
+	{data}
+	{startingLat}
+	{startingLong}
+	{startingZoom}
+	{height}
+	{basemap}
+	{title}
+	{legendPosition}
+	{isInitial}
+	{chartType}
+	{emptySet}
+	{emptyMessage}
+	{error}
+>
+	<Points {data} {lat} {long} {colorPalette} {legendType} {chartType} {...$$restProps} {legend} />
+</BaseMap>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
@@ -1,0 +1,41 @@
+<script>
+	import QueryLoad from '../../../atoms/query-load/QueryLoad.svelte';
+	import ErrorChart from '../core/ErrorChart.svelte';
+	import EmptyChart from '../core/EmptyChart.svelte';
+	import BaseMap from './BaseMap.svelte';
+
+	/** @type {import("@evidence-dev/sdk/usql").QueryValue} */
+	export let data;
+
+	/** @type {string|undefined} */
+	export let title = undefined;
+
+	/** @type {'pass' | 'warn' | 'error' | undefined} */
+	export let emptySet = undefined;
+
+	/** @type {string | undefined} */
+	export let emptyMessage = undefined;
+
+	/** @type {string} */
+	export let chartType = undefined;
+
+	/** @type {boolean} */
+	export let isInitial = true;
+
+	export let error = undefined;
+</script>
+
+<div style="margin-top: 15px; margin-bottom: 10px;">
+	{#if title}
+		<h4 class="markdown mb-2">{title}</h4>
+	{/if}
+
+	<QueryLoad {data} let:loaded>
+		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
+		<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
+
+		<BaseMap {...$$restProps}>
+			<slot data={loaded} />
+		</BaseMap>
+	</QueryLoad>
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
@@ -34,7 +34,7 @@
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
 		<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
 
-		<BaseMap {...$$restProps} title={undefined} >
+		<BaseMap {...$$restProps} title={undefined}>
 			<slot data={loaded} />
 		</BaseMap>
 	</QueryLoad>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
@@ -34,7 +34,7 @@
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
 		<ErrorChart let:loaded slot="error" {chartType} error={error ?? loaded.error.message} />
 
-		<BaseMap {...$$restProps}>
+		<BaseMap {...$$restProps} title={undefined} >
 			<slot data={loaded} />
 		</BaseMap>
 	</QueryLoad>


### PR DESCRIPTION
### Description

#### Before
![before-map](https://github.com/user-attachments/assets/d9297c12-d803-40f9-bc59-a1e71f669bf4)


#### After
![after-map](https://github.com/user-attachments/assets/2e11e4a6-b494-4ac0-b533-8a7e47d13b44)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)