### PR TITLE
mute multi-select badges

### DIFF
--- a/.changeset/lemon-singers-pretend.md
+++ b/.changeset/lemon-singers-pretend.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Bug fix: mute the color of badges in multi-selects.

--- a/packages/ui/core-components/src/lib/atoms/shadcn/badge/index.js
+++ b/packages/ui/core-components/src/lib/atoms/shadcn/badge/index.js
@@ -5,9 +5,9 @@ export const badgeVariants = tv({
 	base: 'inline-flex items-center rounded-md border border-base-300 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-base-content-muted focus:ring-offset-2 select-none',
 	variants: {
 		variant: {
-			default: 'border-transparent bg-base-300 text-base-content shadow hover:bg-base-300/80',
+			default: 'border-transparent bg-base-200 text-base-content hover:bg-base-200/80',
 			destructive:
-				'border-transparent bg-negative text-negative-content shadow hover:bg-negative/80',
+				'border-transparent bg-negative text-negative-content hover:bg-negative/80',
 			outline: 'text-foreground'
 		}
 	},

--- a/packages/ui/core-components/src/lib/atoms/shadcn/badge/index.js
+++ b/packages/ui/core-components/src/lib/atoms/shadcn/badge/index.js
@@ -6,8 +6,7 @@ export const badgeVariants = tv({
 	variants: {
 		variant: {
 			default: 'border-transparent bg-base-200 text-base-content hover:bg-base-200/80',
-			destructive:
-				'border-transparent bg-negative text-negative-content hover:bg-negative/80',
+			destructive: 'border-transparent bg-negative text-negative-content hover:bg-negative/80',
 			outline: 'text-foreground'
 		}
 	},


### PR DESCRIPTION
Noticed when reviewing #2940 brings the badge styling in multi-selects back to pre-themes. 

Before: 

![CleanShot 2024-12-19 at 16 01 14@2x](https://github.com/user-attachments/assets/e25a4294-446a-4d6e-aa9e-4c23f974343c)

After: 
![CleanShot 2024-12-19 at 16 01 27@2x](https://github.com/user-attachments/assets/c49426d0-f983-4eea-9e25-51c7b5f00882)
