### PR TITLE
Warning default index page

### DIFF
--- a/.changeset/green-jeans-hide.md
+++ b/.changeset/green-jeans-hide.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Add warning message to default index.md

--- a/sites/example-project/src/pages/+page.md
+++ b/sites/example-project/src/pages/+page.md
@@ -1,5 +1,9 @@
 # Welcome to the Evidence Development Workspace!
 
+<Alert status=warning>
+    If you see this page in your Evidence App, you have deleted the `index.md` file from your project. Add a `pages/index.md` to your project to override this page.
+</Alert>
+
 This workspace contains examples of all Evidence features.
 
 If you are developing a new feature, add a page to this project. The page will be used as a reference for the feature, as a sandbox for anyone making changes to the feature in the future, and for general product testing.


### PR DESCRIPTION
### Description

If you delete the index.md page, then you you puzzlingly get the +page.md from the example-project

This adds a warning to help users rectify this case

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
