### PR TITLE
Hash built parquet files

### DIFF
--- a/.changeset/large-tips-end.md
+++ b/.changeset/large-tips-end.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+hash parquet file paths after build

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -194,9 +194,9 @@ const buildHelper = function (command, args) {
 					for (let i = 0; i < files.length; i++) {
 						// <url prefix>/sqlite/transactions/transactions.parquet
 						//              ^^^^^^ ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^
-						const DISK_PARTS = 3;
+						const nDiskParts = 3;
 
-						const diskParts = files[i].split('/').slice(-DISK_PARTS).join('/');
+						const diskParts = files[i].split('/').slice(-nDiskParts).join('/');
 						const filePath = path.posix.join(buildDataDir, diskParts);
 						if (!fs.existsSync(filePath)) continue;
 
@@ -256,8 +256,8 @@ prog
 ${chalk.bold('[!] Unable to load source manifest')}
 	This likely means you have no source data, and need to generate it.
 	Running ${chalk.bold('npm run sources')} will generate the needed data. See ${chalk.bold(
-		'npm run sources --help'
-	)} for more usage information
+						'npm run sources --help'
+					)} for more usage information
 	Documentation: https://docs.evidence.dev/core-concepts/data-sources/
 		`.trim()
 				)

--- a/packages/evidence/cli.js
+++ b/packages/evidence/cli.js
@@ -256,8 +256,8 @@ prog
 ${chalk.bold('[!] Unable to load source manifest')}
 	This likely means you have no source data, and need to generate it.
 	Running ${chalk.bold('npm run sources')} will generate the needed data. See ${chalk.bold(
-						'npm run sources --help'
-					)} for more usage information
+		'npm run sources --help'
+	)} for more usage information
 	Documentation: https://docs.evidence.dev/core-concepts/data-sources/
 		`.trim()
 				)


### PR DESCRIPTION
### Description

Hashes parquet files when projects are built via the evidence cli

The logic here is a bit weird to try to align w/ the `process.env.EVIDENCE_DATA_DIR` and `process.env.EVIDENCE_DATA_URL_PREFIX` env vars

The main sketchy part is the `static` directory "disappearing" when static is copied into the build directory, and since we want to(?) allow custom `static` directory naming (via `svelte.config.js`), it's hard to determine the location of `manifest.json` (though its location is hardcoded as `./static/data/manifest.json` in some places which is a whole other problem)

I think if we officially decide you can't have a custom static directory location it can be simplified more (but then I have more complaints about `process.env.EVIDENCE_DATA_DIR` and `process.env.EVIDENCE_DATA_URL_PREFIX`

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)