### PR TITLE
fixed border regression in dateinput

### DIFF
--- a/.changeset/cool-weeks-hang.md
+++ b/.changeset/cool-weeks-hang.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed border regression in dateinput

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
@@ -232,7 +232,7 @@
 				variant="outline"
 				size="sm"
 				class={cn(
-					`flex justify-start ${range ? 'border-r rounded-r-none text-left' : 'text-center'} font-normal`,
+					`flex justify-start ${range ? 'border-r-0 rounded-r-none text-left' : 'text-center'} font-normal`,
 					!selectedDateInput && 'text-base-content-muted'
 				)}
 				builders={[builder]}


### PR DESCRIPTION
### Description

Regression in border styling for `dateRange` and `dateInput` `range={true}`. Simple fix, `border-r` --> `border-r-0` 

Before:

![image](https://github.com/user-attachments/assets/3a415173-038f-4cdd-9902-b7a4f7591996)

After:

![image](https://github.com/user-attachments/assets/aea0ee8a-cde1-4d15-8122-570ddec98016)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
