### PR TITLE
fix: sparkline tooltip uses theme

### DIFF
--- a/.changeset/lucky-walls-scream.md
+++ b/.changeset/lucky-walls-scream.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Sparkline tooltip theming

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
@@ -44,8 +44,6 @@
 	let staticSVGSSR;
 	let error;
 
-	let tooltipBackgroundColor = 'white';
-
 	// Initialize chart for interactive mode
 	function initializeChart() {
 		if (interactive && chartContainer && !chartInstance) {
@@ -119,7 +117,6 @@
 			value_format_object,
 			date_format_object,
 			height,
-			tooltipBackgroundColor,
 			$theme
 		);
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
@@ -84,7 +84,6 @@ export function getSparklineConfig(
 	value_format_object,
 	date_format_object,
 	height,
-	tooltipBackgroundColor,
 	theme
 ) {
 	return {
@@ -105,7 +104,7 @@ export function getSparklineConfig(
 				// Assuming params[0] is your primary data point
 				const dataPoint = params[0];
 				// Customize these HTML blocks as needed
-				const valuePart = `<div style="text-align: center; background-color: ${tooltipBackgroundColor}; border-radius: 1px; padding: 0px 2px; height: 12px;">${formatValue(
+				const valuePart = `<div style="text-align: center; background-color: ${theme.colors['base-200']}; border-radius: 1px; padding: 0px 2px;">${formatValue(
 					dataPoint.value[1],
 					value_format_object
 				)}</div>`;


### PR DESCRIPTION
### Description

Before:
![image](https://github.com/user-attachments/assets/8094e55d-8917-4a34-b652-5c21169ef57e)

After:
![image](https://github.com/user-attachments/assets/0168d41f-c69e-4e9a-a7ef-aa59d3cac745)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- ~~[ ] I have added to the docs where applicable~~
- ~~[ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
