### PR TITLE
Minor component styling updates

### DIFF
--- a/.changeset/ten-humans-fetch.md
+++ b/.changeset/ten-humans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Minor styling updates

--- a/packages/ui/core-components/src/lib/unsorted/ui/Details.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Details.svelte
@@ -9,8 +9,11 @@
 	import { slide } from 'svelte/transition';
 </script>
 
-<div class="mb-4 mt-3">
-	<button class="text-sm cursor-pointer inline-flex gap-2" on:click={() => (open = !open)}>
+<div class="mb-4 mt-2">
+	<button
+		class="text-sm text-base-content-muted cursor-pointer inline-flex gap-2"
+		on:click={() => (open = !open)}
+	>
 		<span class={open ? 'marker rotate-marker' : 'marker'} />
 		<span> {title} </span>
 	</button>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
@@ -104,7 +104,7 @@ export function getSparklineConfig(
 				// Assuming params[0] is your primary data point
 				const dataPoint = params[0];
 				// Customize these HTML blocks as needed
-				const valuePart = `<div style="text-align: center; background-color: ${theme.colors['base-200']}; border-radius: 1px; padding: 0px 2px;">${formatValue(
+				const valuePart = `<div style="text-align: center; background-color: ${theme.colors['base-100']}; border-radius: 1px; padding: 0px 2px;">${formatValue(
 					dataPoint.value[1],
 					value_format_object
 				)}</div>`;

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Areas.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Areas.svelte
@@ -30,7 +30,7 @@
 	/** @type {string|undefined} */
 	export let value = undefined;
 	/** @type {string|undefined} */
-	export let valueFmt = undefined;
+	export let valueFmt = 'num0';
 	/** @type {number|undefined} */
 	export let min = undefined;
 	/** @type {number|undefined} */

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Points.svelte
@@ -32,9 +32,9 @@
 	/** @type {string|undefined} */
 	export let value = undefined; // column with the value to be represented
 	/** @type {string|undefined} */
-	export let valueFmt = undefined;
+	export let valueFmt = 'num0';
 	/** @type {string|undefined} */
-	export let sizeFmt = undefined;
+	export let sizeFmt = 'num0';
 	/** @type {number|undefined} */
 	export let size = undefined; // point size
 	/** @type {'categorical' | 'scalar' | undefined} */

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableHeader.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableHeader.svelte
@@ -77,7 +77,7 @@
 		{/if}
 	{/if}
 
-	<tr class="border-b border-base-content-muted">
+	<tr class="border-b border-base-content-muted/60">
 		{#if rowNumbers}
 			<th
 				role="columnheader"

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -320,7 +320,7 @@
 
 <style lang="postcss">
 	.row-lines {
-		@apply border-b border-base-300;
+		@apply border-b border-base-content-muted/20;
 	}
 
 	.shaded-row {


### PR DESCRIPTION
### Description

- Sparkline tooltip background color to `base-100`
- DataTable row lines and header lines slightly lighter
- Details component text lighter
- Maps legends default to `num0` formatting

### DataTable

#### Before
![CleanShot 2025-01-02 at 17 49 13@2x](https://github.com/user-attachments/assets/4d59c2b9-e9a2-4caf-82ab-100548ff2b76)

#### After
![CleanShot 2025-01-02 at 17 43 21@2x](https://github.com/user-attachments/assets/664b4948-0f88-46b4-af35-5d6a59b865cf)

### Sparkline

#### Before
![CleanShot 2025-01-02 at 17 47 33@2x](https://github.com/user-attachments/assets/c87112b9-caba-4b55-9c59-32c5d4070c01)

#### After
![CleanShot 2025-01-02 at 17 42 57@2x](https://github.com/user-attachments/assets/73c902e5-fbfd-47a4-bd2e-acd4cad3bca9)

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)