### PR TITLE
Docs: Remove Evidence Labs

### DIFF
--- a/sites/docs/pages/components/custom-components/index.md
+++ b/sites/docs/pages/components/custom-components/index.md
@@ -7,11 +7,9 @@ Custom components allow you to extend the functionality of Evidence, as well as 
 
 In Evidence, you can build your own components and use them anywhere in your app. This is made possible through Svelte, the JavaScript framework Evidence is built on. These components can include the charts used for visualization, custom components created completely from scratch, or adaptations of existing UI components such as the header, sidebar, menu, etc.
 
-[Evidence Labs](https://labs.evidence.dev) contains several good examples of custom components.
-
 Below is a **short guide** on building a simple component in Evidence.
 
-For a fuller guide, Svelte offers a really great interactive tutorial that you can complete in your browser in about an hour: [Svelte Tutorial](https://svelte.dev/tutorial/basics)
+For a fuller guide, Svelte offers a great interactive tutorial that you can complete in your browser in about an hour: [Svelte Tutorial](https://svelte.dev/tutorial/basics)
 
 <Alert status=info>
 
@@ -19,7 +17,7 @@ For a fuller guide, Svelte offers a really great interactive tutorial that you c
 
 Let us know in our [Slack community](https://slack.evidence.dev)!
 
-We'd love to see what you've built, and may add generally applicable components to Evidence Labs, or the Evidence component library!
+We'd love to see what you've built, and may add generally applicable components to the Evidence core component library!
 
 </Alert>
 

--- a/sites/docs/pages/guides/usql-migration-guide/index.md
+++ b/sites/docs/pages/guides/usql-migration-guide/index.md
@@ -268,12 +268,12 @@ This means that any query chains included in `sources` will need to be replaced 
 If you use the VS Code migration command, chained queries found on markdown pages are left on the page rather than being moved to the `sources` directory like other queries. This is because we assume that most chained queries are simple enough for the syntax of your source database to match with the DuckDB syntax they will need to move to. In some cases, the syntax will not line up and you will need to make an adjustment.
 
 ### Evidence Plugins
-If your app includes an Evidence plugin (e.g., [Evidence Labs](https://labs.evidence.dev)):
+If your app includes an Evidence plugin
 1. Find the `evidence.plugins.yaml` file in your `_legacy_project` folder and copy the line(s) containing the plugin(s) you're using
 2. Paste those lines into the `evidence.plugins.yaml` file in your new project
 3. Install the plugin(s) in your project. E.g.,:
 ```shell
-npm install --save @evidence-dev/labs
+npm install --save your-plugin-name
 ```
 
 ### External Package Dependencies

--- a/sites/docs/pages/plugins/create-component-plugin/index.md
+++ b/sites/docs/pages/plugins/create-component-plugin/index.md
@@ -6,7 +6,14 @@ sidebar_position: 3
 
 You can build a component plugin to publish your own custom components, or to make existing open source component libraries easily available for Evidence users.
 
-The easiest way to get started is from the example component library [**on GitHub**](https://github.com/evidence-dev/labs), with a live demo of the components [here](https://labs.evidence.dev).
+
+<Alert status=warning>
+
+Evidence Labs is deprecated and should not be used as a plugin in your Evidence app. This section of the documentation will be updated in the future. 
+
+</Alert>
+
+An example component library [Evidence Labs](https://github.com/evidence-dev/labs) is available on GitHub, with a live demo of the components [here](https://labs.evidence.dev).
 
 ## Basic Steps
 1. Clone the [Evidence Labs example repo](https://github.com/evidence-dev/labs)
@@ -24,7 +31,7 @@ The easiest way to get started is from the example component library [**on GitHu
 
 Plugins must "export" their components to make them available to your Evidence apps.
 
-There are 2 ways to set up component exporting in your plugin:
+There are two ways to set up component exporting in your plugin:
 1. [Module Exports](#module-exports) (recommended)
 2. [Manifest](#manifest) - this method can be used in cases when a large component library already exists
 


### PR DESCRIPTION
### Description

Evidence labs is deprecated and so should be removed from the docs

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
