### PR TITLE
Automatically add injected Evidence imports to Vite's `optimizeDeps.include`

### DIFF
--- a/.changeset/kind-mugs-walk.md
+++ b/.changeset/kind-mugs-walk.md
@@ -1,0 +1,6 @@
+---
+'@evidence-dev/evidence': patch
+'@evidence-dev/preprocess': patch
+---
+
+Automatically add injected Evidence imports to Vite's `optimizeDeps.include`

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -49,6 +49,7 @@ fsExtra.outputFileSync(
 	import { createLogger } from 'vite';
 	import { sourceQueryHmr } from '@evidence-dev/sdk/vite';
 	import { isDebug } from '@evidence-dev/sdk/utils';
+	import preprocess from '@evidence-dev/preprocess';
 
 	const logger = createLogger();
 	const loggerWarn = logger.warn;
@@ -81,13 +82,7 @@ fsExtra.outputFileSync(
 				// We need these to prevent HMR from doing a full page reload
 				...(process.env.EVIDENCE_DISABLE_INCLUDE ? [] : [
 					'@evidence-dev/core-components',
-					'@evidence-dev/component-utilities/stores',
-					'@evidence-dev/component-utilities/formatting',
-					'@evidence-dev/component-utilities/globalContexts',
-					'@evidence-dev/component-utilities/buildQuery',
-					'@evidence-dev/component-utilities/profile',
-					'@evidence-dev/sdk/usql',
-					'@evidence-dev/sdk/utils/svelte',
+					...preprocess.injectedEvidenceImports.map(i => i.from),
 					'debounce', 
 					'@duckdb/duckdb-wasm',
 					'apache-arrow'

--- a/packages/lib/preprocess/index.cjs
+++ b/packages/lib/preprocess/index.cjs
@@ -13,7 +13,7 @@ module.exports = function evidencePreprocess(componentDevelopmentMode = false) {
 	return [
 		injectPartials,
 		addScriptTags,
-		processQueries(componentDevelopmentMode),
+		processQueries.processQueries(componentDevelopmentMode),
 		mdsvex.mdsvex({
 			extensions: ['.md'],
 			smartypants: {
@@ -53,3 +53,5 @@ const extractQueries = require('./src/extract-queries/extract-queries.cjs');
 module.exports.extractQueries = extractQueries.extractQueries;
 module.exports.getQueryIds = extractQueries.getQueryIds;
 module.exports.injectPartials = injectPartials.injectPartials;
+module.exports.processQueries = processQueries.processQueries;
+module.exports.injectedEvidenceImports = processQueries.injectedEvidenceImports;


### PR DESCRIPTION
### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
