### PR TITLE
[Theming] `DocTab` uses theme

### DIFF
--- a/sites/docs/components/DocTab.svelte
+++ b/sites/docs/components/DocTab.svelte
@@ -7,11 +7,6 @@
 	const tabs = ['preview', 'code'];
 	let tabButtons = [];
 
-	function setTab(tab, index) {
-		activeTab = tab;
-		updateActiveBorder(index);
-	}
-
 	const [send, receive] = crossfade({
 		duration: 200,
 		easing: cubicInOut
@@ -28,7 +23,7 @@
 						tab
 							? 'text-gray-950'
 							: 'text-gray-600'}"
-						on:click={() => setTab(tab, index)}
+						on:click={() => (activeTab = tab)}
 						bind:this={tabButtons[index]}
 					>
 						{tab}

--- a/sites/docs/components/DocTab.svelte
+++ b/sites/docs/components/DocTab.svelte
@@ -15,14 +15,13 @@
 
 <div class="doc-tab mt-2">
 	<div class="flex justify-end">
-		<div class="flex gap-1 bg-gray-100 rounded-md p-1 shadow-inner">
+		<div class="flex gap-1 bg-base-200 rounded-md p-1 shadow-inner light:shadow-base-300">
 			{#each tabs as tab, index}
 				<div class="relative">
 					<button
-						class="relative z-10 py-1 px-2 transition-colors duration-300 text-xs font-medium ease-in-out capitalize tracking-wide focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-400 rounded-md hover:text-gray-950 {activeTab ===
-						tab
-							? 'text-gray-950'
-							: 'text-gray-600'}"
+						class="relative z-10 py-1 px-2 transition-colors duration-300 text-xs font-medium ease-in-out capitalize tracking-wide focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-content-muted rounded-md hover:text-base-content"
+						class:text-base-content={activeTab === tab}
+						class:text-base-content-muted={activeTab !== tab}
 						on:click={() => (activeTab = tab)}
 						bind:this={tabButtons[index]}
 					>
@@ -30,7 +29,7 @@
 					</button>
 					{#if activeTab === tab}
 						<div
-							class="absolute bottom-0 left-0 w-full h-full rounded border bg-white shadow-sm z-0"
+							class="absolute bottom-0 left-0 w-full h-full rounded border border-base-300 bg-base-100 shadow-sm z-0"
 							in:send={{ key: 'trigger' }}
 							out:receive={{ key: 'trigger' }}
 						/>


### PR DESCRIPTION
### Description

#### Before


https://github.com/user-attachments/assets/eb5c10c6-1440-497f-b8a7-7ab7e23c4296



#### After

https://github.com/user-attachments/assets/52f4781a-709c-4179-a4b5-174f2d881a4d

https://github.com/user-attachments/assets/d7069b04-f026-4a8e-b7e8-7a3996a98a24




### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- ~~[ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)~~
- ~~[ ] I have added to the docs where applicable~~
- ~~[ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
