### PR TITLE
fix: validate plugins using node module resolution

### DIFF
--- a/.changeset/silent-seahorses-argue.md
+++ b/.changeset/silent-seahorses-argue.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/plugin-connector': patch
+---
+
+validate plugins using node module resolution

--- a/packages/lib/plugin-connector/package.json
+++ b/packages/lib/plugin-connector/package.json
@@ -79,7 +79,8 @@
 			"require": "./dist/index.cjs",
 			"types": "./types/index.d.ts"
 		},
-		"./load-config": "./dist/loadConfig/load-config.js"
+		"./load-config": "./dist/loadConfig/load-config.js",
+		"./find-plugin-directory": "./dist/plugin-discovery/find-plugin-directory.js"
 	},
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",

--- a/packages/lib/plugin-connector/src/plugin-discovery/find-plugin-directory.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/find-plugin-directory.js
@@ -1,0 +1,29 @@
+import { createRequire } from 'module';
+import path from 'path';
+
+/**
+ *
+ * @param {string} packageName
+ * @returns {string}
+ */
+export const findPluginDirectory = (packageName) => {
+	// TODO: it would probably be better to use findPackageJSON but only available in node ^23
+	//       https://nodejs.org/api/module.html#modulefindpackagejsonspecifier-base
+	const mainPackageExportFile = createRequire(import.meta.url).resolve(packageName);
+
+	let packageRoot = mainPackageExportFile;
+
+	const packageNamePath = packageName.replace('/', path.sep);
+
+	while (packageRoot !== path.sep && packageRoot.endsWith(packageNamePath) === false) {
+		packageRoot = path.dirname(packageRoot);
+	}
+
+	if (packageRoot.endsWith(packageName) === false) {
+		throw new Error(
+			`failed to find plugin package root for ${packageName}, export file ${mainPackageExportFile}`
+		);
+	}
+
+	return packageRoot;
+};

