### PR TITLE
Chart upgrades and spacing improvements

### DIFF
--- a/.changeset/shiny-rocks-chew.md
+++ b/.changeset/shiny-rocks-chew.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': minor
+---
+
+Chart upgrades and spacing improvements

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"chroma-js": "^2.4.2",
 		"debounce": "^1.2.1",
 		"downloadjs": "1.4.7",
-		"echarts": "5.5.1",
+		"echarts": "5.6.0",
 		"echarts-stat": "1.2.0",
 		"eslint": "8.45.0",
 		"eslint-config-prettier": "^8.10.0",

--- a/packages/lib/component-utilities/package.json
+++ b/packages/lib/component-utilities/package.json
@@ -28,7 +28,7 @@
 		"@uwdata/mosaic-sql": "^0.3.2",
 		"debounce": "^1.2.1",
 		"downloadjs": "1.4.7",
-		"echarts": "5.5.1",
+		"echarts": "5.6.0",
 		"ssf": "^0.11.2",
 		"svelte": "4.2.19"
 	}

--- a/packages/lib/component-utilities/src/echarts.js
+++ b/packages/lib/component-utilities/src/echarts.js
@@ -172,7 +172,7 @@ const echartsAction = (node, options) => {
 					xAxis: {
 						axisLabel: {
 							interval: 0,
-							overflow: 'truncate',
+							overflow: options.xAxisLabelOverflow,
 							width: (clientWidth * modConst) / distinctXValues.size
 						}
 					}

--- a/packages/lib/component-utilities/src/echartsThemes.js
+++ b/packages/lib/component-utilities/src/echartsThemes.js
@@ -23,7 +23,7 @@ const createTheme = (mode) => {
 			fontFamily: ['Inter', 'sans-serif']
 		},
 		grid: {
-			left: '0%',
+			left: '1%',
 			right: '4%',
 			bottom: '0%',
 			top: '15%',
@@ -42,7 +42,7 @@ const createTheme = (mode) => {
 				color: subtitleColor,
 				overflow: 'break'
 			},
-			top: '0%'
+			top: '1px'
 		},
 		line: {
 			itemStyle: {
@@ -409,8 +409,31 @@ const createTheme = (mode) => {
 			color: ['#c41621', '#e39588', '#f5ed98']
 		},
 		dataZoom: {
-			handleSize: 'undefined%',
-			textStyle: {}
+			type: 'slider',
+			bottom: 10,
+			height: 30,
+			showDetail: false,
+			handleSize: '80%',
+			borderColor: gridlineColor,
+			handleStyle: {
+				borderColor: gridlineColor,
+				color: gridlineColor
+			},
+			moveHandleStyle: {
+				borderColor: gridlineColor,
+				color: gridlineColor
+			},
+			textStyle: {},
+			emphasis: {
+				handleStyle: {
+					borderColor: gridlineColor,
+					color: gridlineColor
+				},
+				moveHandleStyle: {
+					borderColor: gridlineColor,
+					color: gridlineColor
+				}
+			}
 		},
 		markPoint: {
 			label: {

--- a/packages/ui/core-components/package.json
+++ b/packages/ui/core-components/package.json
@@ -55,7 +55,7 @@
 		"cmdk-sv": "^0.0.12",
 		"codemirror": "^6.0.1",
 		"date-fns": "^3.6.0",
-		"echarts": "5.5.1",
+		"echarts": "5.6.0",
 		"echarts-stat": "1.2.0",
 		"export-to-csv": "0.2.1",
 		"leaflet": "^1.9.4",

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/AreaChart.svelte
@@ -96,6 +96,11 @@
 
 	export let connectGroup = undefined;
 	export let seriesLabelFmt = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
+
+	export let xLabelWrap = undefined;
 </script>
 
 <Chart
@@ -140,6 +145,9 @@
 	{downloadableImage}
 	{connectGroup}
 	seriesColors={seriesColorsStore}
+	{leftPadding}
+	{rightPadding}
+	{xLabelWrap}
 >
 	<Area
 		{line}

--- a/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bar/BarChart.svelte
@@ -7,7 +7,6 @@
 
 	import Chart from '../core/Chart.svelte';
 	import Bar from './Bar.svelte';
-	import { onMount } from 'svelte';
 
 	const { resolveColor, resolveColorsObject, resolveColorPalette } = getThemeStores();
 
@@ -52,23 +51,8 @@
 	export let y2Scale = undefined;
 	export let swapXY = false;
 
-	let xEvidenceType = undefined;
-
-	onMount(() => {
-		xEvidenceType = data?.[0]?._evidenceColumnTypes?.find(
-			(ect) => ect.name?.toLowerCase() === x?.toLowerCase()
-		)?.evidenceType;
-	});
-
-	$: if (!showAllXaxisLabelsManuallySet)
-		showAllXAxisLabels = xType === 'category' || xEvidenceType === 'string';
-
 	/** @type {boolean} */
 	export let showAllXAxisLabels;
-	const showAllXaxisLabelsManuallySet = typeof showAllXAxisLabels !== 'undefined';
-
-	$: if (typeof showAllXAxisLabels === 'string')
-		showAllXAxisLabels = showAllXAxisLabels?.toLowerCase() === 'true';
 
 	$: {
 		if (swapXY === 'true' || swapXY === true) {
@@ -136,6 +120,11 @@
 	export let connectGroup = undefined;
 
 	export let seriesLabelFmt = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
+
+	export let xLabelWrap = undefined;
 </script>
 
 <Chart
@@ -193,7 +182,10 @@
 	{downloadableData}
 	{downloadableImage}
 	{connectGroup}
+	{xLabelWrap}
 	seriesColors={seriesColorsStore}
+	{leftPadding}
+	{rightPadding}
 >
 	<Bar
 		{type}

--- a/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/box/BoxPlot.svelte
@@ -62,6 +62,11 @@
 	export let emptySet = undefined;
 	export let emptyMessage = undefined;
 
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
+
+	export let xLabelWrap = undefined;
+
 	$: {
 		if (swapXY === 'true' || swapXY === true) {
 			swapXY = true;
@@ -136,6 +141,9 @@
 	{downloadableImage}
 	{connectGroup}
 	{seriesColors}
+	{leftPadding}
+	{rightPadding}
+	{xLabelWrap}
 >
 	<Box {boxPlotData} color={colorStore} {max} />
 	<slot />

--- a/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/bubble/BubbleChart.svelte
@@ -83,6 +83,9 @@
 
 	export let connectGroup = undefined;
 	export let seriesLabelFmt = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
 </script>
 
 <Chart
@@ -128,6 +131,8 @@
 	{downloadableImage}
 	{connectGroup}
 	seriesColors={seriesColorsStore}
+	{leftPadding}
+	{rightPadding}
 >
 	<Bubble
 		{shape}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
@@ -38,6 +38,8 @@
 
 	export let connectGroup = undefined;
 
+	export let xAxisLabelOverflow = undefined;
+
 	const dispatch = createEventDispatcher();
 
 	let downloadChart = false;
@@ -62,7 +64,7 @@
 
 <div
 	role="none"
-	class="chart-container"
+	class="chart-container mt-2 mb-3"
 	on:mouseenter={() => (hovering = true)}
 	on:mouseleave={() => (hovering = false)}
 >
@@ -75,9 +77,6 @@
 				style="
 				height: {height};
 				width: {width};
-				margin-left: 0;
-				margin-top: 15px;
-				margin-bottom: 10px;
 				overflow: visible;
 				display: {copying ? 'none' : 'inherit'}
 			"
@@ -89,6 +88,7 @@
 					dispatch,
 					renderer,
 					connectGroup,
+					xAxisLabelOverflow,
 					seriesColors: $seriesColorsStore,
 					theme: $activeAppearance
 				}}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Chart.svelte
@@ -42,7 +42,7 @@
 	export let size = undefined;
 	export let tooltipTitle = undefined;
 
-	export let showAllXAxisLabels = false;
+	export let showAllXAxisLabels = undefined;
 
 	export let printEchartsConfig = false; // helper for custom chart development
 	$: printEchartsConfig = printEchartsConfig === 'true' || printEchartsConfig === true;
@@ -170,6 +170,14 @@
 	$: downloadableImage = downloadableImage === 'true' || downloadableImage === true;
 
 	export let connectGroup = undefined; // string represent name of group for connected charts. Charts with same connectGroup will have connected interactions
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
+
+	export let xLabelWrap = false; // false = truncate, true = wrap
+	$: xLabelWrap = xLabelWrap === 'true' || xLabelWrap === true;
+
+	const xAxisLabelOverflow = xLabelWrap ? 'break' : 'truncate';
 
 	// ---------------------------------------------------------------------------------------
 	// Variable Declaration
@@ -416,6 +424,15 @@
 			}
 
 			xType = xType === 'category' ? 'category' : xDataType;
+
+			// Set xAxisLabel overflow behaviour based on column type
+			if (!showAllXAxisLabels) {
+				// if user has not set showXAxisLabels
+				showAllXAxisLabels = xType === 'category';
+			} else {
+				// if user has set showXAxisLabels, convert to boolean
+				showAllXAxisLabels = showAllXAxisLabels === 'true' || showAllXAxisLabels === true;
+			}
 
 			// Throw error if attempting to plot value or time on horizontal x-axis:
 			if (swapXY && xType !== 'category') {
@@ -677,6 +694,15 @@
 					type: xType,
 					min: xMin,
 					max: xMax,
+					tooltip: {
+						show: true,
+						position: 'inside',
+						formatter(p) {
+							if (p.isTruncated()) {
+								return p.name;
+							}
+						}
+					},
 					splitLine: {
 						show: xGridlines
 					},
@@ -865,7 +891,7 @@
 				titleBoxPadding * Math.max(hasTitle, hasSubtitle);
 
 			chartAreaPaddingTop = 10;
-			chartAreaPaddingBottom = 8;
+			chartAreaPaddingBottom = 10;
 
 			bottomAxisTitleSize = 14;
 			topAxisTitleSize = 14 + 0; // font size + padding top
@@ -935,6 +961,7 @@
 				},
 				tooltip: {
 					trigger: 'axis',
+					show: true,
 					// formatter function is overridden in ScatterPlot, BubbleChart, and Histogram
 					formatter: function (params) {
 						let output;
@@ -1018,8 +1045,8 @@
 					data: []
 				},
 				grid: {
-					left: '0.5%',
-					right: swapXY ? '4%' : '3%',
+					left: leftPadding ?? (swapXY ? '1%' : '0.8%'),
+					right: rightPadding ?? (swapXY ? '4%' : '3%'),
 					bottom: chartBottom,
 					top: chartTop,
 					containLabel: true
@@ -1069,6 +1096,7 @@
 		{downloadableData}
 		{downloadableImage}
 		{connectGroup}
+		{xAxisLabelOverflow}
 		seriesColors={seriesColorsStore}
 	/>
 {:else}

--- a/packages/ui/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/histogram/Histogram.svelte
@@ -52,6 +52,9 @@
 	export let downloadableImage = undefined;
 
 	export let connectGroup = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
 </script>
 
 <Chart
@@ -86,6 +89,8 @@
 	{downloadableData}
 	{downloadableImage}
 	{connectGroup}
+	{leftPadding}
+	{rightPadding}
 >
 	<Hist fillColor={fillColorStore} {fillOpacity} />
 	<slot />

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/LineChart.svelte
@@ -115,6 +115,11 @@
 	export let connectGroup = undefined;
 	/** @type {string | undefined} */
 	export let seriesLabelFmt = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
+
+	export let xLabelWrap = undefined;
 </script>
 
 <Chart
@@ -169,6 +174,9 @@
 	{downloadableImage}
 	{connectGroup}
 	seriesColors={seriesColorsStore}
+	{leftPadding}
+	{rightPadding}
+	{xLabelWrap}
 >
 	<Line
 		lineColor={lineColorStore}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_EChartsMap.svelte
@@ -61,7 +61,7 @@
 
 <div
 	role="none"
-	class="chart-container"
+	class="chart-container mt-2 mb-6"
 	on:mouseenter={() => (hovering = true)}
 	on:mouseleave={() => (hovering = false)}
 >
@@ -222,9 +222,5 @@
 		margin: 3px 12px;
 		font-size: 12px;
 		height: 9px;
-	}
-
-	.chart-container {
-		margin-bottom: 25px;
 	}
 </style>

--- a/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/scatter/ScatterPlot.svelte
@@ -83,6 +83,9 @@
 	export let connectGroup = undefined;
 	/** @type {string | undefined} */
 	export let seriesLabelFmt = undefined;
+
+	export let leftPadding = undefined;
+	export let rightPadding = undefined;
 </script>
 
 <Chart
@@ -127,6 +130,8 @@
 	{downloadableImage}
 	{connectGroup}
 	seriesColors={seriesColorsStore}
+	{leftPadding}
+	{rightPadding}
 >
 	<Scatter
 		{shape}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: 1.4.7
         version: 1.4.7
       echarts:
-        specifier: 5.5.1
-        version: 5.5.1
+        specifier: 5.6.0
+        version: 5.6.0
       echarts-stat:
         specifier: 1.2.0
         version: 1.2.0
@@ -942,8 +942,8 @@ importers:
         specifier: 1.4.7
         version: 1.4.7
       echarts:
-        specifier: 5.5.1
-        version: 5.5.1
+        specifier: 5.6.0
+        version: 5.6.0
       ssf:
         specifier: ^0.11.2
         version: 0.11.2
@@ -1338,8 +1338,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       echarts:
-        specifier: 5.5.1
-        version: 5.5.1
+        specifier: 5.6.0
+        version: 5.6.0
       echarts-stat:
         specifier: 1.2.0
         version: 1.2.0
@@ -9160,6 +9160,7 @@ packages:
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
@@ -10184,6 +10185,7 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: false
 
   /cli-cursor@4.0.0:
@@ -11096,6 +11098,13 @@ packages:
     dependencies:
       tslib: 2.3.0
       zrender: 5.6.0
+    dev: false
+
+  /echarts@5.6.0:
+    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.6.1
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -12959,6 +12968,7 @@ packages:
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    requiresBuild: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -15808,6 +15818,9 @@ packages:
     resolution: {integrity: sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==}
     engines: {node: '>= 16.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.13.3(@parcel/core@2.13.3)(postcss@8.4.49)(typescript@5.4.2)
       '@parcel/core': 2.13.3
@@ -17505,6 +17518,9 @@ packages:
   /sqlite3@5.1.6:
     resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       node-addon-api: 4.3.0
@@ -19992,6 +20008,12 @@ packages:
 
   /zrender@5.6.0:
     resolution: {integrity: sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==}
+    dependencies:
+      tslib: 2.3.0
+    dev: false
+
+  /zrender@5.6.1:
+    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
     dependencies:
       tslib: 2.3.0
 

--- a/sites/docs/pages/components/charts/area-chart/index.md
+++ b/sites/docs/pages/components/charts/area-chart/index.md
@@ -322,6 +322,21 @@ queries:
     options="Array of series names in the order they should be used in the chart seriesOrder={`{['series one', 'series two']}`}"
     defaultValue="default order implied by the data"
 />
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Value Labels
 

--- a/sites/docs/pages/components/charts/area-chart/index.md
+++ b/sites/docs/pages/components/charts/area-chart/index.md
@@ -336,6 +336,7 @@ queries:
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Value Labels

--- a/sites/docs/pages/components/charts/bar-chart/index.md
+++ b/sites/docs/pages/components/charts/bar-chart/index.md
@@ -473,6 +473,21 @@ queries:
     options="Array of series names in the order they should be used in the chart seriesOrder={`{['series one', 'series two']}`}"
     defaultValue="default order implied by the data"
 />
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Value Labels
 
@@ -674,12 +689,6 @@ queries:
 <PropListing
     name=y2Scale
     description="Whether to scale the y-axis to fit your data. `y2Min` and `y2Max` take precedence over `y2Scale`"
-    options={['true', 'false']}
-    defaultValue=false
-/>
-<PropListing
-    name=showAllXAxisLabels
-    description="Force every x-axis value to be shown. This can truncate labels if there are too many."
     options={['true', 'false']}
     defaultValue=false
 />

--- a/sites/docs/pages/components/charts/bar-chart/index.md
+++ b/sites/docs/pages/components/charts/bar-chart/index.md
@@ -159,7 +159,6 @@ queries:
             x=category
             y=sales
             series=channel
-            swapXY=true
         />
     </div>
 

--- a/sites/docs/pages/components/charts/bar-chart/index.md
+++ b/sites/docs/pages/components/charts/bar-chart/index.md
@@ -487,6 +487,7 @@ queries:
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Value Labels

--- a/sites/docs/pages/components/charts/box-plot/index.md
+++ b/sites/docs/pages/components/charts/box-plot/index.md
@@ -279,6 +279,7 @@ from ${sales_distribution_by_channel}
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Axes

--- a/sites/docs/pages/components/charts/box-plot/index.md
+++ b/sites/docs/pages/components/charts/box-plot/index.md
@@ -265,6 +265,21 @@ from ${sales_distribution_by_channel}
     options="object with series names and assigned colors"
     defaultValue="colors applied by order of series in data"
 />
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Axes
 
@@ -343,12 +358,6 @@ from ${sales_distribution_by_channel}
     name="yMax"
     description="Maximum value for the y-axis"
     options="number"
-/>
-<PropListing 
-    name="showAllXAxisLabels"
-    description="Force every x-axis value to be shown. This can truncate labels if there are too many."
-    options={['true', 'false']}
-    defaultValue="false"
 />
 
 ### Chart

--- a/sites/docs/pages/components/charts/bubble-chart/index.md
+++ b/sites/docs/pages/components/charts/bubble-chart/index.md
@@ -244,6 +244,7 @@ queries:
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Axes

--- a/sites/docs/pages/components/charts/bubble-chart/index.md
+++ b/sites/docs/pages/components/charts/bubble-chart/index.md
@@ -230,6 +230,21 @@ queries:
     options="Array of series names in the order they should be used in the chart seriesOrder={`{['series one', 'series two']}`}"
     defaultValue="default order implied by the data"
 />
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Axes
 

--- a/sites/docs/pages/components/charts/histogram/index.md
+++ b/sites/docs/pages/components/charts/histogram/index.md
@@ -140,6 +140,7 @@ Array of custom colours to use for the chart. E.g., `{['#cf0d06','#eb5752','#e88
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Axes

--- a/sites/docs/pages/components/charts/histogram/index.md
+++ b/sites/docs/pages/components/charts/histogram/index.md
@@ -126,6 +126,21 @@ Color to override default series color
 Array of custom colours to use for the chart. E.g., `{['#cf0d06','#eb5752','#e88a87']}`
 
 </PropListing>
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Axes
 

--- a/sites/docs/pages/components/charts/line-chart/index.md
+++ b/sites/docs/pages/components/charts/line-chart/index.md
@@ -513,6 +513,7 @@ group by all
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Axes

--- a/sites/docs/pages/components/charts/line-chart/index.md
+++ b/sites/docs/pages/components/charts/line-chart/index.md
@@ -499,6 +499,21 @@ group by all
     options={["true", "false"]}
     defaultValue="false"
 />
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Axes
 

--- a/sites/docs/pages/components/charts/scatter-plot/index.md
+++ b/sites/docs/pages/components/charts/scatter-plot/index.md
@@ -253,6 +253,21 @@ Apply a specific color to each series in your chart. Unspecified series will rec
 Apply a specific order to the series in a multi-series chart.
 
 </PropListing>
+<PropListing
+    name=leftPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=rightPadding
+    description="Number representing the padding (whitespace) on the left side of the chart. Useful to avoid labels getting cut off"
+    options="number"
+/>
+<PropListing
+    name=xLabelWrap
+    description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
+    options={["true", "false"]}
+/>
 
 ### Axes
 

--- a/sites/docs/pages/components/charts/scatter-plot/index.md
+++ b/sites/docs/pages/components/charts/scatter-plot/index.md
@@ -267,6 +267,7 @@ Apply a specific order to the series in a multi-series chart.
     name=xLabelWrap
     description="Whether to wrap x-axis labels when there is not enough space. Default behaviour is to truncate the labels."
     options={["true", "false"]}
+    defaultValue="false"
 />
 
 ### Axes


### PR DESCRIPTION
### Description

- Echarts upgrade to 5.6.0
- Axis label tooltip for truncated labels
- Datazoom echarts theme adjustments to include handles
- Echarts grid adjustments
- Move padding and margin settings to parent chart container
- Add `leftPadding` and `rightPadding` props to charts for full control of label cutoff
- x label fixes
    - All x-labels now show by default on string x-axes
    - Truncate when labels overflow, with tooltip to show column name on hover
    - Option to wrap using `xLabelWrap`    

## Examples

### Spacing

#### Before
![CleanShot 2025-01-02 at 18 16 13@2x](https://github.com/user-attachments/assets/7909624b-12b4-45d6-8329-f49622f6d6a4)

#### After
![CleanShot 2025-01-02 at 18 11 32@2x](https://github.com/user-attachments/assets/3c8c3890-4422-4290-9ce1-dbfc366da003)

### X Axis Labels

#### Before
![CleanShot 2025-01-02 at 18 18 23@2x](https://github.com/user-attachments/assets/1cfa19a5-ccbd-4c8b-ba47-8f73f58ba1f7)

#### After - truncate (Default)
![CleanShot 2025-01-02 at 18 09 59](https://github.com/user-attachments/assets/b1d41ff3-5d92-4d57-8468-c86d909a66a8)

#### After - wrap (`xLabelWrap=true`)
![CleanShot 2025-01-02 at 18 09 29@2x](https://github.com/user-attachments/assets/844ab345-6016-4ccf-b484-063fdaf939b0)

### DataZoom (via echartsOptions)

```svelte
     <LineChart 
            data={orders_by_month}
            x=month
            y=sales_usd0k 
            yAxisTitle="Sales per Month"
            echartsOptions={{
                dataZoom: {
                    show: true,
                    bottom: 10
                },
                grid: {
                    bottom: 50
                }
            }}
        />
```

#### Before
![CleanShot 2025-01-02 at 18 21 49@2x](https://github.com/user-attachments/assets/652ed3a2-744b-46f2-bad7-3be1ded12717)


#### After
![CleanShot 2025-01-02 at 18 22 59@2x](https://github.com/user-attachments/assets/7d54a732-6e78-4ff3-be93-0678b3fd33a4)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
