### PR TITLE
Silence all non-error Vite logging

### DIFF
--- a/.changeset/pretty-worms-worry.md
+++ b/.changeset/pretty-worms-worry.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': minor
+---
+
+disable all non-error vite logging

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -128,6 +128,7 @@ fsExtra.outputFileSync(
 	} else {
 		config.logLevel = 'silent';
 		logger.error = (msg) => log.error(msg);
+		logger.info = logger.warn = logger.warnOnce = () => {};
 	}
 
     export default config`

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -56,10 +56,6 @@ fsExtra.outputFileSync(
 	import { log } from "@evidence-dev/sdk/logger";
 
 	const logger = createLogger();
-	logger.error = (msg) => log.error(msg);
-	logger.warn = (msg) => log.debug(msg);
-	logger.info = (msg) => log.debug(msg);
-	logger.warnOnce = (msg) => log.debug(msg);
 
     const strictFs = (process.env.NODE_ENV === 'development') ? false : true;
     /** @type {import('vite').UserConfig} */
@@ -104,9 +100,36 @@ fsExtra.outputFileSync(
 				}
 			}
 		},
-		customLogger: logger,
-		logLevel: 'silent'
+		customLogger: logger
     }
+
+	if (isDebug()) {
+		const loggerWarn = logger.warn;
+		const loggerOnce = logger.warnOnce
+
+		/**
+		 * @see https://github.com/evidence-dev/evidence/issues/1876
+		 * Ignore the duckdb-wasm sourcemap warning
+		 */
+		logger.warnOnce = (m, o) => {
+			if (m.match(/Sourcemap for ".+\\/node_modules\\/@duckdb\\/duckdb-wasm\\/dist\\/duckdb-browser-eh\\.worker\\.js" points to missing source files/)) return;
+			loggerOnce(m, o)
+		}
+
+		logger.warn = (msg, options) => {
+			// ignore fs/promises warning, used in +layout.js behind if (!browser) check
+			if (msg.includes('Module "fs/promises" has been externalized for browser compatibility')) return;
+
+			// ignore eval warning, used in duckdb-wasm
+			if (msg.includes('Use of eval in') && msg.includes('is strongly discouraged as it poses security risks and may cause issues with minification.')) return;
+
+			loggerWarn(msg, options);
+		};
+	} else {
+		config.logLevel = 'silent';
+		logger.error = (msg) => log.error(msg);
+	}
+
     export default config`
 );
 

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -52,27 +52,13 @@ fsExtra.outputFileSync(
 	import { sourceQueryHmr, configVirtual } from '@evidence-dev/sdk/build/vite';
 	import { isDebug } from '@evidence-dev/sdk/utils';
 	import preprocess from '@evidence-dev/preprocess';
+	import { log } from "@evidence-dev/sdk/logger";
 
 	const logger = createLogger();
-	const loggerWarn = logger.warn;
-  const loggerOnce = logger.warnOnce
-  
-  /**
-   * @see https://github.com/evidence-dev/evidence/issues/1876
-   * Ignore the duckdb-wasm sourcemap warning
-   */
-  logger.warnOnce = (m, o) => {
-  if (m.match(/Sourcemap for ".+\\/node_modules\\/@duckdb\\/duckdb-wasm\\/dist\\/duckdb-browser-eh\\.worker\\.js" points to missing source files/)) return;
-  loggerOnce(m, o)
-}
-
-	logger.warn = (msg, options) => {
-		// ignore fs/promises warning, used in +layout.js behind if (!browser) check
-		if (msg.includes('Module "fs/promises" has been externalized for browser compatibility')) return;
-		// ignore eval warning, used in duckdb-wasm
-		if (msg.includes('Use of eval in') && msg.includes('is strongly discouraged as it poses security risks and may cause issues with minification.')) return;
-		loggerWarn(msg, options);
-};
+	logger.error = (msg) => log.error(msg);
+	logger.warn = (msg) => {};
+	logger.info = (msg) => {};
+	logger.warnOnce = (msg) => {};
 
     const strictFs = (process.env.NODE_ENV === 'development') ? false : true;
     /** @type {import('vite').UserConfig} */
@@ -116,7 +102,8 @@ fsExtra.outputFileSync(
 				}
 			}
 		},
-		customLogger: logger
+		customLogger: logger,
+		logLevel: 'silent'
     }
     export default config`
 );

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -56,9 +56,9 @@ fsExtra.outputFileSync(
 
 	const logger = createLogger();
 	logger.error = (msg) => log.error(msg);
-	logger.warn = (msg) => {};
-	logger.info = (msg) => {};
-	logger.warnOnce = (msg) => {};
+	logger.warn = (msg) => log.debug(msg);
+	logger.info = (msg) => log.debug(msg);
+	logger.warnOnce = (msg) => log.debug(msg);
 
     const strictFs = (process.env.NODE_ENV === 'development') ? false : true;
     /** @type {import('vite').UserConfig} */


### PR DESCRIPTION
### Description

Disables all non-error Vite logging, except in debug mode

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)