### PR TITLE
Fix spelling mistake

### DIFF
--- a/sites/docs/pages/components/bar-chart/index.md
+++ b/sites/docs/pages/components/bar-chart/index.md
@@ -291,7 +291,7 @@ queries:
 
 
 
-### Secondary / Duel y Axis
+### Secondary / Dual y Axis
 
 <DocTab>
     <div slot='preview'>
@@ -315,7 +315,7 @@ queries:
 </DocTab>
 
 
-### Secondary / Duel Axis with Line
+### Secondary / Dual Axis with Line
 
 <DocTab>
     <div slot='preview'>


### PR DESCRIPTION
Change "duel" to "dual" for bar chart docs.

### Description

Simple spelling fix.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [X] I have added to the docs where applicable
- [X] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
