### PR TITLE
Fix double URL encoding

### DIFF
--- a/.changeset/eleven-planets-listen.md
+++ b/.changeset/eleven-planets-listen.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+double url encoding

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -27,7 +27,7 @@ export function _buildPageManifest(pages) {
 		isPage: false
 	};
 	for (const [pagePath, pageContent] of Object.entries(pages)) {
-		const path = pagePath.replace('/src/pages/', '');
+		const path = pagePath.replace('src/pages/', '');
 		let node = fileTree;
 		for (const part of path.split('/')) {
 			if (part === '+page.md') {
@@ -71,7 +71,8 @@ export async function GET() {
 				const relative_path = path.join(dirent.parentPath ?? dirent.path ?? dir, dirent.name);
 				const content = await fs.readFile(relative_path, 'utf-8');
 				// regularize for windows
-				pages[new URL(`file:///${relative_path}`).pathname] = content;
+				const normalized_path = path.normalize(relative_path).replace('\\', '/');
+				pages[normalized_path] = content;
 			} else if (dirent.isDirectory()) {
 				await recursiveReadDir(path.join(dir, dirent.name));
 			}

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -27,7 +27,7 @@ export function _buildPageManifest(pages) {
 		isPage: false
 	};
 	for (const [pagePath, pageContent] of Object.entries(pages)) {
-		const path = pagePath.replace('src/pages/', '');
+		const path = pagePath.replace('/src/pages/', '');
 		let node = fileTree;
 		for (const part of path.split('/')) {
 			if (part === '+page.md') {
@@ -71,7 +71,7 @@ export async function GET() {
 				const relative_path = path.join(dirent.parentPath ?? dirent.path ?? dir, dirent.name);
 				const content = await fs.readFile(relative_path, 'utf-8');
 				// regularize for windows
-				const normalized_path = path.normalize(relative_path).replace('\\', '/');
+				const normalized_path = path.normalize(relative_path).split(path.sep).join('/');
 				pages[normalized_path] = content;
 			} else if (dirent.isDirectory()) {
 				await recursiveReadDir(path.join(dir, dirent.name));

--- a/sites/example-project/src/pages/api/pagesManifest.json/+server.js
+++ b/sites/example-project/src/pages/api/pagesManifest.json/+server.js
@@ -71,7 +71,7 @@ export async function GET() {
 				const relative_path = path.join(dirent.parentPath ?? dirent.path ?? dir, dirent.name);
 				const content = await fs.readFile(relative_path, 'utf-8');
 				// regularize for windows
-				const normalized_path = path.normalize(relative_path).split(path.sep).join('/');
+				const normalized_path = '/' + path.normalize(relative_path).split(path.sep).join('/');
 				pages[normalized_path] = content;
 			} else if (dirent.isDirectory()) {
 				await recursiveReadDir(path.join(dir, dirent.name));


### PR DESCRIPTION
### Description



#### Changelog
- Fixed an issue where URLs were being encoded twice
- Corrected handling of the `src/pages/` path in server configuration



#### Process
In `+server.js`, the URL was being encoded twice due to the following two steps:
- Use of `new URL` to support Windows file paths
- Calculation of `node.href` in the `_buildPageManifest` function.

The following log from `Sidebar.svelte` illustrates the double encoding issue with the fileTree object:
```bash
'white%20space': {
  label: 'white%20space',
  href: '/white%2520space',
  children: {},
  frontMatter: [Object],
  isTemplated: false,
  isPage: true
}
```
![image](https://github.com/user-attachments/assets/329dcce1-494d-4df4-bb7d-51d9d9168c3b)

The `_buildPageManifest` function expects an unencoded `pagePath` for the computation of variables such as `part` and `label`.

To rectify this, I replaced the use of `new URL` with `path.normalize` and `replace` to maintain Windows compatibility.

This change also led me to adjust how paths starting with `/src/pages` are handled, changing them to start with `src/pages` instead.

Here are the updated results logged from the `Sidebar.svelte` file showing the corrected handling:

```bash
'white space': {
  label: 'white space',
  href: '/white%20space',
  children: {},
  frontMatter: [Object],
  isTemplated: false,
  isPage: true
}
```

![image](https://github.com/user-attachments/assets/f0c22feb-3fd2-4e7b-9aab-4b123d50c142)

This resolves issue #2953 .



#### Additional Comment
When I first started reading at the code, I thought `example-project` was a test repository unrelated to deployment.

However, I noticed that it's actually a "template" being copied to `.evidence/template`, based on various PRs such as #1737 and #2529. Have I understood this correctly?

If so, to avoid confusion, how about you rename `example-project` to something like `project-template`?




### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)