### PR TITLE
make next the base branch for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
 	"fixed": [],
 	"linked": [],
 	"access": "public",
-	"baseBranch": "main",
+	"baseBranch": "next",
 	"updateInternalDependencies": "patch",
 	"ignore": []
 }


### PR DESCRIPTION
### Description

Now the changesets CLI will add the right packages by default, as next is our development branch

![CleanShot 2024-11-11 at 15 44 31@2x](https://github.com/user-attachments/assets/a0726f8d-edac-4de6-98ad-fc51321cffb8)
