### PR TITLE
feat: allow overriding usage of npx

### DIFF
--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -197,6 +197,7 @@ const prog = sade('evidence');
 prog
 	.command('dev')
 	.option('--debug', 'Enables verbose console logs')
+	.option('--override-exec', 'Overrides the method of execution', 'npx')
 	.describe('launch the local evidence development environment')
 	.action((args) => {
 		increaseNodeMemoryLimit();
@@ -204,6 +205,9 @@ prog
 			enableDebug();
 			delete args.debug;
 		}
+
+		const executable = args['override-exec'] || 'npx'
+		delete args['override-exec']
 
 		loadEnvFile();
 
@@ -233,7 +237,7 @@ ${chalk.bold('[!] Unable to load source manifest')}
 
 		logQueryEvent('dev-server-start', undefined, undefined, undefined, true);
 		// Run svelte kit dev in the hidden directory
-		const child = spawn(`npx vite dev --port 3000`, flatArgs, {
+		const child = spawn(`${executable} vite dev --port 3000`, flatArgs, {
 			shell: true,
 			detached: false,
 			cwd: '.evidence/template',
@@ -273,6 +277,7 @@ prog
 prog
 	.command('build')
 	.option('--debug', 'Enables verbose console logs')
+	.option('--override-exec', 'Overrides the method of execution', 'npx')
 	.describe('build production outputs')
 	.action((args) => {
 		increaseNodeMemoryLimit();
@@ -280,16 +285,21 @@ prog
 			enableDebug();
 			delete args.debug;
 		}
+
+		const executable = args['override-exec'] || 'npx'
+		delete args['override-exec']
+
 		loadEnvFile();
 		populateTemplate();
 
 		logQueryEvent('build-start');
-		buildHelper('npx vite build', args);
+		buildHelper(`${executable} vite build`, args);
 	});
 
 prog
 	.command('build:strict')
 	.option('--debug', 'Enables verbose console logs')
+	.option('--override-exec', 'Overrides the method of execution', 'npx')
 	.describe('build production outputs and fails on error')
 	.action((args) => {
 		increaseNodeMemoryLimit();
@@ -297,12 +307,16 @@ prog
 			enableDebug();
 			delete args.debug;
 		}
+
+		const executable = args['override-exec'] || 'npx'
+		delete args['override-exec']
+
 		loadEnvFile();
 		populateTemplate();
 		strictMode();
 
 		logQueryEvent('build-strict-start');
-		buildHelper('npx vite build', args);
+		buildHelper(`${executable} vite build`, args);
 	});
 
 prog
@@ -349,12 +363,18 @@ prog
 prog
 	.command('preview')
 	.describe('preview the production build')
+	.option('--debug', 'Enables verbose console logs')
+	.option('--override-exec', 'Overrides the method of execution', 'npx')
 	.action((args) => {
 		increaseNodeMemoryLimit();
 		if (args.debug) {
 			enableDebug();
 			delete args.debug;
 		}
+
+		const executable = args['override-exec'] || 'npx'
+		delete args['override-exec']
+
 		loadEnvFile();
 		const buildExists = fs.lstatSync(path.join('build'), {
 			throwIfNoEntry: false
@@ -368,7 +388,7 @@ prog
 
 		logQueryEvent('preview-server-start', undefined, undefined, undefined, true);
 
-		let command = 'npx serve build';
+		let command = `${executable} serve build`;
 		if (process.env.VITE_EVIDENCE_SPA === 'true') {
 			command += ' -s';
 		}


### PR DESCRIPTION
### Description
I don't love this solution, but throwing it out there for discussion.

#### Problem
When `workspaces` are in play, `npx` will execute the command with the current working directory set to the `workspace` directory.

```
/root
  package.json
 packages
   my-evidence-proj <- CWD of the vite command ran by npx (incorrect)
     package.json
     pages
     evidence.plugins.yaml
     ...
     .evidence
       template <- CWD of the npx command (correct)
       tailwind.config.cjs
```

- https://github.com/npm/cli/blob/latest/lib/npm.js#L233-L248
- https://github.com/npm/cli/blob/latest/lib/commands/exec.js#L34-L38
- https://github.com/npm/cli/blob/latest/lib/commands/exec.js#L103

Which ultimately means that `vite` gets run in the wrong `cwd` and thus can't find the template / config.

I think arguably this is surprising behavior from `npm` / `npx`, but changing it would probably be a hard sell. Perhaps adding a flag to specify the `cwd` might be accepted?

Aside from this, personally I find the use of `npx` for this usecase to be a bit surprising - it's not clear to me how the dependency versions are being controlled.

#### Possible Solutions
- Change `npm` to allow specifying the `cwd` when running `npx` / `npm exec` in a project using workspaces
- Install all dependencies in project and run using `yarn vite` instead of `npx`
- Explicitly pass the template root directory to `vite`
  - this almost works, but `svelte-kit` overrides it / ignores it and ends up being unable to find anything
  - if it's possible to explicitly pass the template root to svelte-kit instead of relying on the `process.cwd()` that would probably be the cleanest way to solve this

I've seen everything work with the use `yarn` to run `vite` option, and these additional dependencies installed (which also solves all the missing `peerDependency` warnings I get from the sample project):
```
    "@evidence-dev/trino": "^1.0.8",
    "@sveltejs/kit": "2.5.4",
    "@sveltejs/vite-plugin-svelte": "^3.0.0",
    "autoprefixer": "^10.4.20",
    "debounce": "^1.2.1",
    "git-remote-origin-url": "^4.0.0",
    "postcss": "^8.4.49",
    "postcss-load-config": "^4.0.1",
    "svelte": "4.2.19",
    "svelte-preprocess": "5.1.3",
    "svelte2tsx": "0.7.4",
    "tailwindcss": "^3.4.15",
    "unist-util-visit": "4.1.2",
    "vite": "^5.4.11"
```

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
