### PR TITLE
Fix page query HMR

### DIFF
--- a/.changeset/blue-sloths-sort.md
+++ b/.changeset/blue-sloths-sort.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/preprocess': patch
+---
+
+fix query HMR

--- a/e2e/hmr/tests/tests.spec.js
+++ b/e2e/hmr/tests/tests.spec.js
@@ -89,7 +89,7 @@ test.describe('error handling', () => {
 
 test.describe('page query HMR', () => {
 	test('editing should HMR', async ({ page }) => {
-		const query0 = "select * from orders;";
+		const query0 = 'select * from orders;';
 
 		await page.goto('/orders');
 		// hard reload page for queries to SSR
@@ -99,12 +99,12 @@ test.describe('page query HMR', () => {
 
 		await expect(page.getByText('Loaded 10000 orders')).toBeVisible();
 
-		const query1 = "select * from orders LIMIT 500;";
+		const query1 = 'select * from orders LIMIT 500;';
 		editFile('pages/orders.md', (content) => content.replace(query0, query1));
 		await waitForHMR(page);
 		await expect(page.getByText('Loaded 500 orders')).toBeVisible();
 
-		const query2 = "select * from orders LIMIT 100;";
+		const query2 = 'select * from orders LIMIT 100;';
 		editFile('pages/orders.md', (content) => content.replace(query1, query2));
 		await waitForHMR(page);
 		await expect(page.getByText('Loaded 100 orders')).toBeVisible();

--- a/e2e/hmr/tests/tests.spec.js
+++ b/e2e/hmr/tests/tests.spec.js
@@ -86,3 +86,31 @@ test.describe('error handling', () => {
 		await expect(page.getByText('"new" cannot be used as a query name')).toBeVisible();
 	});
 });
+
+test.describe('page query HMR', () => {
+	test('editing should HMR', async ({ page }) => {
+		const query0 = "select * from orders;";
+
+		await page.goto('/orders');
+		// hard reload page for queries to SSR
+		await page.reload();
+
+		await waitForPageToLoad(page);
+
+		await expect(page.getByText('Loaded 10000 orders')).toBeVisible();
+
+		const query1 = "select * from orders LIMIT 500;";
+		editFile('pages/orders.md', (content) => content.replace(query0, query1));
+		await waitForHMR(page);
+		await expect(page.getByText('Loaded 500 orders')).toBeVisible();
+
+		const query2 = "select * from orders LIMIT 100;";
+		editFile('pages/orders.md', (content) => content.replace(query1, query2));
+		await waitForHMR(page);
+		await expect(page.getByText('Loaded 100 orders')).toBeVisible();
+
+		editFile('pages/orders.md', (content) => content.replace(query2, query0));
+		await waitForHMR(page);
+		await expect(page.getByText('Loaded 10000 orders')).toBeVisible();
+	});
+});

--- a/packages/lib/preprocess/src/process-queries.cjs
+++ b/packages/lib/preprocess/src/process-queries.cjs
@@ -64,6 +64,11 @@ const createDefaultProps = function (filename, componentDevelopmentMode, duckdbQ
 			return `
                 // Update external queries
                 if (import.meta?.hot) {
+					import.meta.hot.on("vite:beforeUpdate", () => {
+						// remove all prerendered queries
+						delete props.data;
+					});
+
                     import.meta.hot.on("evidence:queryChange", ({queryId, content}) => {
                         let errors = []
                         if (!queryId) errors.push("Malformed event: Missing queryId")


### PR DESCRIPTION
### Description

Fixes #2926 

Deletes prerendered queries on HMR so nothing leaks through from edited queries

We could implement some level of caching so non-edited queries aren't deleted, not sure if it's worth the added complexity or not

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)