### PR TITLE
Fix virtual source configs

### DIFF
--- a/.changeset/clever-avocados-punch.md
+++ b/.changeset/clever-avocados-punch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/sdk': patch
+---
+
+fix virtual/references fields in datasource plugin schemas

--- a/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.js
+++ b/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.js
@@ -245,8 +245,8 @@ export const getSpecAtPath = (options, optionPath) => {
 
 	const out = x[OptionGetSpec]
 		? x[OptionGetSpec][
-		finalKey
-		] /* Option is a parent, so we need to look at the parent's spec @ this value */
+				finalKey
+			] /* Option is a parent, so we need to look at the parent's spec @ this value */
 		: x[finalKey]; /* Option is not a parent, so we can look at it's spec directly */
 
 	return out;

--- a/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.js
+++ b/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.js
@@ -68,6 +68,7 @@ export const Options = (spec, sourceOptions, opts) => {
 		ownKeys() {
 			const output = [];
 			for (const [specKey, specEntry] of Object.entries(spec)) {
+				if (specEntry.virtual) continue;
 				const valueKey = specEntry.children && specEntry.nest ? `_${specKey}` : specKey;
 				if (
 					!opts?.specMode /* Value Mode */ &&
@@ -244,8 +245,8 @@ export const getSpecAtPath = (options, optionPath) => {
 
 	const out = x[OptionGetSpec]
 		? x[OptionGetSpec][
-				finalKey
-			] /* Option is a parent, so we need to look at the parent's spec @ this value */
+		finalKey
+		] /* Option is a parent, so we need to look at the parent's spec @ this value */
 		: x[finalKey]; /* Option is not a parent, so we can look at it's spec directly */
 
 	return out;

--- a/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.spec.js
+++ b/packages/lib/sdk/src/plugins/datasources/cli/edit/Options.spec.js
@@ -59,6 +59,103 @@ const testSpec = {
 	}
 };
 
+const complexSpec = {
+	project_id: {
+		title: 'Project ID',
+		type: 'string',
+		secret: true,
+		virtual: false,
+		references: '$.keyfile.project_id',
+		forceReference: false,
+		required: true
+	},
+	location: {
+		title: 'Location (Region)',
+		type: 'string',
+		secret: false,
+		virtual: false,
+		forceReference: false,
+		required: false,
+		default: 'US'
+	},
+	authenticator: {
+		title: 'Authentication Method',
+		type: 'select',
+		secret: false,
+		virtual: false,
+		forceReference: false,
+		children: {
+			'service-account': {
+				keyfile: {
+					title: 'Credentials File',
+					type: 'file',
+					secret: false,
+					virtual: true,
+					forceReference: false,
+					fileFormat: 'json',
+					required: false
+				},
+				client_email: {
+					title: 'Client Email',
+					type: 'string',
+					secret: true,
+					virtual: false,
+					references: '$.keyfile.client_email',
+					forceReference: true,
+					required: true
+				},
+				private_key: {
+					title: 'Private Key',
+					type: 'string',
+					secret: true,
+					virtual: false,
+					references: '$.keyfile.private_key',
+					forceReference: true,
+					required: true
+				}
+			},
+			'gcloud-cli': {},
+			oauth: {
+				token: {
+					title: 'Token',
+					type: 'string',
+					secret: true,
+					virtual: false,
+					forceReference: false,
+					required: true
+				}
+			}
+		},
+		required: true,
+		options: [
+			{ value: 'service-account', label: 'Service Account' },
+			{ value: 'gcloud-cli', label: 'GCloud CLI' },
+			{ value: 'oauth', label: 'OAuth Access Token' }
+		],
+		nest: false,
+		default: 'service-account'
+	}
+};
+const complexOpts = {
+	location: 'US',
+	authenticator: 'service-account',
+	project_id: 'deadbeef-project',
+	keyfile: {
+		type: 'service_account',
+		project_id: 'deadbeef-project',
+		private_key_id: 'deadbeef',
+		private_key: 'my private key',
+		client_email: 'client@email.com',
+		client_id: '42',
+		auth_uri: 'https://evidence.dev',
+		token_uri: 'https://evidence.dev',
+		auth_provider_x509_cert_url: 'https://evidence.dev',
+		client_x509_cert_url: 'https://evidence.dev'
+	},
+	client_email: 'https://evidence.dev',
+	private_key: 'my private key'
+};
+
 describe('Options', () => {
 	describe('get', () => {
 		describe('root-level', () => {
@@ -294,6 +391,18 @@ describe('getSecretOptions', () => {
 		expect(secrets.unnested).toBeUndefined();
 		expect(secrets).toEqual({ _secret: 'Hi!' });
 	});
+
+	it('should ignore virtual fields', () => {
+		const options = Options(complexSpec, complexOpts);
+
+		const secrets = getSecretOptions(options);
+
+		expect(secrets).toEqual({
+			client_email: 'https://evidence.dev',
+			private_key: 'my private key',
+			project_id: 'deadbeef-project'
+		});
+	});
 });
 describe('getSafeOptions', () => {
 	it('should return safe values', () => {
@@ -340,6 +449,14 @@ describe('getSafeOptions', () => {
 		expect(safes._opt).toEqual('Bye!');
 		expect(safes.unnested).toEqual('a');
 		expect(safes).toEqual({ _opt: 'Bye!', unnested: 'a' });
+	});
+
+	it('should ignore virtual fields', () => {
+		const options = Options(complexSpec, complexOpts);
+
+		const safes = getSafeOptions(options);
+
+		expect(safes).toEqual({ authenticator: 'service-account', location: 'US' });
 	});
 });
 

--- a/sites/example-project/src/pages/settings/+page.server.js
+++ b/sites/example-project/src/pages/settings/+page.server.js
@@ -10,6 +10,7 @@ import {
 	getDatasourceConfigAsEnvironmentVariables
 } from '@evidence-dev/sdk/plugins';
 import { isDebug } from '@evidence-dev/sdk/utils';
+import { log } from '@evidence-dev/sdk/logger';
 
 export const load = async () => {
 	if (dev) {
@@ -64,10 +65,8 @@ export const actions = {
 				updatedSource: await writeSourceConfig(opts, source)
 			};
 		} catch (e) {
-			if (isDebug()) {
-				console.error(e);
-				if (e.stack) console.error(e.stack);
-			}
+			log.debug(`error updating sources: ${e}`);
+			if (e.stack) log.debug(e.stack);
 			return fail(500, e.message);
 		}
 	},

--- a/sites/example-project/src/pages/settings/+page.server.js
+++ b/sites/example-project/src/pages/settings/+page.server.js
@@ -9,6 +9,7 @@ import {
 	writeSourceConfig,
 	getDatasourceConfigAsEnvironmentVariables
 } from '@evidence-dev/sdk/plugins';
+import { isDebug } from '@evidence-dev/sdk/utils';
 
 export const load = async () => {
 	if (dev) {
@@ -63,6 +64,10 @@ export const actions = {
 				updatedSource: await writeSourceConfig(opts, source)
 			};
 		} catch (e) {
+			if (isDebug()) {
+				console.error(e);
+				if (e.stack) console.error(e.stack);
+			}
 			return fail(500, e.message);
 		}
 	},

--- a/sites/example-project/src/pages/settings/+page.server.js
+++ b/sites/example-project/src/pages/settings/+page.server.js
@@ -64,7 +64,7 @@ export const actions = {
 				updatedSource: await writeSourceConfig(opts, source)
 			};
 		} catch (e) {
-			log.debug(`error updating sources: ${e}`, {error: e});
+			log.debug(`error updating sources: ${e}`, { error: e });
 			return fail(500, e.message);
 		}
 	},

--- a/sites/example-project/src/pages/settings/+page.server.js
+++ b/sites/example-project/src/pages/settings/+page.server.js
@@ -9,7 +9,6 @@ import {
 	writeSourceConfig,
 	getDatasourceConfigAsEnvironmentVariables
 } from '@evidence-dev/sdk/plugins';
-import { isDebug } from '@evidence-dev/sdk/utils';
 import { log } from '@evidence-dev/sdk/logger';
 
 export const load = async () => {

--- a/sites/example-project/src/pages/settings/+page.server.js
+++ b/sites/example-project/src/pages/settings/+page.server.js
@@ -64,8 +64,7 @@ export const actions = {
 				updatedSource: await writeSourceConfig(opts, source)
 			};
 		} catch (e) {
-			log.debug(`error updating sources: ${e}`);
-			if (e.stack) log.debug(e.stack);
+			log.debug(`error updating sources: ${e}`, {error: e});
 			return fail(500, e.message);
 		}
 	},


### PR DESCRIPTION
### Description

fixes datasources that use virtual/references, adds tests, logs info when source updating errors in debug mode

not totally sure this is the proper fix, still not 100% sure of what `Options.ownKeys` semantically represents (I'm understanding it as the keys of the given options that have materialized values in the schema? Or something like that)

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)