--- a/packages/lib/plugin-connector/src/plugin-discovery/load-config.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/load-config.js
@@ -34,8 +34,7 @@ export const loadConfig = (rootDir) => {
 
 		return configResult.data;
 	} catch (e) {
-		if (!(e instanceof Error)) throw e;
-		if (e.message.startsWith('ENOENT')) {
+		if (e instanceof Error && e.message.startsWith('ENOENT')) {
 			throw new Error(`Could not find evidence plugins file. (Look at ${configPath})`, {
 				cause: e
 			});

--- a/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
@@ -1,34 +1,6 @@
 import { isValidPackage } from './is-valid-package';
-import path from 'path';
 import { loadConfig } from './load-config';
-import { createRequire } from 'module';
-
-/**
- *
- * @param {string} packageName
- * @returns {string}
- */
-const findPluginDirectory = (packageName) => {
-	// TODO: it would probably be better to use findPackageJSON but only available in node ^23
-	//       https://nodejs.org/api/module.html#modulefindpackagejsonspecifier-base
-	const mainPackageExportFile = createRequire(import.meta.url).resolve(packageName);
-
-	let packageRoot = mainPackageExportFile;
-
-	const packageNamePath = packageName.replace('/', path.sep);
-
-	while (packageRoot !== path.sep && packageRoot.endsWith(packageNamePath) === false) {
-		packageRoot = path.dirname(packageRoot);
-	}
-
-	if (packageRoot.endsWith(packageName) === false) {
-		throw new Error(
-			`failed to find plugin package root for ${packageName}, export file ${mainPackageExportFile}`
-		);
-	}
-
-	return packageRoot;
-};
+import findPluginDirectory from './find-plugin-directory.js';
 
 /**
  * Validates that the given package name exists and is a valid plugin package

--- a/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
@@ -1,6 +1,6 @@
 import { isValidPackage } from './is-valid-package';
 import { loadConfig } from './load-config';
-import findPluginDirectory from './find-plugin-directory.js';
+import { findPluginDirectory } from './find-plugin-directory.js';
 
 /**
  * Validates that the given package name exists and is a valid plugin package

--- a/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
@@ -4,12 +4,40 @@ import { loadConfig } from './load-config';
 import { createRequire } from 'module';
 
 /**
+ *
+ * @param {string} packageName
+ * @returns {string}
+ */
+const findPluginDirectory = (packageName) => {
+	// TODO: it would probably be better to use findPackageJSON but only available in node ^23
+	//       https://nodejs.org/api/module.html#modulefindpackagejsonspecifier-base
+	const mainPackageExportFile = createRequire(import.meta.url).resolve(packageName);
+
+	let packageRoot = mainPackageExportFile;
+
+	const packageNamePath = packageName.replace('/', path.sep);
+
+	while (packageRoot !== path.sep && packageRoot.endsWith(packageNamePath) === false) {
+		packageRoot = path.dirname(packageRoot);
+	}
+
+	if (packageRoot.endsWith(packageName) === false) {
+		throw new Error(
+			`failed to find plugin package root for ${packageName}, export file ${mainPackageExportFile}`
+		);
+	}
+
+	return packageRoot;
+};
+
+/**
  * Validates that the given package name exists and is a valid plugin package
  * @param {string} packageName
  * @returns {Promise<EvidencePluginPackage<ValidPackage> | false>}
  */
 const validatePlugin = async (packageName) => {
-	const packagePath = path.dirname(createRequire(import.meta.url).resolve(packageName));
+	const packagePath = findPluginDirectory(packageName);
+
 	const validPackage = await isValidPackage(packagePath);
 	if (!validPackage) return false;
 	return {

--- a/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
+++ b/packages/lib/plugin-connector/src/plugin-discovery/resolve-evidence-config.js
@@ -1,27 +1,22 @@
 import { isValidPackage } from './is-valid-package';
 import path from 'path';
 import { loadConfig } from './load-config';
+import { createRequire } from 'module';
+
 /**
- * Wrapper function to create a package validator function
- * @param {string} rootDir
- * @returns {(packageName: string) => Promise<EvidencePluginPackage<ValidPackage> | false>}
+ * Validates that the given package name exists and is a valid plugin package
+ * @param {string} packageName
+ * @returns {Promise<EvidencePluginPackage<ValidPackage> | false>}
  */
-const validatePlugin =
-	(rootDir) =>
-	/**
-	 * Validates that the given package name exists and is a valid plugin package
-	 * @param {string} packageName
-	 * @returns {Promise<EvidencePluginPackage<ValidPackage> | false>}
-	 */
-	async (packageName) => {
-		const packagePath = path.resolve(rootDir, 'node_modules', packageName);
-		const validPackage = await isValidPackage(packagePath);
-		if (!validPackage) return false;
-		return {
-			package: validPackage,
-			path: packagePath
-		};
+const validatePlugin = async (packageName) => {
+	const packagePath = path.dirname(createRequire(import.meta.url).resolve(packageName));
+	const validPackage = await isValidPackage(packagePath);
+	if (!validPackage) return false;
+	return {
+		package: validPackage,
+		path: packagePath
 	};
+};
 
 /**
  * Leverages evidence.plugins.yaml to resolve plugins
@@ -34,12 +29,12 @@ export const resolveEvidencePackages = async (rootDir) => {
 
 	/** @type {EvidencePluginPackage<ValidPackage>[]} */
 	const componentPackages = await Promise.all(
-		Object.keys(configContent.components).map(validatePlugin(rootDir))
+		Object.keys(configContent.components).map(validatePlugin)
 	).then((pack) => /** @type {Exclude<typeof pack[number], false>[]} */ (pack.filter(Boolean)));
 
 	/** @type {EvidencePluginPackage<EvidenceDatasourcePackage>[]} */
 	const datasourcePackages = await Promise.all(
-		Object.keys(configContent.datasources).map(validatePlugin(rootDir))
+		Object.keys(configContent.datasources).map(validatePlugin)
 	).then(
 		(pack) =>
 			/** @type {EvidencePluginPackage<EvidenceDatasourcePackage>[]} */

--- a/packages/ui/core-components/package.json
+++ b/packages/ui/core-components/package.json
@@ -126,7 +126,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
### Description
in a similar vein to https://github.com/evidence-dev/evidence/pull/2755 resolve the location of plugins using
`createRequire` such that packages hoisted by `yarn` can be discovered
in a mono repo using yarn workspaces

solves errors like:
```shell
[!] "@evidence-dev/core-components" could not be found in your node_modules. Check for spelling errors or try running npm install.
[!] "@evidence-dev/bigquery" could not be found in your node_modules. Check for spelling errors or try running npm install.
[!] "@evidence-dev/csv" could not be found in your node_modules. Check for spelling errors or try running npm install.
```

with this change I can _almost_ get the sample project to work as a yarn workspace

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
