### PR TITLE
fix: resolve plugin directories using node

### DIFF
--- a/.changeset/brown-countries-fold.md
+++ b/.changeset/brown-countries-fold.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/sdk': patch
+---
+
+fix plugin resolution when hoisted by package managers

--- a/packages/lib/sdk/src/plugins/loadPluginPackage.js
+++ b/packages/lib/sdk/src/plugins/loadPluginPackage.js
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import { PluginPackageSchema } from './schemas/plugin-package.schema.js';
 import fs from 'fs/promises';
+import { createRequire } from 'module';
 import path from 'path';
-import { projectRoot } from '../lib/projectRoot.js';
 
 /**
  *
@@ -10,8 +10,8 @@ import { projectRoot } from '../lib/projectRoot.js';
  * @returns {Promise<null | import("./schemas/plugin-package.schema.js").PluginPackage & {dir: string}>}
  */
 export const loadPluginPackage = async (name) => {
-	// We have to use this instead of read/resolve PackageJSON because these packages don't have an index file
-	const packagePath = path.join(projectRoot, 'node_modules', name, 'package.json');
+	const pluginPackageDirectory = path.dirname(createRequire(import.meta.url).resolve(name));
+	const packagePath = path.join(pluginPackageDirectory, 'package.json');
 
 	const packageContent = JSON.parse(await fs.readFile(packagePath, 'utf-8'));
 	const pack = PluginPackageSchema.safeParse(packageContent);


### PR DESCRIPTION
### Description
aims to resolve errors like the following when running `sources`, for projects that are using `yarn` in a monorepo with package hoisting

```shell
yarn workspace charts sources
✖ Loading plugins & sources
[ ! ] ENOENT: no such file or directory, open '/path/to/project/packages/charts/node_modules/@evidence-dev/bigquery/package.json'
```

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
