### PR TITLE
Last 365 days preset in DateRange

### DIFF
--- a/.changeset/lazy-days-cheer.md
+++ b/.changeset/lazy-days-cheer.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Adds a 'Last 365 days' option to defaultValues

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.stories.svelte
@@ -14,19 +14,13 @@
 <script>
 	import { Template, Story } from '@storybook/addon-svelte-csf';
 	import DateRange from './DateRange.svelte';
-	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
-	// From layout.js
-	const inputStore = getInputContext();
 	// Mock "today"
 	import MockDate from 'mockdate';
 	MockDate.set('2024-06-19');
 </script>
 
 <Template let:args>
-	<DateRange {...args} name="date_range" />
-
-	<p>State:</p>
-	{JSON.stringify($inputStore.date_range)}
+	<DateRange {...args} />
 </Template>
 
 <Story name="Basic Usage" let:args>

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.stories.svelte
@@ -14,14 +14,19 @@
 <script>
 	import { Template, Story } from '@storybook/addon-svelte-csf';
 	import DateRange from './DateRange.svelte';
-
+	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
+	// From layout.js
+	const inputStore = getInputContext();
 	// Mock "today"
 	import MockDate from 'mockdate';
 	MockDate.set('2024-06-19');
 </script>
 
 <Template let:args>
-	<DateRange {...args} />
+	<DateRange {...args} name="date_range" />
+
+	<p>State:</p>
+	{JSON.stringify($inputStore.date_range)}
 </Template>
 
 <Story name="Basic Usage" let:args>
@@ -41,3 +46,8 @@
 />
 
 <Story name="Default Value" args={{ defaultValue: 'last Month' }} />
+
+<Story
+	name="Last 365 Days"
+	args={{ presetRanges: ['Last 7 Days', 'Last 30 Days', 'Last 90 Days', 'Last 365 Days'] }}
+/>

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/_DateRange.svelte
@@ -67,6 +67,14 @@
 			}
 		},
 		{
+			label: 'Last 365 Days',
+			group: 'Days',
+			range: {
+				start: calendarEnd.subtract({ days: 364 }),
+				end: calendarEnd
+			}
+		},
+		{
 			label: 'Last 3 Months',
 			group: 'Months',
 			range: {

--- a/sites/docs/pages/components/date-range/index.md
+++ b/sites/docs/pages/components/date-range/index.md
@@ -254,7 +254,7 @@ Title to display in the Date Range component
     default=undefined
 >
 
-Customize "Select a Range" drop down, by including present range options. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
+Customize "Select a Range" drop down, by including present range options. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
 
 </PropListing>
 <PropListing 
@@ -264,7 +264,7 @@ Customize "Select a Range" drop down, by including present range options. **Rang
 >
 
 
-Accepts preset in string format to apply default value in Date Range picker. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
+Accepts preset in string format to apply default value in Date Range picker. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
 
 </PropListing>
 <PropListing 


### PR DESCRIPTION
### Description

Adds a **Last 365 days** option to the preset ranges in DateRange

| Before | After |
|--|--|
| ![CleanShot 2024-12-16 at 13 59 38@2x](https://github.com/user-attachments/assets/caeca0e2-0f6c-439d-944b-4951f7e557f7) | ![CleanShot 2024-12-16 at 13 57 13@2x](https://github.com/user-attachments/assets/7882b5be-485e-42e5-b7f9-dc9f4afd1310) |


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
