### PR TITLE
seriesFmt for series labels in charts

### DIFF
--- a/.changeset/cuddly-peas-do.md
+++ b/.changeset/cuddly-peas-do.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+series names can be formatted in Area, Bar, Bubble, Line charts and Scatter plot

--- a/packages/lib/component-utilities/src/getSeriesConfig.js
+++ b/packages/lib/component-utilities/src/getSeriesConfig.js
@@ -1,4 +1,5 @@
 import getDistinctValues from './getDistinctValues.js';
+import { fmt } from '@evidence-dev/component-utilities/formatting';
 
 export default function getSeriesConfig(
 	data,
@@ -13,7 +14,8 @@ export default function getSeriesConfig(
 	seriesOrder,
 	size = undefined,
 	tooltipTitle = undefined,
-	y2 = undefined
+	y2 = undefined,
+	seriesFmt = undefined
 ) {
 	function generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig) {
 		let tempConfig = {
@@ -221,6 +223,13 @@ export default function getSeriesConfig(
 
 	if (seriesOrder) {
 		seriesConfig.sort((a, b) => seriesOrder.indexOf(a.name) - seriesOrder.indexOf(b.name));
+	}
+
+	// format series config:
+	if (seriesFmt) {
+		seriesConfig.forEach((item) => {
+			item.name = fmt(item.name, seriesFmt);
+		});
 	}
 
 	return seriesConfig;

--- a/packages/lib/component-utilities/src/getSeriesConfig.js
+++ b/packages/lib/component-utilities/src/getSeriesConfig.js
@@ -15,7 +15,7 @@ export default function getSeriesConfig(
 	size = undefined,
 	tooltipTitle = undefined,
 	y2 = undefined,
-	seriesFmt = undefined
+	seriesLabelFmt = undefined
 ) {
 	function generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig) {
 		let tempConfig = {
@@ -226,9 +226,9 @@ export default function getSeriesConfig(
 	}
 
 	// format series config:
-	if (seriesFmt) {
+	if (seriesLabelFmt) {
 		seriesConfig.forEach((item) => {
-			item.name = fmt(item.name, seriesFmt);
+			item.name = fmt(item.name, seriesLabelFmt);
 		});
 	}
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
@@ -65,6 +65,8 @@
 	}
 	export let showAllLabels = false;
 	export let seriesOrder = undefined;
+	export let seriesFmt = undefined;
+
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
 	$: x = $props.x;
@@ -145,6 +147,20 @@
 		symbolSize: labels && !markers ? 0 : markerSize,
 		step: step ? stepPosition : false
 	};
+	// data,
+	// x,
+	// y,
+	// series,
+	// swapXY,
+	// baseConfig,
+	// name,
+	// xMismatch, // this checks for scenarios where xType is string and xDataType is number. When this is the case, we need to inject strings into the x axis, or else it will cause echarts to think there are duplicate x-axis values (e.g., "4" and 4)
+	// columnSummary,
+	// seriesOrder,
+	// size = undefined,
+	// tooltipTitle = undefined,
+	// y2 = undefined,
+	// seriesFmt = undefined
 
 	$: seriesConfig = getSeriesConfig(
 		data,
@@ -156,7 +172,11 @@
 		name,
 		xMismatch,
 		columnSummary,
-		seriesOrder
+		seriesOrder,
+		undefined, // size (not needed)
+		undefined, // tooltipTitle (not needed)
+		undefined, // y2 (not needed)
+		seriesFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
@@ -147,20 +147,6 @@
 		symbolSize: labels && !markers ? 0 : markerSize,
 		step: step ? stepPosition : false
 	};
-	// data,
-	// x,
-	// y,
-	// series,
-	// swapXY,
-	// baseConfig,
-	// name,
-	// xMismatch, // this checks for scenarios where xType is string and xDataType is number. When this is the case, we need to inject strings into the x axis, or else it will cause echarts to think there are duplicate x-axis values (e.g., "4" and 4)
-	// columnSummary,
-	// seriesOrder,
-	// size = undefined,
-	// tooltipTitle = undefined,
-	// y2 = undefined,
-	// seriesLabelFmt = undefined
 
 	$: seriesConfig = getSeriesConfig(
 		data,

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
@@ -65,7 +65,7 @@
 	}
 	export let showAllLabels = false;
 	export let seriesOrder = undefined;
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
@@ -160,7 +160,7 @@
 	// size = undefined,
 	// tooltipTitle = undefined,
 	// y2 = undefined,
-	// seriesFmt = undefined
+	// seriesLabelFmt = undefined
 
 	$: seriesConfig = getSeriesConfig(
 		data,
@@ -176,7 +176,7 @@
 		undefined, // size (not needed)
 		undefined, // tooltipTitle (not needed)
 		undefined, // y2 (not needed)
-		seriesFmt
+		seriesLabelFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
@@ -277,7 +277,7 @@ LIMIT 200`,
 	<AreaChart {data} {...args} />
 </Story>
 <Story
-	name="With seriesFmt"
+	name="With seriesLabelFmt"
 	args={{ x: 'x', y: 'y', series: 'series', seriesOrder: ['ivory', 'blue', 'violet', 'olive'] }}
 	let:args
 >
@@ -295,5 +295,5 @@ UNION
 SELECT 0.5 AS series, 3 AS x, 25 AS y`,
 		query
 	)}
-	<AreaChart {data} seriesFmt="pct" {...args} />
+	<AreaChart {data} seriesLabelFmt="pct" {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.stories.svelte
@@ -276,3 +276,24 @@ LIMIT 200`,
 	{@const data = Query.create(`select * from numeric_series`, query)}
 	<AreaChart {data} {...args} />
 </Story>
+<Story
+	name="With seriesFmt"
+	args={{ x: 'x', y: 'y', series: 'series', seriesOrder: ['ivory', 'blue', 'violet', 'olive'] }}
+	let:args
+>
+	{@const data = Query.create(
+		`SELECT 0.1 AS series, 1 AS x, 10 AS y
+UNION
+SELECT 0.1 AS series, 2 AS x, 20 AS y
+UNION
+SELECT 0.1 AS series, 3 AS x, 30 AS y
+UNION
+SELECT 0.5 AS series, 1 AS x, 5 AS y
+UNION
+SELECT 0.5 AS series, 2 AS x, 15 AS y
+UNION
+SELECT 0.5 AS series, 3 AS x, 25 AS y`,
+		query
+	)}
+	<AreaChart {data} seriesFmt="pct" {...args} />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
@@ -79,6 +79,7 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
+	export let seriesFmt = undefined;
 </script>
 
 <Chart
@@ -143,6 +144,7 @@
 		{labelFmt}
 		{showAllLabels}
 		{seriesOrder}
+		{seriesFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
@@ -79,7 +79,7 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 </script>
 
 <Chart
@@ -144,7 +144,7 @@
 		{labelFmt}
 		{showAllLabels}
 		{seriesOrder}
-		{seriesFmt}
+		{seriesLabelFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/Bar.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/Bar.svelte
@@ -197,7 +197,7 @@
 		}
 	};
 
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 
 	$: seriesConfig = getSeriesConfig(
 		data,
@@ -213,7 +213,7 @@
 		undefined,
 		undefined,
 		y2,
-		seriesFmt
+		seriesLabelFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/Bar.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/Bar.svelte
@@ -197,6 +197,8 @@
 		}
 	};
 
+	export let seriesFmt = undefined;
+
 	$: seriesConfig = getSeriesConfig(
 		data,
 		x,
@@ -210,7 +212,8 @@
 		seriesOrder,
 		undefined,
 		undefined,
-		y2
+		y2,
+		seriesFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
@@ -86,7 +86,7 @@
 	<BarChart {data} {...args} />
 </Story>
 <Story
-	name="With seriesFmt"
+	name="With seriesLabelFmt"
 	args={{ x: 'x', y: 'y', series: 'series', seriesOrder: [0.1, 0.5] }}
 	let:args
 >
@@ -104,5 +104,5 @@ UNION
 SELECT 0.5 AS series, 3 AS x, 25 AS y`,
 		query
 	)}
-	<BarChart {data} seriesFmt="pct" {...args} />
+	<BarChart {data} seriesLabelFmt="pct" {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.stories.svelte
@@ -85,3 +85,24 @@
 	{@const data = Query.create(`select * from numeric_series`, query)}
 	<BarChart {data} {...args} />
 </Story>
+<Story
+	name="With seriesFmt"
+	args={{ x: 'x', y: 'y', series: 'series', seriesOrder: [0.1, 0.5] }}
+	let:args
+>
+	{@const data = Query.create(
+		`SELECT 0.1 AS series, 1 AS x, 10 AS y
+UNION
+SELECT 0.1 AS series, 2 AS x, 20 AS y
+UNION
+SELECT 0.1 AS series, 3 AS x, 30 AS y
+UNION
+SELECT 0.5 AS series, 1 AS x, 5 AS y
+UNION
+SELECT 0.5 AS series, 2 AS x, 15 AS y
+UNION
+SELECT 0.5 AS series, 3 AS x, 25 AS y`,
+		query
+	)}
+	<BarChart {data} seriesFmt="pct" {...args} />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
@@ -116,7 +116,7 @@
 	export let seriesOrder = undefined;
 	export let connectGroup = undefined;
 
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 </script>
 
 <Chart
@@ -194,7 +194,7 @@
 		{showAllLabels}
 		{y2SeriesType}
 		{seriesOrder}
-		{seriesFmt}
+		{seriesLabelFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
@@ -115,6 +115,8 @@
 	export let seriesColors = undefined;
 	export let seriesOrder = undefined;
 	export let connectGroup = undefined;
+
+	export let seriesFmt = undefined;
 </script>
 
 <Chart
@@ -192,6 +194,7 @@
 		{showAllLabels}
 		{y2SeriesType}
 		{seriesOrder}
+		{seriesFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/Bubble.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/Bubble.svelte
@@ -35,7 +35,7 @@
 	export let useTooltip = false;
 	export let tooltipTitle;
 	export let seriesOrder = undefined;
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 
 	let multiSeries;
 	let tooltipOutput;
@@ -252,7 +252,7 @@
 		size,
 		tooltipTitle,
 		undefined, // y2 (not needed)
-		seriesFmt
+		seriesLabelFmt
 	);
 	$: config.update((d) => {
 		d.series.push(...seriesConfig);

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/Bubble.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/Bubble.svelte
@@ -35,6 +35,7 @@
 	export let useTooltip = false;
 	export let tooltipTitle;
 	export let seriesOrder = undefined;
+	export let seriesFmt = undefined;
 
 	let multiSeries;
 	let tooltipOutput;
@@ -249,7 +250,9 @@
 		columnSummary,
 		seriesOrder,
 		size,
-		tooltipTitle
+		tooltipTitle,
+		undefined, // y2 (not needed)
+		seriesFmt
 	);
 	$: config.update((d) => {
 		d.series.push(...seriesConfig);

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
@@ -193,7 +193,7 @@
 </Story>
 
 <Story
-	name="With seriesFmt"
+	name="With seriesLabelFmt"
 	args={{
 		series: 'series',
 		x: 'x',
@@ -216,5 +216,5 @@ UNION
 SELECT 0.5 AS series, 3 AS x, 25 AS y, 250 AS size`,
 	query
 )}
-	<BubbleChart seriesFmt="pct" {data} {...args} />
+	<BubbleChart seriesLabelFmt="pct" {data} {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
@@ -198,12 +198,12 @@
 		series: 'series',
 		x: 'x',
 		y: 'y',
-		size: 'size',
+		size: 'size'
 	}}
 	let:args
 >
-{@const data = Query.create(
-	`SELECT 0.1 AS series, 1 AS x, 10 AS y, 100 AS size
+	{@const data = Query.create(
+		`SELECT 0.1 AS series, 1 AS x, 10 AS y, 100 AS size
 UNION
 SELECT 0.1 AS series, 2 AS x, 20 AS y, 200 AS size
 UNION
@@ -214,7 +214,7 @@ UNION
 SELECT 0.5 AS series, 2 AS x, 15 AS y, 150 AS size
 UNION
 SELECT 0.5 AS series, 3 AS x, 25 AS y, 250 AS size`,
-	query
-)}
+		query
+	)}
 	<BubbleChart seriesLabelFmt="pct" {data} {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.stories.svelte
@@ -191,3 +191,30 @@
 >
 	<BubbleChart {data} {...args} />
 </Story>
+
+<Story
+	name="With seriesFmt"
+	args={{
+		series: 'series',
+		x: 'x',
+		y: 'y',
+		size: 'size',
+	}}
+	let:args
+>
+{@const data = Query.create(
+	`SELECT 0.1 AS series, 1 AS x, 10 AS y, 100 AS size
+UNION
+SELECT 0.1 AS series, 2 AS x, 20 AS y, 200 AS size
+UNION
+SELECT 0.1 AS series, 3 AS x, 30 AS y, 300 AS size
+UNION
+SELECT 0.5 AS series, 1 AS x, 5 AS y, 50 AS size
+UNION
+SELECT 0.5 AS series, 2 AS x, 15 AS y, 150 AS size
+UNION
+SELECT 0.5 AS series, 3 AS x, 25 AS y, 250 AS size`,
+	query
+)}
+	<BubbleChart seriesFmt="pct" {data} {...args} />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
@@ -67,6 +67,7 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
+	export let seriesFmt = undefined;
 </script>
 
 <Chart
@@ -122,6 +123,7 @@
 		{scaleTo}
 		{useTooltip}
 		{seriesOrder}
+		{seriesFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
@@ -67,7 +67,7 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 </script>
 
 <Chart
@@ -123,7 +123,7 @@
 		{scaleTo}
 		{useTooltip}
 		{seriesOrder}
-		{seriesFmt}
+		{seriesLabelFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
@@ -4,11 +4,6 @@
 		title: 'Charts/Chart',
 		component: Chart
 	};
-
-	const data = Query.create(
-		'SELECT plane, fare, SUM(fare) as total_sales, SUM(fare) as total_fare FROM flights WHERE plane IN (SELECT DISTINCT plane FROM flights LIMIT 2) GROUP BY plane, fare LIMIT 25',
-		query
-	);
 </script>
 
 <script>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
@@ -2,7 +2,7 @@
 	/** @type {import("@storybook/svelte").Meta}*/
 	export const meta = {
 		title: 'Charts/Chart',
-		component: Chart,
+		component: Chart
 	};
 
 	const data = Query.create(
@@ -22,7 +22,7 @@
 
 <Story name="Base">
 	{@const data = Query.create(
-`SELECT 1 AS x, 5 AS growth, 50 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+		`SELECT 1 AS x, 5 AS growth, 50 AS size, 0.1 AS seriesA, 0.7 AS seriesB
 UNION
 SELECT 2 AS x, 10 AS growth, 60 AS size, 0.1 AS seriesA, 0.7 AS seriesB
 UNION
@@ -32,14 +32,11 @@ SELECT 4 AS x, 30 AS growth, 90 AS size, 0.1 AS seriesA, 0.7 AS seriesB
 UNION
 SELECT 5 AS x, 40 AS growth, 110 AS size, 0.1 AS seriesA, 0.7 AS seriesB
 UNION
-SELECT 6 AS x, 50 AS growth, 130 AS size, 0.1 AS seriesA, 0.7 AS seriesB`
-,
+SELECT 6 AS x, 50 AS growth, 130 AS size, 0.1 AS seriesA, 0.7 AS seriesB`,
 		query
 	)}
 	<Chart {data} title="Growth vs Sales">
-		<Bar y="growth" series=seriesA seriesLabelFmt="pct"/>
-		<Line y="size" series=seriesB 	seriesLabelFmt="pct"/>
+		<Bar y="growth" series="seriesA" seriesLabelFmt="pct" />
+		<Line y="size" series="seriesB" seriesLabelFmt="pct" />
 	</Chart>
 </Story>
-
-

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
@@ -37,8 +37,8 @@ SELECT 6 AS x, 50 AS growth, 130 AS size, 0.1 AS seriesA, 0.7 AS seriesB`
 		query
 	)}
 	<Chart {data} title="Growth vs Sales">
-		<Bar y="growth" series=seriesA seriesFmt="pct"/>
-		<Line y="size" series=seriesB 	seriesFmt="pct"/>
+		<Bar y="growth" series=seriesA seriesLabelFmt="pct"/>
+		<Line y="size" series=seriesB 	seriesLabelFmt="pct"/>
 	</Chart>
 </Story>
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.stories.svelte
@@ -1,0 +1,45 @@
+<script context="module">
+	/** @type {import("@storybook/svelte").Meta}*/
+	export const meta = {
+		title: 'Charts/Chart',
+		component: Chart,
+	};
+
+	const data = Query.create(
+		'SELECT plane, fare, SUM(fare) as total_sales, SUM(fare) as total_fare FROM flights WHERE plane IN (SELECT DISTINCT plane FROM flights LIMIT 2) GROUP BY plane, fare LIMIT 25',
+		query
+	);
+</script>
+
+<script>
+	import { Story } from '@storybook/addon-svelte-csf';
+	import { Query } from '@evidence-dev/sdk/usql';
+	import { query } from '@evidence-dev/universal-sql/client-duckdb';
+	import Chart from './Chart.svelte';
+	import Bar from '../bar/Bar.svelte';
+	import Line from '../line/Line.svelte';
+</script>
+
+<Story name="Base">
+	{@const data = Query.create(
+`SELECT 1 AS x, 5 AS growth, 50 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+UNION
+SELECT 2 AS x, 10 AS growth, 60 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+UNION
+SELECT 3 AS x, 20 AS growth, 70 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+UNION
+SELECT 4 AS x, 30 AS growth, 90 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+UNION
+SELECT 5 AS x, 40 AS growth, 110 AS size, 0.1 AS seriesA, 0.7 AS seriesB
+UNION
+SELECT 6 AS x, 50 AS growth, 130 AS size, 0.1 AS seriesA, 0.7 AS seriesB`
+,
+		query
+	)}
+	<Chart {data} title="Growth vs Sales">
+		<Bar y="growth" series=seriesA seriesFmt="pct"/>
+		<Line y="size" series=seriesB 	seriesFmt="pct"/>
+	</Chart>
+</Story>
+
+

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -952,9 +952,9 @@
 									yVal = params[i].value[swapXY ? 0 : 1];
 									output =
 										output +
-										`<br> ${params[i].marker} ${
+										`<br> <span style='font-size: 11px;'>${params[i].marker} ${
 											params[i].seriesName
-										} <span style='float:right; margin-left: 10px;'>${formatValue(
+										}<span/><span style='float:right; margin-left: 10px; font-size: 12px;'>${formatValue(
 											yVal,
 											// Not sure if this will work. Need to check with multi series on both axes
 											// Check if echarts does the order in the same way - y first, then y2

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
@@ -76,6 +76,8 @@
 	 */
 	export let stepPosition = 'end';
 	export let seriesOrder = undefined;
+	/** @type {string | undefined} */
+	export let seriesFmt = undefined;
 
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
@@ -193,7 +195,8 @@
 		seriesOrder,
 		undefined,
 		undefined,
-		y2
+		y2,
+		seriesFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
@@ -77,7 +77,7 @@
 	export let stepPosition = 'end';
 	export let seriesOrder = undefined;
 	/** @type {string | undefined} */
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 
 	// Prop check. If local props supplied, use those. Otherwise fall back to global props.
 	$: data = $props.data;
@@ -196,7 +196,7 @@
 		undefined,
 		undefined,
 		y2,
-		seriesFmt
+		seriesLabelFmt
 	);
 
 	$: config.update((d) => {

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
@@ -98,7 +98,7 @@
 
 	export let connectGroup = undefined;
 	/** @type {string | undefined} */
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 </script>
 
 <Chart
@@ -175,7 +175,7 @@
 		{showAllLabels}
 		{y2SeriesType}
 		{seriesOrder}
-		{seriesFmt}
+		{seriesLabelFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
@@ -97,6 +97,8 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
+	/** @type {string | undefined} */
+	export let seriesFmt = undefined;
 </script>
 
 <Chart
@@ -173,6 +175,7 @@
 		{showAllLabels}
 		{y2SeriesType}
 		{seriesOrder}
+		{seriesFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/Scatter.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/Scatter.svelte
@@ -30,6 +30,8 @@
 	export let useTooltip = false; // if true, will override the default 'axis'-based echarts tooltip. true only for scatter-only charts
 	export let tooltipTitle;
 	export let seriesOrder = undefined;
+	/** @type {string | undefined} */
+	export let seriesFmt = undefined;
 	let multiSeries;
 	let tooltipOutput;
 
@@ -197,7 +199,9 @@
 		columnSummary,
 		seriesOrder,
 		undefined,
-		tooltipTitle
+		tooltipTitle,
+		undefined,
+		seriesFmt
 	);
 	$: config.update((d) => {
 		d.series.push(...seriesConfig);

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/Scatter.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/Scatter.svelte
@@ -31,7 +31,7 @@
 	export let tooltipTitle;
 	export let seriesOrder = undefined;
 	/** @type {string | undefined} */
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 	let multiSeries;
 	let tooltipOutput;
 
@@ -201,7 +201,7 @@
 		undefined,
 		tooltipTitle,
 		undefined,
-		seriesFmt
+		seriesLabelFmt
 	);
 	$: config.update((d) => {
 		d.series.push(...seriesConfig);

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
@@ -185,3 +185,49 @@
 >
 	<ScatterPlot {data} {...args} />
 </Story>
+<Story
+	name="With seriesFmt"
+	let:args
+>
+{@const data = Query.create(
+	`SELECT 0.1 AS series, 5000 AS advertising_spend, 25000 AS sales
+UNION
+SELECT 0.1 AS series, 3000 AS advertising_spend, 18000 AS sales
+UNION
+SELECT 0.1 AS series, 4000 AS advertising_spend, 22000 AS sales
+UNION
+SELECT 0.25 AS series, 9000 AS advertising_spend, 45000 AS sales
+UNION
+SELECT 0.3 AS series, 10000 AS advertising_spend, 50000 AS sales
+UNION
+SELECT 0.25 AS series, 7000 AS advertising_spend, 32000 AS sales
+UNION
+SELECT 0.1 AS series, 3500 AS advertising_spend, 21000 AS sales
+UNION
+SELECT 0.1 AS series, 4500 AS advertising_spend, 22000 AS sales
+UNION
+SELECT 0.3 AS series, 12000 AS advertising_spend, 60000 AS sales
+UNION
+SELECT 0.25 AS series, 9500 AS advertising_spend, 46000 AS sales
+UNION
+SELECT 0.1 AS series, 3200 AS advertising_spend, 15000 AS sales
+UNION
+SELECT 0.3 AS series, 11000 AS advertising_spend, 54000 AS sales
+UNION
+SELECT 0.25 AS series, 8000 AS advertising_spend, 41000 AS sales
+UNION
+SELECT 0.1 AS series, 4000 AS advertising_spend, 19000 AS sales
+UNION
+SELECT 0.3 AS series, 11500 AS advertising_spend, 55000 AS sales
+UNION
+SELECT 0.25 AS series, 8200 AS advertising_spend, 42000 AS sales
+UNION
+SELECT 0.1 AS series, 3800 AS advertising_spend, 19000 AS sales
+UNION
+SELECT 0.3 AS series, 13000 AS advertising_spend, 65000 AS sales;
+
+`,
+	query
+)}
+	<ScatterPlot {data} x=advertising_spend y=sales series=series seriesFmt="pct" {...args} />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
@@ -186,7 +186,7 @@
 	<ScatterPlot {data} {...args} />
 </Story>
 <Story
-	name="With seriesFmt"
+	name="With seriesLabelFmt"
 	let:args
 >
 {@const data = Query.create(
@@ -229,5 +229,5 @@ SELECT 0.3 AS series, 13000 AS advertising_spend, 65000 AS sales;
 `,
 	query
 )}
-	<ScatterPlot {data} x=advertising_spend y=sales series=series seriesFmt="pct" {...args} />
+	<ScatterPlot {data} x=advertising_spend y=sales series=series seriesLabelFmt="pct" {...args} />
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.stories.svelte
@@ -185,12 +185,9 @@
 >
 	<ScatterPlot {data} {...args} />
 </Story>
-<Story
-	name="With seriesLabelFmt"
-	let:args
->
-{@const data = Query.create(
-	`SELECT 0.1 AS series, 5000 AS advertising_spend, 25000 AS sales
+<Story name="With seriesLabelFmt" let:args>
+	{@const data = Query.create(
+		`SELECT 0.1 AS series, 5000 AS advertising_spend, 25000 AS sales
 UNION
 SELECT 0.1 AS series, 3000 AS advertising_spend, 18000 AS sales
 UNION
@@ -227,7 +224,14 @@ UNION
 SELECT 0.3 AS series, 13000 AS advertising_spend, 65000 AS sales;
 
 `,
-	query
-)}
-	<ScatterPlot {data} x=advertising_spend y=sales series=series seriesLabelFmt="pct" {...args} />
+		query
+	)}
+	<ScatterPlot
+		{data}
+		x="advertising_spend"
+		y="sales"
+		series="series"
+		seriesLabelFmt="pct"
+		{...args}
+	/>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -67,7 +67,7 @@
 
 	export let connectGroup = undefined;
 		/** @type {string | undefined} */
-	export let seriesFmt = undefined;
+	export let seriesLabelFmt = undefined;
 </script>
 
 <Chart
@@ -122,7 +122,7 @@
 		{pointSize}
 		{useTooltip}
 		{seriesOrder}
-		{seriesFmt}
+		{seriesLabelFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -66,6 +66,8 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
+		/** @type {string | undefined} */
+	export let seriesFmt = undefined;
 </script>
 
 <Chart
@@ -120,6 +122,7 @@
 		{pointSize}
 		{useTooltip}
 		{seriesOrder}
+		{seriesFmt}
 	/>
 	<slot />
 </Chart>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -66,7 +66,7 @@
 	export let seriesOrder = undefined;
 
 	export let connectGroup = undefined;
-		/** @type {string | undefined} */
+	/** @type {string | undefined} */
 	export let seriesLabelFmt = undefined;
 </script>
 

--- a/sites/docs/pages/components/area-chart/index.md
+++ b/sites/docs/pages/components/area-chart/index.md
@@ -253,6 +253,13 @@ queries:
     defaultValue="-"
 />
 <PropListing
+    name="seriesLabelFmt"
+    description="Format to use for series label (<a class=markdown href='/core-concepts/formatting'>see available formats<a/>)"
+    required=false
+    options="Excel-style format | built-in format name | custom format name"
+    defaultValue="-"
+/>
+<PropListing
     name="step"
     description="Specifies whether the chart is displayed as a step line."
     required=false

--- a/sites/docs/pages/components/bar-chart/index.md
+++ b/sites/docs/pages/components/bar-chart/index.md
@@ -427,6 +427,13 @@ queries:
     options="Excel-style format | built-in format name | custom format name"
 />
 <PropListing
+    name="seriesLabelFmt"
+    description="Format to use for series label (<a class=markdown href='/core-concepts/formatting'>see available formats<a/>)"
+    required=false
+    options="Excel-style format | built-in format name | custom format name"
+    defaultValue="-"
+/>
+<PropListing
     name=fillColor
     description="Color to override default series color. Only accepts a single color."
     options="CSS name | hexademical | RGB | HSL"

--- a/sites/docs/pages/components/bubble-chart/index.md
+++ b/sites/docs/pages/components/bubble-chart/index.md
@@ -162,6 +162,13 @@ queries:
     required=false
     options="Excel-style format | built-in format name | custom format name"
 />
+<PropListing
+    name="seriesLabelFmt"
+    description="Format to use for series label (<a class=markdown href='/core-concepts/formatting'>see available formats<a/>)"
+    required=false
+    options="Excel-style format | built-in format name | custom format name"
+    defaultValue="-"
+/>
 <PropListing 
     name="shape"
     description="Options for which shape to use for bubble points"

--- a/sites/docs/pages/components/line-chart/index.md
+++ b/sites/docs/pages/components/line-chart/index.md
@@ -378,6 +378,13 @@ group by all
     options="Excel-style format | built-in format name | custom format name"
 />
 <PropListing
+    name="seriesLabelFmt"
+    description="Format to use for series label (<a class=markdown href='/core-concepts/formatting'>see available formats<a/>)"
+    required=false
+    options="Excel-style format | built-in format name | custom format name"
+    defaultValue="-"
+/>
+<PropListing
     name=step
     description="Specifies whether the chart is displayed as a step line"
     options={["true", "false"]}

--- a/sites/docs/pages/components/scatter-plot/index.md
+++ b/sites/docs/pages/components/scatter-plot/index.md
@@ -168,6 +168,13 @@ Format to use for y column ([see available formats](/core-concepts/formatting))
 
 </PropListing>
 <PropListing
+    name="seriesLabelFmt"
+    description="Format to use for series label (<a class=markdown href='/core-concepts/formatting'>see available formats<a/>)"
+    required=false
+    options="Excel-style format | built-in format name | custom format name"
+    defaultValue="-"
+/>
+<PropListing
     name="shape"
     options="circle | emptyCircle | rect | triangle | diamond"
     defaultValue="circle"


### PR DESCRIPTION
### Description

Adding existing evidence/excel formatting properties to series name displayed in chart legends

- [x] Area Chart
- [x] Bar Chart
- [x] Bubble Chart
- [x] Chart
- ~~[ ] Funnel Chart~~ _does not use charts_
- ~~[ ] Histogram~~ _does not accept multiseries_
- [x] Line Chart
- [x] Scatter Plot

_Before:_
`<BarChart {data} />`

![image](https://github.com/user-attachments/assets/567facd7-62be-466a-936a-9e73f21e78dd)


_After:_

`<BarChart {data} seriesFmt="pct"/>`

![image](https://github.com/user-attachments/assets/2e9e097f-6508-49f1-bdaf-70310b3c6c39)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
