### PR TITLE
Allow changing the name of the homepage in the sidebar

### DIFF
--- a/.changeset/rude-ducks-type.md
+++ b/.changeset/rude-ducks-type.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Allows customization of the name of the Home page in the sidebar

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -44,7 +44,8 @@
 	export let slackCommunity = undefined;
 	/** @type {string}*/
 	export let maxWidth = undefined;
-
+	/** @type {string}*/
+	export let homePageName = "Home";
 	/** @type {boolean} */
 	export let hideBreadcrumbs = false;
 	/** @type {boolean} */
@@ -144,6 +145,7 @@
 						bind:mobileSidebarOpen
 						{title}
 						{logo}
+						{homePageName}
 						{builtWithEvidence}
 						{hideHeader}
 						{sidebarFrontMatter}

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -45,7 +45,7 @@
 	/** @type {string}*/
 	export let maxWidth = undefined;
 	/** @type {string}*/
-	export let homePageName = "Home";
+	export let homePageName = 'Home';
 	/** @type {boolean} */
 	export let hideBreadcrumbs = false;
 	/** @type {boolean} */

--- a/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
@@ -10,6 +10,7 @@
 	export let fileTree = undefined;
 	export let title = undefined;
 	export let logo = undefined;
+	export let homePageName = undefined;
 	export let builtWithEvidence = undefined;
 	export let hideHeader = false;
 	export let sidebarFrontMatter = undefined;
@@ -122,7 +123,7 @@
 						class="sticky top-0 bg-white shadow shadow-white text-gray-950 font-semibold pb-1 mb-1 group inline-block capitalize transition-colors duration-100"
 						href="/"
 					>
-						Home
+						{homePageName}
 					</a>
 					{#each firstLevelFiles as file}
 						{#if file.children.length === 0 && file.href && (file.frontMatter?.sidebar_link !== false || file.frontMatter?.sidebar_link === undefined)}
@@ -212,7 +213,7 @@
 					class="sticky top-0 bg-white shadow shadow-white text-gray-950 font-semibold pb-1 mb-1 group inline-block capitalize hover:underline"
 					href="/"
 				>
-					Home
+					{homePageName}
 				</a>
 				{#each firstLevelFiles as file}
 					{#if file.children.length === 0 && file.href && (file.frontMatter?.sidebar_link !== false || file.frontMatter?.sidebar_link === undefined)}

--- a/sites/docs/pages/reference/themes-and-layouts/index.md
+++ b/sites/docs/pages/reference/themes-and-layouts/index.md
@@ -46,6 +46,15 @@ Link to an image which will replace the Evidence logo. This will also override a
 
 </PropListing>
 <PropListing
+    name="homePageName"
+    options="Any string"
+    defaultValue=Home
+>
+
+Name of the home page in the sidebar.
+
+</PropListing>
+<PropListing
     name="neverShowQueries"
     options={['true', 'false']}
     defaultValue=false


### PR DESCRIPTION
### Description

See https://evidencedev.slack.com/archives/C0239KTKHH7/p1730837677172329

### After

![CleanShot 2024-11-05 at 16 01 30@2x](https://github.com/user-attachments/assets/54e560e3-cb08-4e25-b512-852172ab352a)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
