### PR TITLE
Component styling changes for consistency

### DIFF
--- a/.changeset/wise-papayas-clap.md
+++ b/.changeset/wise-papayas-clap.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Styling changes for consistency

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -102,15 +102,17 @@
 {:else}
 	<HiddenInPrint enabled={hideDuringPrint}>
 		<div
-			class={display === 'tabs' ? '' : 'inline-flex w-fit max-w-full flex-col mt-2 mb-4 ml-0 mr-2'}
+			class={display === 'tabs'
+				? ''
+				: `inline-block overflow-scroll no-scrollbar align-bottom w-fit max-w-full flex-col mb-3 ml-0 mr-2`}
 		>
 			{#if title}
-				<span class="text-sm block mb-1">{title}</span>
+				<span class="text-xs font-medium block mb-0.5">{title}</span>
 			{/if}
 			<div
 				class={display === 'tabs'
 					? 'my-6 flex flex-wrap gap-x-1 gap-y-1'
-					: 'inline-flex rounded-md shadow-sm shadow-base-100 overflow-auto h-8 border border-base-300 no-scrollbar'}
+					: 'inline-flex rounded-md shadow-sm mb-1 overflow-auto border border-base-300 no-scrollbar h-8'}
 				role="group"
 			>
 				{#if preset}

--- a/packages/ui/core-components/src/lib/atoms/inputs/checkbox/Checkbox.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/checkbox/Checkbox.svelte
@@ -34,7 +34,7 @@
 		on:click={() => ($inputs[name] = !$inputs[name])}
 		variant="outline"
 		size="sm"
-		class="min-w-40 inline-flex justify-between gap-4 items-center w-full max-w-fit mb-2"
+		class="min-w-40 inline-flex justify-between gap-4 items-center w-full max-w-fit mb-4 mr-2"
 	>
 		<p class="truncate font-medium">
 			{title}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
@@ -89,9 +89,9 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
+	<div class="mb-4 ml-0 mr-2 inline-block">
 		{#if title}
-			<span class="text-sm text-base-content block mb-1">{title}</span>
+			<span class="text-xs font-medium text-base-content block mb-0.5">{title}</span>
 		{/if}
 
 		{#if $query?.error}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -209,7 +209,7 @@
 {/each}
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
+	<div class="mb-4 ml-0 mr-2 inline-block">
 		{#if hasQuery && $query.error}
 			<span
 				class="group inline-flex items-center relative cursor-help cursor-helpfont-sans px-1 border border-negative py-[1px] bg-negative/10 rounded"

--- a/packages/ui/core-components/src/lib/atoms/inputs/slider/_Slider.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/slider/_Slider.svelte
@@ -164,8 +164,10 @@
 <HiddenInPrint enabled={hideDuringPrint}>
 	<div class={`relative ${sizeClass} mb-10 select-none`}>
 		<p class="pb-2 truncate text-xs">
-			{title} :
-			<span class="text-xs">{fmt ? formatValue($inputs[name], format_object) : $inputs[name]}</span>
+			<span class="font-medium">{title}: </span>
+			<span class="text-xs">
+				{fmt ? formatValue($inputs[name], format_object) : $inputs[name]}</span
+			>
 		</p>
 		<SliderShadcn {min} {max} {step} {sizeClass} bind:value />
 		{#if showMaxMin}

--- a/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
@@ -58,13 +58,13 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
+	<div class="mb-4 ml-0 mr-2 inline-block align-bottom">
 		{#if title}
-			<span class="text-sm block mb-1">{title}</span>
+			<span class="text-xs font-medium block mb-0.5">{title}</span>
 		{/if}
 		<input
 			bind:value
-			class="font-medium border border-base-300 bg-base-100 p-1 mt-2 pr-5 h-8 rounded-md px-3 sm:text-xs flex flex-row items-center max-w-fit bg-transparent cursor-text bg-right bg-no-repeat focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-content-muted shadow-sm text-base"
+			class="font-medium border pb-1 pt-[3px] h-8 border-base-300 bg-base-100 pr-3 rounded-md px-2 sm:text-xs max-w-fit bg-transparent cursor-text bg-right bg-no-repeat focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-content-muted shadow-sm text-base placeholder:font-normal placeholder:text-base-content-muted/80"
 			{placeholder}
 		/>
 	</div>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
@@ -111,14 +111,16 @@
 
 <!-- {dimensionCutQuery} -->
 
-<div class="w-60 flex-shrink-0 sm:w-1/4 text-sm antialiased pr-4 pb-4 overflow-clip">
+<div class="w-60 flex-shrink-0 sm:w-1/4 text-xs antialiased pr-4 pb-4 overflow-clip">
 	<div class="capitalize border-b flex justify-between items-baseline">
-		<span class="truncate w-2/3">
+		<span class={`truncate pl-1 font-semibold ${metricLabel ? 'w-2/3' : ''}`}>
 			{formatTitle(dimension.column_name)}
 		</span>
-		<span class="truncate w-1/3 text-right">
-			{metricLabel ?? ''}
-		</span>
+		{#if metricLabel}
+			<span class="truncate w-1/3 text-right font-semibold">
+				{metricLabel ?? ''}
+			</span>
+		{/if}
 	</div>
 	<QueryLoad data={results} let:loaded>
 		<Alert slot="error" status="negative">

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionRow.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionRow.svelte
@@ -14,7 +14,7 @@
 	<!-- Bar -->
 	<div
 		class={cn(
-			'group-hover:bg-primary/30 dark:group-hover:bg-primary/40 bg-base-100 absolute inset-y-0 left-0 z-[-10] transition-colors w-full',
+			'group-hover:bg-primary/15 dark:group-hover:bg-primary/40 bg-base-100 absolute inset-y-0 left-0 z-[-10] transition-colors w-full',
 			{
 				'bg-base-200': isSelected
 			}
@@ -22,7 +22,7 @@
 	/>
 	<div
 		class={cn(
-			'bg-primary/20 dark:bg-primary/30 group-hover:bg-primary/30 dark:group-hover:bg-primary/40 absolute inset-y-0 left-0 z-[-10]',
+			'bg-primary/10 dark:bg-primary/30 group-hover:bg-primary/15 dark:group-hover:bg-primary/40 absolute inset-y-0 left-0 z-[-10]',
 			{
 				// undefined occurs in multi-selects where the user has selected mutually exclusive options (see null row column combination story)
 				'bg-base-300': row.metric === undefined
@@ -32,7 +32,7 @@
 				'bg-transparent': row.metric === null
 			},
 			{
-				'bg-primary/50 dark:bg-primary/60 text-primary-content': row.metric && isSelected
+				'bg-primary/30 dark:bg-primary/60 text-primary-content': row.metric && isSelected
 			}
 		)}
 		style={row.metric
@@ -45,7 +45,7 @@
 
 	<span
 		class={cn(
-			'truncate transition-colors',
+			'truncate transition-colors pl-1',
 			{
 				'font-medium': isSelected
 			},
@@ -56,7 +56,7 @@
 	>
 		{row.dimensionValue ?? 'Missing'}
 	</span>
-	<span class="tabular-nums">
+	<span class="tabular-nums pr-1">
 		{#if row.metric}
 			{formattedValue}
 		{:else}

--- a/packages/ui/core-components/src/lib/unsorted/ui/BigLink.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/BigLink.stories.svelte
@@ -12,5 +12,5 @@
 </script>
 
 <Story name="Base">
-	<BigLink href={'https://evidence.dev/'}>Best Website Ever</BigLink>
+	<BigLink href={'https://evidence.dev/'}>Next: Deep Dive on Metrics &rarr;</BigLink>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/ui/BigLink.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/BigLink.svelte
@@ -4,37 +4,22 @@
 
 <script>
 	import { addBasePath } from '@evidence-dev/sdk/utils/svelte';
-	export let href;
+	export let href; // to be deprecated in favor of url
+	export let url;
 </script>
 
-<a href={addBasePath(href)}>
-	<div>
-		<span>
-			<slot />
-		</span>
-	</div>
-</a>
-
-<style lang="postcss">
-	div {
-		@apply border border-base-300 hover:shadow-md shadow-base-100;
-		border-radius: 6px;
-		padding: 0.3em 0.6em;
-		font-family: var(--ui-font-family);
-		font-size: 0.8em;
-		margin-top: 1em;
-		margin-bottom: 1.25em;
-		cursor: pointer;
-		transition: all 400ms;
-	}
-
-	a {
-		text-decoration: none;
-		color: var(--primary);
-	}
-
-	a:hover {
-		text-decoration: none;
-		filter: brightness(80%);
-	}
-</style>
+<div class="flex w-full max-w-full flex-col mt-2 mb-4 ml-0 mr-0">
+	<a
+		href={addBasePath(url ?? href)}
+		class="rounded-md shadow-sm overflow-hidden h-8 border
+	flex items-center py-1 font-medium px-3 text-xs text-primary truncate
+ border-base-300
+hover:bg-base-200 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-300 z-0 bg-base-100"
+	>
+		<div class="w-full">
+			<span>
+				<slot />
+			</span>
+		</div>
+	</a>
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.stories.svelte
@@ -13,4 +13,5 @@
 
 <Story name="Base">
 	<LinkButton url={'https://evidence.dev/'}>Best Website Ever</LinkButton>
+	<LinkButton url={'https://evidence.dev/'}>Best Website Ever</LinkButton>
 </Story>

--- a/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/LinkButton.svelte
@@ -7,13 +7,18 @@
 	export let url;
 </script>
 
-<a
-	href={addBasePath(url)}
-	class="font-ui font-normal text-base no-underline border border-info/20 bg-info/10 my-5 rounded-lg py-2 px-3 inline-block transition hover:ease-in hover:border-info/50 hover:bg-info/20 hover:no-underline focus:border-info"
->
-	<div>
-		<span>
-			<slot />
-		</span>
-	</div>
-</a>
+<div class="inline-flex w-fit max-w-full flex-col mt-2 mb-4 ml-0 mr-2">
+	<a
+		href={addBasePath(url)}
+		class="rounded-md shadow-sm overflow-auto h-8 border
+	flex items-center py-1 font-medium px-3 text-xs truncate
+ border-base-300
+hover:bg-base-200 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-300 z-0 bg-base-100"
+	>
+		<div>
+			<span>
+				<slot />
+			</span>
+		</div>
+	</a>
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Modal.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Modal.stories.svelte
@@ -1,0 +1,24 @@
+<script context="module">
+	/** @type {import("@storybook/svelte").Meta}*/
+	export const meta = {
+		title: 'ui/Modal'
+	};
+</script>
+
+<script>
+	import { Story } from '@storybook/addon-svelte-csf';
+
+	import Modal from './Modal.svelte';
+</script>
+
+<Story name="Base">
+	<Modal buttonText="Click to open modal" title="Title"
+		>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+		labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+		laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+		voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+		non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+		sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+		magna aliqua.</Modal
+	>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Modal.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Modal.svelte
@@ -7,40 +7,61 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { createEventDispatcher } from 'svelte';
 	const dispatch = createEventDispatcher();
+
 	export let open = false;
 	export let title = '';
 	export let buttonText = '';
 	export let innerText = '';
+
+	let closing = false;
+
 	const isOpen = () => {
-		open = !open;
-		if (!open) dispatch('close');
+		if (open) {
+			closing = true;
+			setTimeout(() => {
+				closing = false;
+				open = false;
+				dispatch('close');
+			}, 150); // Set duration to slightly shorter than exit animation
+		} else {
+			open = true;
+		}
 	};
 </script>
 
-<button
-	on:click={() => isOpen()}
-	class="font-ui font-normal text-base no-underline border border-info/20 bg-info/10 my-5 rounded-lg py-2 px-3 inline-block transition hover:ease-in hover:border-info/50 hover:bg-info/20 hover:no-underline focus:border-info"
->
-	{buttonText}
-</button>
-{#if open}
-	<div class="modal z-50 fixed w-full h-full top-0 left-0 flex items-center justify-center lg:p-0">
+<div class="inline-flex w-fit max-w-full flex-col mt-2 mb-4 ml-0 mr-2">
+	<button
+		on:click={() => isOpen()}
+		class="rounded-md shadow-sm overflow-auto h-8 border
+		flex-none py-1 font-medium px-3 text-xs truncate
+		border-base-300
+		hover:bg-base-200 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-300 z-0 bg-base-100"
+	>
+		{buttonText}
+	</button>
+</div>
+{#if open || closing}
+	<div
+		class="modal z-50 fixed w-full h-full top-0 left-0 flex items-center justify-center lg:p-0 {closing
+			? 'modal-exit'
+			: 'modal-enter'}"
+	>
 		<div class="fixed inset-0 bg-base-100/70" />
 		<div
-			class="bg-base-100 w-4/5 max-w-lg mx-auto rounded-lg shadow-xl z-50 overflow-y-auto font-ui"
+			class="border border-base-300 bg-base-100 w-4/5 max-w-lg mx-auto rounded-lg shadow-lg z-50 overflow-y-auto font-ui"
 		>
 			<div
-				class="relative flex justify-between items-center {title.trim() != ''
-					? ' bg-base-200 py-4 px-10 text-xl font-bold break-normal text-center'
+				class="relative flex justify-between items-start {title.trim() != ''
+					? 'pt-3 pb-1 px-5 text-lg font-semibold break-normal text-center'
 					: ''}"
 			>
 				{#if title.trim() != ''}
 					{title}
 					<button
-						class="flex items-center justify-center border-none hover:bg-base-300"
+						class="flex items-center justify-center border-none text-base hover:bg-base-200 mt-1"
 						on:click={() => isOpen()}
 					>
-						<Icon src={X} class="w-6 h-6" />
+						<Icon src={X} class="w-4 h-4" />
 					</button>
 				{/if}
 				{#if title.trim() == ''}
@@ -48,14 +69,14 @@
 						class="flex items-center justify-center border-none p-0.5 absolute right-0 top-0 ml-4"
 						on:click={() => isOpen()}
 					>
-						<Icon src={X} class="w-6 h-6 mt-2 mr-2 hover:bg-base-300" />
+						<Icon src={X} class="w-4 h-4 mt-2 mr-2 text-base hover:bg-base-200" />
 					</button>
 				{/if}
 			</div>
 			<div
-				class="h-auto max-h-96 overflow-y-auto px-10 {title.trim() != ''
+				class="h-auto max-h-96 overflow-y-auto px-5 {title.trim() != ''
 					? 'my-4'
-					: 'my-6'} text-base break-normal"
+					: 'my-6'} text-sm break-normal"
 			>
 				{innerText}
 				<slot />
@@ -63,3 +84,43 @@
 		</div>
 	</div>
 {/if}
+
+<style lang="postcss">
+	dialog::backdrop {
+		@apply backdrop-blur-sm bg-base-100/80;
+	}
+
+	.modal-enter::backdrop {
+		all: unset;
+	}
+
+	@keyframes fadeInScale {
+		0% {
+			opacity: 0;
+			transform: scale(0.9);
+		}
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.modal-enter {
+		animation: fadeInScale 0.2s ease-out;
+	}
+
+	@keyframes fadeOutScale {
+		0% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		100% {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+	}
+
+	.modal-exit {
+		animation: fadeOutScale 0.2s ease-in;
+	}
+</style>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/SearchBar.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/SearchBar.svelte
@@ -26,18 +26,17 @@
 
 <style lang="postcss">
 	.search-container {
-		@apply bg-base-100 border border-base-300;
+		@apply bg-base-100 border border-base-300 shadow-sm h-7 rounded-md;
 		width: 30%;
 		display: block;
 		align-items: center;
-		border-radius: 4px;
-		height: 22px;
 		position: relative;
 		margin: 25px 3px 10px 0px;
 		box-sizing: content-box;
 	}
 
 	.search-icon {
+		@apply text-base-content-muted/80;
 		height: 16px;
 		width: 16px;
 		padding-left: 3px;
@@ -69,7 +68,7 @@
 	}
 
 	input.search-bar::placeholder {
-		@apply text-base-content-muted;
+		@apply text-base-content-muted/80;
 	}
 
 	*:focus {


### PR DESCRIPTION
Styling changes to make components more consistent-looking.

## Inputs
Standardized to the following:
- Margin top: none
- Margin bottom: `mb-4`
- Margin right: `mr-2`
 
Before and afters below

### Remaining Issues
- DataTable search bar I don't think is 100% right
- Spacing between input components is tricky with titles involved and when only using bottom margin
   - One approach we could try is using some top margin and removing it when a title is used (letting the title occupy the margin space)
   - When on multiple lines, once a title is included it makes the components look too far apart
- A way to handle groups of inputs (will address in a separate PR with an InputGroup component)
- Tabs styling looks out of place with the rest of components

## Modal

### Before
![CleanShot 2024-12-19 at 13 50 32](https://github.com/user-attachments/assets/5c36c76f-6376-4386-a4d9-d2a98988608c)

### After
![CleanShot 2024-12-19 at 13 51 15](https://github.com/user-attachments/assets/9f4ade07-5652-4031-a564-e44c628ae70a)

## LinkButton

### Before
![CleanShot 2024-12-19 at 13 53 06@2x](https://github.com/user-attachments/assets/9ea41c52-2471-42d0-87bc-a23dd48e8f0b)

### After
![CleanShot 2024-12-19 at 13 53 12@2x](https://github.com/user-attachments/assets/5c72f0e1-4d95-429f-aa57-56496e86f963)


## BigLink

### Before
![CleanShot 2024-12-19 at 13 54 17@2x](https://github.com/user-attachments/assets/3c2d57e5-86af-49e2-83a1-6be7987475a1)

### After
![CleanShot 2024-12-19 at 13 54 23@2x](https://github.com/user-attachments/assets/5005794f-e3ff-44ec-b692-a4fe90079591)


## TextInput

### Before
![CleanShot 2024-12-19 at 13 54 58@2x](https://github.com/user-attachments/assets/57c7c9e1-2a5b-4beb-8cd5-d2911489f599)

### After
![CleanShot 2024-12-19 at 13 55 07@2x](https://github.com/user-attachments/assets/1dddbe53-41ee-410a-b3f1-ffdd3021a2f5)

## ButtonGroup
ButtonGroup is now `inline-block` rather than `inline-flex` to align well with other input components when side by side

### Before
![CleanShot 2024-12-19 at 13 55 44@2x](https://github.com/user-attachments/assets/1e3a79ad-111d-4914-8b30-273996d0020d)

![CleanShot 2024-12-19 at 14 05 24@2x](https://github.com/user-attachments/assets/77c7d2cd-4011-41d9-b1e3-134b24a72dbc)

### After
![CleanShot 2024-12-19 at 13 55 56@2x](https://github.com/user-attachments/assets/5038c1c6-6277-4af6-8bd0-400563b19075)

![CleanShot 2024-12-19 at 14 03 22@2x](https://github.com/user-attachments/assets/3f06eadd-e26d-41ae-9d53-f32e96d9eec1)

## Slider

### Before
![CleanShot 2024-12-19 at 13 56 35@2x](https://github.com/user-attachments/assets/32292f57-1cd9-478d-ba34-624033965a94)

### After
![CleanShot 2024-12-19 at 13 56 46@2x](https://github.com/user-attachments/assets/08797dea-c841-4c2a-a247-4f9b58841fbe)

## DimensionGrid

### Before
![CleanShot 2024-12-19 at 13 57 20@2x](https://github.com/user-attachments/assets/47da3689-236b-4a10-a9d9-e6b251dbc7ed)

### After
![CleanShot 2024-12-19 at 13 57 33@2x](https://github.com/user-attachments/assets/412248dc-f22a-4e24-bdbf-e814894d4eaa)


## DataTable (search box)

### Before
![CleanShot 2024-12-19 at 13 58 20@2x](https://github.com/user-attachments/assets/15157219-a44e-4eb4-9789-7b6b0acd0cca)

### After
![CleanShot 2024-12-19 at 13 58 32@2x](https://github.com/user-attachments/assets/9372b28e-37c6-42ff-aaf2-685a1c2c47f9)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
