### PR TITLE
Fix full null date column source gen

### DIFF
--- a/.changeset/five-bottles-worry.md
+++ b/.changeset/five-bottles-worry.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/universal-sql': patch
+---
+
+workaround bug in duckdb-wasm that errors when fully null date column is read as parquet

--- a/packages/lib/universal-sql/src/build-parquet.js
+++ b/packages/lib/universal-sql/src/build-parquet.js
@@ -34,6 +34,17 @@ function convertArrayToVector(column, rawValues) {
 		case 'string':
 			return vectorFromArray(rawValues, new Utf8());
 		case 'date':
+			if (!rawValues.some((v) => v !== null)) {
+				// All null date columns error out, so we have to do this
+				// https://github.com/evidence-dev/evidence/issues/2897
+				// separate reason than the bool version
+				console.warn(
+					chalk.yellow(
+						`\nWarning: Column "${column.name}" (type Date) contains only null values so it has been cast to Float64`
+					)
+				);
+				return vectorFromArray(rawValues, new Float64());
+			}
 			// TODO: What gives with timezones
 			return vectorFromArray(rawValues, new TimestampMillisecond());
 		case 'boolean':

--- a/sites/test-env/pages/nullish-dates.md
+++ b/sites/test-env/pages/nullish-dates.md
@@ -1,0 +1,14 @@
+<script>
+	$: if (nully.loaded) {
+		console.log([...nully])
+		if (nully[0].from_canada !== true) throw new Error('from_canada should be true');
+		if (nully[1].from_canada !== true) throw new Error('from_canada should be true');
+		if (nully[2].from_canada !== false) throw new Error('from_canada should be false');
+	}
+</script>
+
+```nully
+SELECT * FROM nullish_dates
+```
+
+<DataTable data={nully} />

--- a/sites/test-env/sources/needful_things/nullish_dates.sql
+++ b/sites/test-env/sources/needful_things/nullish_dates.sql
@@ -1,0 +1,6 @@
+select null::date as country, 100 as sales, true as from_canada
+union all 
+select null::date as country, 200 as sales, true as from_canada
+union all 
+select null::date as country, 300 as sales, false as from_canada
+order by sales


### PR DESCRIPTION
### Description

Fixes #2897

Originates from https://github.com/duckdb/duckdb/pull/14268, so we can remove this workaround when a new stable version of duckdb-wasm is released (it's fixed in [1.29.1-dev17.0](https://www.npmjs.com/package/@duckdb/duckdb-wasm/v/1.29.1-dev17.0))

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)