### PR TITLE
feat: tailwind configuration works in mono repos

### DIFF
--- a/packages/lib/sdk/package.json
+++ b/packages/lib/sdk/package.json
@@ -78,6 +78,12 @@
 			"import": "./src/plugins/index.js",
 			"require": null,
 			"types": "./src/plugins/index.js"
+		},
+		"./plugins/discoverPluginPackageRootPathSync": {
+			"default": "./src/plugins/discoverPluginPackageRootPathSync.js",
+			"import": "./src/plugins/discoverPluginPackageRootPathSync.js",
+			"require": "./src/plugins/discoverPluginPackageRootPathSync.js",
+			"types": "./src/plugins/discoverPluginPackageRootPathSync.js"
 		}
 	},
 	"scripts": {

--- a/packages/lib/sdk/src/plugins/discoverPluginPackageRootPathSync.js
+++ b/packages/lib/sdk/src/plugins/discoverPluginPackageRootPathSync.js
@@ -1,0 +1,35 @@
+import path from 'path';
+import { createRequire } from 'module';
+import fs from 'fs';
+import { log } from '../logger/index.js';
+import chalk from 'chalk';
+
+/**
+ *
+ * @param {string} packageName
+ * @returns {string|null}
+ */
+export const discoverPluginPackageRootPathSync = (packageName) => {
+	// note: this will return the directory of the package entrypoint, eg: `some-package/dist/index.js`
+	//       so we need to walk up the tree until we find a `package.json` file to discover the root.
+	let pluginPackageDirectory = path.dirname(createRequire(import.meta.url).resolve(packageName));
+	let pluginPackageDirContents = fs.readdirSync(pluginPackageDirectory);
+	while (!pluginPackageDirContents.includes('package.json')) {
+		pluginPackageDirectory = path.dirname(pluginPackageDirectory);
+		pluginPackageDirContents = fs.readdirSync(pluginPackageDirectory);
+	}
+
+	if (pluginPackageDirectory === path.dirname(pluginPackageDirectory)) {
+		// reached root
+		log.warn(
+			chalk.yellow(
+				`Package ${chalk.bold(
+					`"${packageName}"`
+				)} not found, run again with --debug for more information`
+			)
+		);
+		return null;
+	}
+
+	return pluginPackageDirectory;
+};

--- a/packages/lib/sdk/src/plugins/schemas/plugin-package.schema.js
+++ b/packages/lib/sdk/src/plugins/schemas/plugin-package.schema.js
@@ -69,9 +69,7 @@ const DatasourcePluginSchema = BasePluginPackageSchema.extend({
 	evidence: z.object({
 		datasources: z.array(
 			z.union([
-				z.string({
-					description: 'Name of a supported database, this value is used in the UI'
-				}),
+				z.string({ description: 'Name of a supported database, this value is used in the UI' }),
 				z.array(z.string(), {
 					description:
 						'Group of names that are aliases of the same database. First value is used in UI'

--- a/packages/lib/sdk/src/plugins/schemas/plugin-package.schema.js
+++ b/packages/lib/sdk/src/plugins/schemas/plugin-package.schema.js
@@ -69,7 +69,9 @@ const DatasourcePluginSchema = BasePluginPackageSchema.extend({
 	evidence: z.object({
 		datasources: z.array(
 			z.union([
-				z.string({ description: 'Name of a supported database, this value is used in the UI' }),
+				z.string({
+					description: 'Name of a supported database, this value is used in the UI'
+				}),
 				z.array(z.string(), {
 					description:
 						'Group of names that are aliases of the same database. First value is used in UI'

--- a/sites/example-project/tailwind.config.cjs
+++ b/sites/example-project/tailwind.config.cjs
@@ -4,6 +4,10 @@ const evidenceConfig = require('@evidence-dev/sdk/config').getEvidenceConfig();
 
 const fs = require('fs');
 const path = require('path');
+const {
+	discoverPluginPackageRootPathSync
+} = require('@evidence-dev/sdk/plugins/discoverPluginPackageRootPathSync');
+
 let presets = [evidenceTailwind];
 
 const altConfigFilenames = ['tailwind.config.js', 'tailwind.config.cjs'];
@@ -24,12 +28,10 @@ const config = {
 		get files() {
 			const pluginConfig = evidenceConfig.plugins;
 			const components = pluginConfig.components;
+
 			const componentPaths = Object.keys(components)
-				.map((pluginName) => [
-					`./node_modules/${pluginName}/dist/**/*.{html,js,svelte,ts,md}`,
-					`../../node_modules/${pluginName}/dist/**/*.{html,js,svelte,ts,md}`
-				])
-				.flat();
+				.map((pluginName) => discoverPluginPackageRootPathSync(pluginName))
+				.map((pluginDirectory) => `${pluginDirectory}/dist/**/*.{html,js,svelte,ts,md}`);
 
 			return [
 				'./src/**/*.{html,js,svelte,ts,md}', // This is used for everything in base evidence template


### PR DESCRIPTION
### Description
Previously the tailwind configuration only worked if the directory structure looked like:
```
/root
├── package.json
├── pages
├── evidence.plugins.yaml
├── ...
├── .evidence
│   └── template
│       ├── tailwind.config.cjs
│       └── node_modules # ./node_modules
│           └── some-module
│               └── dist/**/*.{html,js,svelte,ts,md}  
└── node_modules # ../../node_modules
    └── some-module
        └── dist/**/*.{html,js,svelte,ts,md}  
```

This PR aims to replace the assumptions on possible `node_modules` locations with following the same package resolution algorithm used elsewhere in the sdk, meaning that a hoisted monorepo layout like this will now work:
```
/root
├── package.json
├── node_modules
│   └── some-module # will now work
│       └── dist/**/*.{html,js,svelte,ts,md}  
└── packages
    └── my-evidence-proj
        ├── package.json
        ├── node_modules
        │   └── some-other-module # will still work
        │       └── dist/**/*.{html,js,svelte,ts,md}
        ├── pages
        ├── evidence.plugins.yaml
        ├── ...
        └── .evidence
            ├── template
            └── tailwind.config.cjs
```

There remains an assumption/convention that packages must structure their artifacts into a `/dist/**/*.{html,js,svelte,ts,md}` path, but that seems fine to leave alone.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
