### PR TITLE
fixed datatable not displaying sorted group data

### DIFF
--- a/.changeset/unlucky-books-compete.md
+++ b/.changeset/unlucky-books-compete.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed dataTable not displaying sorted data

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
@@ -165,35 +165,6 @@
 		<Column id="sales" fmt="usd" />
 	</DataTable>
 </Story>
-<Story name="With Group Sorting w/ reactive columns">
-	{@const data = Query.create(
-		`SELECT 
-			'd' as category, 'xd' as item, 2000 as sales, 300 as 'Column A', 700 as 'Column B'
-			union all
-			select 'd','yd',400,100,500
-			union all
-			select 'd','zd',4000,200,600
-			union all
-			select 'b','xb',5000,10,50			
-			union all
-			select 'b','yb',1,20,60			
-			union all
-			select 'b','zb',3,30,70
-		`,
-		query
-	)}
-	<ButtonGroup name="selector">
-		<ButtonGroupItem value="Column A" valueLabel="Column A" default />
-		<ButtonGroupItem value="Column B" valueLabel="Column B" />
-	</ButtonGroup>
-	<DataTable {data} groupBy="category" sort="sales desc" subtotals="true">
-		<Column id="category" />
-		<Column id="item" />
-		<Column id="sales" fmt="usd" />
-		<Column id={$inputStore.selector} />
-	</DataTable>
-</Story>
-
 <Story name="With Search (Long Columns)">
 	{@const data = Query.create(`SELECT * from blog_posts`, query)}
 	<DataTable {data} title="Blog Posts" search />

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/DataTable.stories.svelte
@@ -165,6 +165,34 @@
 		<Column id="sales" fmt="usd" />
 	</DataTable>
 </Story>
+<Story name="With Group Sorting w/ reactive columns">
+	{@const data = Query.create(
+		`SELECT 
+			'd' as category, 'xd' as item, 2000 as sales, 300 as 'Column A', 700 as 'Column B'
+			union all
+			select 'd','yd',400,100,500
+			union all
+			select 'd','zd',4000,200,600
+			union all
+			select 'b','xb',5000,10,50			
+			union all
+			select 'b','yb',1,20,60			
+			union all
+			select 'b','zb',3,30,70
+		`,
+		query
+	)}
+	<ButtonGroup name="selector">
+		<ButtonGroupItem value="Column A" valueLabel="Column A" default />
+		<ButtonGroupItem value="Column B" valueLabel="Column B" />
+	</ButtonGroup>
+	<DataTable {data} groupBy="category" sort="sales desc" subtotals="true">
+		<Column id="category" />
+		<Column id="item" />
+		<Column id="sales" fmt="usd" />
+		<Column id={$inputStore.selector} />
+	</DataTable>
+</Story>
 
 <Story name="With Search (Long Columns)">
 	{@const data = Query.create(`SELECT * from blog_posts`, query)}

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -118,11 +118,13 @@
 	$: showLinkCol = showLinkCol === 'true' || showLinkCol === true;
 
 	let error = undefined;
+	let groupDataPopulated = false;
 
 	// ---------------------------------------------------------------------------------------
 	// Add props to store to let child components access them
 	// ---------------------------------------------------------------------------------------
 	props.update((d) => {
+		groupDataPopulated = false;
 		return { ...d, data, columns: [] };
 	});
 
@@ -306,10 +308,6 @@
 					? 1 * sortModifier
 					: 0;
 
-		const sortedFilteredData = [...filteredData].sort(comparator);
-
-		filteredData = sortedFilteredData;
-
 		if (groupBy) {
 			const sortedGroupedData = {};
 
@@ -318,6 +316,9 @@
 			}
 
 			groupedData = sortedGroupedData;
+		} else {
+			const sortedFilteredData = [...filteredData].sort(comparator);
+			filteredData = sortedFilteredData;
 		}
 	};
 
@@ -329,6 +330,10 @@
 				const valA = a[1][sortObj.col],
 					valB = b[1][sortObj.col];
 				// Use the existing sort logic but apply it to groupRowData's values
+				// Special case for groupby column
+				if (sortObj.col === groupBy && isNaN(groupBy)) {
+					return sortObj.ascending ? a[0].localeCompare(b[0]) : b[0].localeCompare(a[0]);
+				}
 				if (
 					(valA === undefined || valA === null || isNaN(valA)) &&
 					valB !== undefined &&
@@ -432,14 +437,17 @@
 	let groupRowData = [];
 
 	$: if (!error) {
-		groupedData = data.reduce((acc, row) => {
-			const groupName = row[groupBy];
-			if (!acc[groupName]) {
-				acc[groupName] = [];
-			}
-			acc[groupName].push(row);
-			return acc;
-		}, {});
+		if (groupBy && !groupDataPopulated) {
+			groupedData = data.reduce((acc, row) => {
+				const groupName = row[groupBy];
+				if (!acc[groupName]) {
+					acc[groupName] = [];
+				}
+				acc[groupName].push(row);
+				return acc;
+			}, {});
+			groupDataPopulated = true;
+		}
 
 		// After groupedData is populated, calculate aggregations for groupRowData
 		groupRowData = Object.keys(groupedData).reduce((acc, groupName) => {


### PR DESCRIPTION
### Description
Originally Data Table was only sorted based on aggregated group values, but the data within each group was unsorted

_Group name not sorting, GDP Growth Russia negative value always first in group_

https://github.com/user-attachments/assets/b859d0df-f2d4-4a77-8c42-1bee29100746

After investigation, the issue was identified: the sorted data was overwritten because the displayed data was repopulated from the original data set. This PR resolves the problem by ensuring the displayed data is only populated during the initial render or when the data changes. This allows the sorted data to render correctly on the page.


https://github.com/user-attachments/assets/b46bd387-da79-4c78-84fb-9ed0ac191cbb


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
