### PR TITLE
run mac and windows tests on non-main PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,13 +32,7 @@ jobs:
           - ${{ github.base_ref == 'main' }}
         exclude:
           - isMain: false
-            node-version: 18
-          - isMain: false
             node-version: 20
-          - isMain: false
-            os: macOS-latest
-          - isMain: false
-            os: windows-latest
 
     name: e2e/${{ matrix.project }}/${{ matrix.os }}/node-${{ matrix.node-version}}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,7 @@ jobs:
           - ${{ github.base_ref == 'main' }}
         exclude:
           - isMain: false
-            node-version: 18
-          - isMain: false
             node-version: 20
-          - isMain: false
-            os: macOS-latest
 
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
### Description

Re-adds the windows/mac tests on e2e, mac on non-e2e tests

also removes node-version 18 exclusions because they aren't used anymore (and we also want them to run for the same reason we're re-adding the windows/mac tests)

could also remove node 20 from the next branch exclusion at this point