### PR TITLE
fix: reexport injectedEvidenceImports from evidence package

### DIFF
--- a/packages/evidence/index.js
+++ b/packages/evidence/index.js
@@ -1,0 +1,2 @@
+import preprocess from '@evidence-dev/preprocess';
+export const injectedEvidenceImports = preprocess.injectedEvidenceImports;

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -51,7 +51,7 @@ fsExtra.outputFileSync(
 	import { createLogger } from 'vite';
 	import { sourceQueryHmr, configVirtual } from '@evidence-dev/sdk/build/vite';
 	import { isDebug } from '@evidence-dev/sdk/utils';
-	import preprocess from '@evidence-dev/preprocess';
+	import { injectedEvidenceImports } from '@evidence-dev/evidence';
 
 	const logger = createLogger();
 	const loggerWarn = logger.warn;
@@ -84,7 +84,7 @@ fsExtra.outputFileSync(
 				// We need these to prevent HMR from doing a full page reload
 				...(process.env.EVIDENCE_DISABLE_INCLUDE ? [] : [
 					'@evidence-dev/core-components',
-					...preprocess.injectedEvidenceImports.map(i => i.from),
+					...injectedEvidenceImports.map(i => i.from),
 					'debounce', 
 					'@duckdb/duckdb-wasm',
 					'apache-arrow'


### PR DESCRIPTION
@evidence-dev/preprocess is not a dependency of the template, so we need to reexport from @evidence-dev/evidence which is a dependency of the template

Should fix failing checks here: https://github.com/evidence-dev/template/pull/184