### PR TITLE
Fix pagesManifest generation for pre-v18.17 node

### DIFF
--- a/.changeset/heavy-dodos-happen.md
+++ b/.changeset/heavy-dodos-happen.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+build directory path manually when using fs.Dirent

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -79,7 +79,7 @@ export async function GET() {
 	}
 
 	try {
-		recursiveReadDir(path.join('src', 'pages'));
+		await recursiveReadDir(path.join('src', 'pages'));
 
 		const fileTree = _buildPageManifest(pages);
 


### PR DESCRIPTION
### Description

Fixes regression in last release's `pagesManifest.json` change that didn't properly support v18.17

Was discussing w/ Archie, might be good to add another set of tests that test the minimum version we want to officially support (atm that appears to be 18.13?)

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)