### PR TITLE
Fix double loading in accordion-wrapped charts

### DIFF
--- a/.changeset/twelve-melons-dream.md
+++ b/.changeset/twelve-melons-dream.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/component-utilities': patch
+---
+
+remove observation of container element

--- a/packages/lib/component-utilities/src/echarts.js
+++ b/packages/lib/component-utilities/src/echarts.js
@@ -136,7 +136,6 @@ export default (node, option) => {
 	let resizeObserver;
 	if (window.ResizeObserver && containerElement) {
 		resizeObserver = new ResizeObserver(onWindowResize);
-		resizeObserver.observe(containerElement);
 		resizeObserver.observe(parentElement);
 	} else {
 		window.addEventListener('resize', onWindowResize);

--- a/packages/lib/component-utilities/src/echarts.js
+++ b/packages/lib/component-utilities/src/echarts.js
@@ -120,8 +120,6 @@ export default (node, option) => {
 		dispatch('click', params);
 	});
 
-	// Resize logic:
-	const containerElement = document.getElementById('evidence-main-article');
 	// watching parent element is necessary for charts within `Fullscreen` components
 	const parentElement = node.parentElement;
 	const onWindowResize = debounce(() => {
@@ -134,7 +132,7 @@ export default (node, option) => {
 	}, 100);
 
 	let resizeObserver;
-	if (window.ResizeObserver && containerElement) {
+	if (window.ResizeObserver && parentElement) {
 		resizeObserver = new ResizeObserver(onWindowResize);
 		resizeObserver.observe(parentElement);
 	} else {
@@ -207,7 +205,6 @@ export default (node, option) => {
 		},
 		destroy() {
 			if (resizeObserver) {
-				resizeObserver.unobserve(containerElement);
 				resizeObserver.unobserve(parentElement);
 			} else {
 				window.removeEventListener('resize', onWindowResize);

--- a/sites/test-env/pages/echarts-blink.md
+++ b/sites/test-env/pages/echarts-blink.md
@@ -11,7 +11,7 @@ select
     item,
     sum(sales) as sales,
 from needful_things.orders
-where category = '${inputs.category}'
+where category = '${inputs.category.value}'
 group by item
 order by sales desc
 ```
@@ -38,6 +38,19 @@ order by sales desc
     y=sales
     yFmt=usd0k
 />
+
+<Accordion>
+ 
+<AccordionItem title='Current vs Prev Week DAU'>
+<BarChart
+    data={noninterpolated_items}
+    x=item
+    y=sales
+    yFmt=usd0k
+/>
+</AccordionItem>
+
+</Accordion>
 
 <Dropdown 
     data={categories}


### PR DESCRIPTION
### Description

Removes resize observation of container element in `echarts.js`. Still works with `Fullscreen`-wrapped charts. I think `Fullscreen` was the only other thing that depended on the resize behaviour, but would be nice if there's a way to test resize animations w/ playwright/storybook.

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
