### PR TITLE
fix: add sdk/utils/evelte to Vite optimizeDeps.include

### DIFF
--- a/.changeset/lemon-pugs-divide.md
+++ b/.changeset/lemon-pugs-divide.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Add @evidence-dev/sdk/utils/svelte to Vite optimizeDeps.include

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -87,6 +87,7 @@ fsExtra.outputFileSync(
 					'@evidence-dev/component-utilities/buildQuery',
 					'@evidence-dev/component-utilities/profile',
 					'@evidence-dev/sdk/usql',
+					'@evidence-dev/sdk/utils/svelte',
 					'debounce', 
 					'@duckdb/duckdb-wasm',
 					'apache-arrow'


### PR DESCRIPTION
This was causing the input store to not update on the page when running the dev server, resulting in queries that used those inputs to never finish. `@evidence-dev/sdk/utils/svelte` provides `ensureInputContext` which is probably the root cause, though not sure why.