### PR TITLE
Input group component

### DIFF
--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -209,7 +209,7 @@
 {/each}
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
+	<div class="mt-2 mb-4 ml-0 mr-2 inline-block bg-base-100">
 		{#if hasQuery && $query.error}
 			<span
 				class="group inline-flex items-center relative cursor-help cursor-helpfont-sans px-1 border border-negative py-[1px] bg-negative/10 rounded"

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/stories/Dropdown.stories.svelte
@@ -8,6 +8,7 @@
 	import { userEvent, within, waitFor } from '@storybook/test';
 
 	import Dropdown from '../Dropdown.svelte';
+	import InputGroup from '../../input-group/InputGroup.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
 	import { query } from '@evidence-dev/universal-sql/client-duckdb';
 	import DropdownOption from '../helpers/DropdownOption.svelte';
@@ -44,7 +45,16 @@
 
 <Story name="Basic Usage">
 	{@const data = Query.create(`SELECT id as value, tag as label from hashtags`, query)}
-	<Dropdown name="test" {data} value="value" label="label" />
+	<InputGroup>
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" title="Dropdown" />
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" />
+		<Dropdown name="test" {data} value="value" label="label" />
+	</InputGroup>
 </Story>
 
 <Story name="Loading state">

--- a/packages/ui/core-components/src/lib/atoms/inputs/input-group/InputGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/input-group/InputGroup.svelte
@@ -1,0 +1,85 @@
+<script context="module">
+	export const evidenceInclude = true;
+</script>
+
+<script>
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { Filter } from '@steeze-ui/tabler-icons';
+
+	import { onMount } from 'svelte';
+
+	export let title = 'Inputs';
+	let isOpen = false;
+	let contentHeight = 0;
+
+	let contentElement;
+
+	function toggle() {
+		isOpen = !isOpen;
+		updateHeight();
+	}
+
+	function updateHeight() {
+		if (contentElement) {
+			contentHeight = contentElement.scrollHeight;
+		}
+	}
+
+	onMount(() => {
+		const resizeObserver = new ResizeObserver(() => {
+			if (isOpen) {
+				updateHeight();
+			}
+		});
+
+		if (contentElement) {
+			resizeObserver.observe(contentElement);
+		}
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	});
+</script>
+
+<div class="space-y-2 pt-2 px-2">
+	<!-- Toggle Button -->
+	<button
+		class="flex items-center gap-2 text-gray-700 hover:text-gray-900 focus:outline-none"
+		on:click={toggle}
+		aria-expanded={isOpen}
+	>
+		<div class="search-icon">
+			<Icon src={Filter} class="pl-0.5 w-4 h-4 text-base-content-muted" />
+		</div>
+		<span class="text-sm font-medium text-base-content">{title}</span>
+		<svg
+			class={`w-4 h-4 transform ${isOpen ? 'rotate-180' : ''} transition-transform`}
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	</button>
+
+	<!-- Collapsible Content with Transition -->
+	<div
+		class="overflow-hidden transition-all duration-300 bg-base-200 {isOpen
+			? 'border'
+			: ''} border-base-300 rounded-md"
+		style={`max-height: ${isOpen ? contentHeight + 'px' : '0px'}`}
+	>
+		<div bind:this={contentElement} class="collapsible-content p-2">
+			<slot />
+		</div>
+	</div>
+</div>
+
+<style>
+	/* Ensure child margins don't cause visual gaps */
+	.collapsible-content > * {
+		margin: 0; /* Reset margins */
+	}
+</style>


### PR DESCRIPTION
### Description
Adds an InputGroup component - a collapsible tray for inputs.

### Questions
- Should this be a component that can be placed anywhere, or a page-level setting that has a standard implementation?
- Currently most input components take the background of their parent container. Should the background be set as `base-100` instead to match the background of the app?
- What is the right naming of this?

![CleanShot 2024-12-21 at 12 44 15](https://github.com/user-attachments/assets/5939aace-cf62-41af-9504-7aca8034a75b)


### Input Background

My preference is `base-100` for input backgrounds, but interested in people's take - see below examples of taking parent background vs. app background:

![CleanShot 2024-12-21 at 12 49 04@2x](https://github.com/user-attachments/assets/29e1939c-e00b-45c7-9dfe-c1207fcbfc7f)
![CleanShot 2024-12-21 at 12 46 52@2x](https://github.com/user-attachments/assets/8bc9146a-804c-4b58-9f97-3acddd10a3ed)


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
