### PR TITLE
Component alignment and title consistency

### DIFF
--- a/.changeset/tasty-meals-grow.md
+++ b/.changeset/tasty-meals-grow.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Title and subtitle consistency across components

--- a/packages/lib/component-utilities/src/echartsThemes.js
+++ b/packages/lib/component-utilities/src/echartsThemes.js
@@ -23,7 +23,7 @@ const createTheme = (mode) => {
 			fontFamily: ['Inter', 'sans-serif']
 		},
 		grid: {
-			left: '0%',
+			left: '1%',
 			right: '4%',
 			bottom: '0%',
 			top: '15%',
@@ -42,7 +42,7 @@ const createTheme = (mode) => {
 				color: subtitleColor,
 				overflow: 'break'
 			},
-			top: '0%'
+			top: '1px'
 		},
 		line: {
 			itemStyle: {

--- a/packages/ui/core-components/src/lib/atoms/fullscreen/Fullscreen.svelte
+++ b/packages/ui/core-components/src/lib/atoms/fullscreen/Fullscreen.svelte
@@ -72,9 +72,9 @@
 >
 	<button
 		class="absolute top-4 right-[18.5px] hover:bg-base-200 rounded-lg p-1 focus:outline-none focus:ring-1 focus:ring-base-300"
-		><Icon class="w-6 h-6 " src={X} /></button
+		><Icon class="w-5 h-5 " src={X} /></button
 	>
-	<div class="py-2 px-6 {!search ? 'pt-6' : ''}">
+	<div class="py-2 px-6 {!search ? 'pt-8' : 'pt-0'}">
 		<slot />
 	</div>
 </dialog>

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -104,15 +104,15 @@
 		<div
 			class={display === 'tabs'
 				? ''
-				: `inline-block overflow-scroll no-scrollbar align-bottom w-fit max-w-full flex-col mb-3 ml-0 mr-2`}
+				: `inline-block overflow-scroll no-scrollbar align-bottom w-fit max-w-full flex-col ${title ? 'mt-0.5' : 'mt-2'} mb-3 ml-0 mr-2`}
 		>
 			{#if title}
-				<span class="text-xs font-medium block mb-0.5">{title}</span>
+				<span class="text-xs font-medium text-base-content block mb-0.5">{title}</span>
 			{/if}
 			<div
 				class={display === 'tabs'
 					? 'my-6 flex flex-wrap gap-x-1 gap-y-1'
-					: 'inline-flex rounded-md shadow-sm mb-1 overflow-auto border border-base-300 no-scrollbar h-8'}
+					: 'inline-flex rounded-md shadow-sm overflow-auto border border-base-300 no-scrollbar h-8 mb-1'}
 				role="group"
 			>
 				{#if preset}

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -8,7 +8,6 @@
 	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
 	import { setContext } from 'svelte';
 	import { buildReactiveInputQuery } from '@evidence-dev/component-utilities/buildQuery';
-	import ErrorChart from '../../../unsorted/viz/core/ErrorChart.svelte';
 	import ButtonGroupItem from './ButtonGroupItem.svelte';
 	import { page } from '$app/stores';
 	import HiddenInPrint from '../shared/HiddenInPrint.svelte';
@@ -98,7 +97,16 @@
 </script>
 
 {#if error}
-	<ErrorChart title={'Button Group'} {error} />
+	<span
+		class="group inline-flex items-center relative cursor-help cursor-helpfont-sans px-1 border border-negative py-[1px] bg-negative/10 rounded"
+	>
+		<span class="inline font-sans font-medium text-xs text-negative">error</span>
+		<span
+			class="hidden font-sans group-hover:inline absolute -top-1 left-[105%] text-sm z-10 px-2 py-1 bg-base-200 border border-base-300 leading-relaxed min-w-[150px] w-max max-w-[400px] rounded-md"
+		>
+			{error}
+		</span>
+	</span>
 {:else}
 	<HiddenInPrint enabled={hideDuringPrint}>
 		<div

--- a/packages/ui/core-components/src/lib/atoms/inputs/checkbox/Checkbox.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/checkbox/Checkbox.svelte
@@ -34,7 +34,7 @@
 		on:click={() => ($inputs[name] = !$inputs[name])}
 		variant="outline"
 		size="sm"
-		class="min-w-40 inline-flex justify-between gap-4 items-center w-full max-w-fit mb-4 mr-2"
+		class="min-w-40 inline-flex justify-between gap-4 items-center w-full max-w-fit mt-2 mb-4 mr-2"
 	>
 		<p class="truncate font-medium">
 			{title}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.svelte
@@ -76,7 +76,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
+	<div class={`${title ? '-mt-0.5' : 'mt-2'} mb-4 ml-0 mr-2 inline-block`}>
 		{#if title && range}
 			<span class="text-sm text-gray-500 block mb-1">{title}</span>
 		{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-range/DateRange.svelte
@@ -63,7 +63,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mb-4 ml-0 mr-2 inline-block">
+	<div class={`${title ? '-mt-0.5' : 'mt-2'} mb-4 ml-0 mr-2 inline-block`}>
 		{#if title}
 			<span class="text-xs font-medium text-base-content block mb-0.5">{title}</span>
 		{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/Dropdown.svelte
@@ -209,7 +209,7 @@
 {/each}
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mb-4 ml-0 mr-2 inline-block">
+	<div class="mt-2 mb-4 ml-0 mr-2 inline-block">
 		{#if hasQuery && $query.error}
 			<span
 				class="group inline-flex items-center relative cursor-help cursor-helpfont-sans px-1 border border-negative py-[1px] bg-negative/10 rounded"

--- a/packages/ui/core-components/src/lib/atoms/inputs/slider/_Slider.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/slider/_Slider.svelte
@@ -162,7 +162,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class={`relative ${sizeClass} mb-10 select-none`}>
+	<div class={`relative ${sizeClass} mt-2 mb-10 select-none`}>
 		<p class="pb-2 truncate text-xs">
 			<span class="font-medium">{title}: </span>
 			<span class="text-xs">

--- a/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/text/TextInput.svelte
@@ -58,7 +58,7 @@
 </script>
 
 <HiddenInPrint enabled={hideDuringPrint}>
-	<div class="mb-4 ml-0 mr-2 inline-block align-bottom">
+	<div class={`${title ? '-mt-0.5' : 'mt-2'} mb-4 ml-0 mr-2 inline-block align-bottom`}>
 		{#if title}
 			<span class="text-xs font-medium block mb-0.5">{title}</span>
 		{/if}

--- a/packages/ui/core-components/src/lib/atoms/query-load/QueryLoad.svelte
+++ b/packages/ui/core-components/src/lib/atoms/query-load/QueryLoad.svelte
@@ -7,6 +7,10 @@
 	/** @type {import("@evidence-dev/sdk/usql).Query | unknown}*/
 	export let data;
 
+	export let height = 200;
+
+	export let skeletonMt = undefined;
+
 	$: if (Query.isQuery(data)) {
 		data.fetch(); // Somebody wants this to load. Without this the query builder features don't work
 		unsub();
@@ -36,8 +40,8 @@
 	{/if}
 {:else if !_data || (!_data.dataLoaded && !_data.error)}
 	<slot name="skeleton" loaded={_data}>
-		<div class="w-full h-64">
-			<Skeleton />
+		<div class="w-full" style="height: {height}px">
+			<Skeleton mt={skeletonMt} />
 		</div>
 	</slot>
 {:else if _data.error && $$slots.error}

--- a/packages/ui/core-components/src/lib/atoms/query-load/QueryLoad.svelte
+++ b/packages/ui/core-components/src/lib/atoms/query-load/QueryLoad.svelte
@@ -9,7 +9,7 @@
 
 	export let height = 200;
 
-	export let skeletonMt = undefined;
+	export let skeletonClass = undefined;
 
 	$: if (Query.isQuery(data)) {
 		data.fetch(); // Somebody wants this to load. Without this the query builder features don't work
@@ -41,7 +41,7 @@
 {:else if !_data || (!_data.dataLoaded && !_data.error)}
 	<slot name="skeleton" loaded={_data}>
 		<div class="w-full" style="height: {height}px">
-			<Skeleton mt={skeletonMt} />
+			<Skeleton class={skeletonClass} />
 		</div>
 	</slot>
 {:else if _data.error && $$slots.error}

--- a/packages/ui/core-components/src/lib/atoms/skeletons/Skeleton.svelte
+++ b/packages/ui/core-components/src/lib/atoms/skeletons/Skeleton.svelte
@@ -4,11 +4,13 @@
 
 <script>
 	import { fade } from 'svelte/transition';
+	import { cn } from '$lib/utils.js';
 
-	export let mt = 2;
+	let className = undefined;
+	export { className as class };
 </script>
 
-<div class="animate-pulse h-full w-full mt-{mt} mb-4" in:fade|local>
+<div class={cn('animate-pulse h-full w-full mt-2 mb-4', className)} in:fade|local>
 	<span class="sr-only">Loading...</span>
 	<div class="h-full w-full rounded-md bg-base-300" />
 </div>

--- a/packages/ui/core-components/src/lib/atoms/skeletons/Skeleton.svelte
+++ b/packages/ui/core-components/src/lib/atoms/skeletons/Skeleton.svelte
@@ -4,9 +4,11 @@
 
 <script>
 	import { fade } from 'svelte/transition';
+
+	export let mt = 2;
 </script>
 
-<div class="animate-pulse h-full w-full my-2" in:fade|local>
+<div class="animate-pulse h-full w-full mt-{mt} mb-4" in:fade|local>
 	<span class="sr-only">Loading...</span>
 	<div class="h-full w-full rounded-md bg-base-300" />
 </div>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
@@ -122,7 +122,7 @@
 			</span>
 		{/if}
 	</div>
-	<QueryLoad data={results} skeletonMt="0" let:loaded>
+	<QueryLoad data={results} skeletonClass="mt-0" let:loaded>
 		<Alert slot="error" status="negative">
 			{$results.error}
 		</Alert>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionCut.svelte
@@ -113,7 +113,7 @@
 
 <div class="w-60 flex-shrink-0 sm:w-1/4 text-xs antialiased pr-4 pb-4 overflow-clip">
 	<div class="capitalize border-b flex justify-between items-baseline">
-		<span class={`truncate pl-1 font-semibold ${metricLabel ? 'w-2/3' : ''}`}>
+		<span class={`truncate pl-1 pb-0.5 font-semibold ${metricLabel ? 'w-2/3' : ''}`}>
 			{formatTitle(dimension.column_name)}
 		</span>
 		{#if metricLabel}
@@ -122,7 +122,7 @@
 			</span>
 		{/if}
 	</div>
-	<QueryLoad data={results} let:loaded>
+	<QueryLoad data={results} skeletonMt="0" let:loaded>
 		<Alert slot="error" status="negative">
 			{$results.error}
 		</Alert>

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/DimensionGrid.svelte
@@ -20,6 +20,10 @@
 	export let multiple = false;
 	/** @type {string} */
 	export let fmt = undefined;
+	/** @type {string | undefined}*/
+	export let title = undefined;
+	/** @type {string | undefined}*/
+	export let subtitle = undefined;
 
 	const handleLimitNum = () => {
 		try {
@@ -35,9 +39,29 @@
 </script>
 
 <QueryLoad {data} let:loaded>
-	<DimensionGrid data={loaded} {metric} {metricLabel} {limit} {name} {multiple} {fmt} />
+	<DimensionGrid
+		data={loaded}
+		{metric}
+		{metricLabel}
+		{limit}
+		{name}
+		{multiple}
+		{fmt}
+		{title}
+		{subtitle}
+	/>
 	<svelte:fragment let:loaded slot="error">
-		<DimensionGrid data={loaded} {metric} {metricLabel} {limit} {name} {multiple} {fmt} />
+		<DimensionGrid
+			data={loaded}
+			{metric}
+			{metricLabel}
+			{limit}
+			{name}
+			{multiple}
+			{fmt}
+			{title}
+			{subtitle}
+		/>
 	</svelte:fragment>
 	<svelte:fragment slot="skeleton">
 		<!-- No loading state -->

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
@@ -3,6 +3,7 @@
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import DimensionCut from './DimensionCut.svelte';
+	import ComponentTitle from '../../unsorted/viz/core/ComponentTitle.svelte';
 	import { getWhereClause } from './dimensionGridQuery.js';
 	import Alert from '../../atoms/alert/Alert.svelte';
 
@@ -20,6 +21,10 @@
 	export let multiple = false;
 	/** @type {string} */
 	export let fmt = undefined;
+	/** @type {string | undefined}*/
+	export let title = undefined;
+	/** @type {string | undefined}*/
+	export let subtitle = undefined;
 
 	$: dimensions = data?.columns?.filter((col) => col.column_type === 'VARCHAR');
 	let selectedDimensions = writable([]);
@@ -40,6 +45,9 @@
 		{data.error}
 	</Alert>
 {:else}
+	{#if title || subtitle}
+		<ComponentTitle {title} {subtitle} />
+	{/if}
 	<div class="flex flex-nowrap overflow-auto sm:flex-wrap select-none">
 		{#each dimensions as dimension}
 			<DimensionCut {data} {dimension} {metric} {limit} {metricLabel} {multiple} {fmt} />

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
@@ -45,14 +45,14 @@
 		{data.error}
 	</Alert>
 {:else}
-<div class="mt-2">
-{#if title || subtitle}
-	<ComponentTitle {title} {subtitle} />
-{/if}
-<div class="flex flex-nowrap overflow-auto sm:flex-wrap select-none">
-		{#each dimensions as dimension}
-			<DimensionCut {data} {dimension} {metric} {limit} {metricLabel} {multiple} {fmt} />
-		{/each}
+	<div class="mt-2">
+		{#if title || subtitle}
+			<ComponentTitle {title} {subtitle} />
+		{/if}
+		<div class="flex flex-nowrap overflow-auto sm:flex-wrap select-none">
+			{#each dimensions as dimension}
+				<DimensionCut {data} {dimension} {metric} {limit} {metricLabel} {multiple} {fmt} />
+			{/each}
+		</div>
 	</div>
-</div>
 {/if}

--- a/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
+++ b/packages/ui/core-components/src/lib/molecules/dimension-grid/_DimensionGrid.svelte
@@ -45,12 +45,14 @@
 		{data.error}
 	</Alert>
 {:else}
-	{#if title || subtitle}
-		<ComponentTitle {title} {subtitle} />
-	{/if}
-	<div class="flex flex-nowrap overflow-auto sm:flex-wrap select-none">
+<div class="mt-2">
+{#if title || subtitle}
+	<ComponentTitle {title} {subtitle} />
+{/if}
+<div class="flex flex-nowrap overflow-auto sm:flex-wrap select-none">
 		{#each dimensions as dimension}
 			<DimensionCut {data} {dimension} {metric} {limit} {metricLabel} {multiple} {fmt} />
 		{/each}
 	</div>
+</div>
 {/if}

--- a/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/CodeBlock.svelte
@@ -46,10 +46,10 @@
 	}
 </script>
 
-<div class="my-5 bg-base-200 border border-base-300 rounded px-3 py-2 relative group">
+<div class="mt-2 mb-4 bg-base-200 border border-base-300 rounded px-3 py-2 relative group">
 	{#if copyToClipboard}
 		<button
-			class={'absolute opacity-0 rounded-sm p-1 group-hover:opacity-100 top-4 right-6 h-6 w-6 z-10 transition-all duration-200 ease-in-out' +
+			class={'absolute opacity-0 rounded-sm p-1 group-hover:opacity-100 top-2 right-2 h-6 w-6 z-10 transition-all duration-200 ease-in-out' +
 				(copied ? '' : '')}
 			on:click={() => {
 				if (source !== undefined) {
@@ -64,7 +64,7 @@
 			{/if}
 		</button>
 	{/if}
-	<pre class="overflow-auto pretty-scrollbar my-[0.5em]"><code class="language-{language} text-sm"
+	<pre class="overflow-auto pretty-scrollbar"><code class="language-{language} text-sm"
 			>{#if source}{source}{:else}<slot />{/if}</code
 		></pre>
 </div>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/BigValueError.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/BigValueError.svelte
@@ -10,7 +10,7 @@
 	width="100%"
 	class="inline-block group w-[100px] relative cursor-help cursor-helpfont-sans box-content grid-cols-1 justify-center bg-negative/10 font-ui font-normal rounded border border-negative/50 h-[38px] mt-0.5 py-3 px-3 print:break-inside-avoid"
 >
-	<div class="font-bold text-center text-sm">Big Value</div>
+	<div class="font-bold text-center text-sm text-negative">Big Value</div>
 	<div class="m-auto w-[100px]">
 		<div class="text-center [word-wrap:break-work] w-full font-medium text-xs text-negative">
 			error

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/Chart.svelte
@@ -23,6 +23,8 @@
 	/** @type {string}*/
 	export let emptyMessage = undefined;
 
+	export let height = 200;
+
 	// Remove any undefined props (e.g. w/o defaults) to prevent them from being passed
 	$: spreadProps = {
 		...Object.fromEntries(Object.entries($$props).filter(([, v]) => v !== undefined))
@@ -32,7 +34,7 @@
 </script>
 
 <!-- Pass all the props through-->
-<QueryLoad {data} let:loaded>
+<QueryLoad {data} {height} let:loaded>
 	<EmptyChart
 		slot="empty"
 		{emptyMessage}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ComponentTitle.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ComponentTitle.svelte
@@ -1,0 +1,21 @@
+<script context="module">
+	export const evidenceInclude = true;
+</script>
+
+<script>
+	export let title;
+	export let subtitle;
+</script>
+
+<div class="mt-0 mb-0">
+	{#if title}
+		<h4 class="text-[14px] text-base-heading font-bold mt-0 mb-{subtitle ? '1' : '2'} leading-none">
+			{title}
+		</h4>
+	{/if}
+	{#if subtitle}
+		<p class="text-[13px] text-base-content-muted font-normal mt-0 mb-2">
+			{subtitle}
+		</p>
+	{/if}
+</div>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
@@ -62,7 +62,7 @@
 
 <div
 	role="none"
-	class="chart-container"
+	class="chart-container mt-2 mb-3"
 	on:mouseenter={() => (hovering = true)}
 	on:mouseleave={() => (hovering = false)}
 >
@@ -75,9 +75,6 @@
 				style="
 				height: {height};
 				width: {width};
-				margin-left: 0;
-				margin-top: 15px;
-				margin-bottom: 10px;
 				overflow: visible;
 				display: {copying ? 'none' : 'inherit'}
 			"

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
@@ -8,7 +8,7 @@
 	/** @type {string} */
 	export let title;
 	/** @type {string} */
-	export let minHeight = '150';
+	export let height = '340';
 </script>
 
 <div
@@ -17,8 +17,9 @@
 			bg-negative/10 text-negative
 			font-ui font-normal
 			rounded border border-negative/50
-			min-h-[{minHeight}px]
-			py-5 px-8 my-5
+			min-h-[200px]
+			h-[{height}px]
+			py-5 px-8 mt-2 mb-4
 			print:break-inside-avoid"
 >
 	<div class="m-auto w-full">
@@ -26,7 +27,7 @@
 			{title}
 		</div>
 		<div class="w-full [word-wrap:break-work] text-xs">
-			<pre class="text-left mx-auto w-fit select-text text-wrap">{error}</pre>
+			<pre class="text-left font-sans mx-auto w-fit select-text text-wrap">{error}</pre>
 		</div>
 	</div>
 </div>

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
@@ -3,8 +3,6 @@
 </script>
 
 <script>
-	import { cn } from '$lib/utils.js';
-
 	/** @type {Error} */
 	export let error;
 	/** @type {string} */

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
@@ -17,9 +17,9 @@
 			bg-negative/10 text-negative
 			font-ui font-normal
 			rounded border border-negative/50
-			min-h-[${height}px]
 			py-5 px-8 mt-2 mb-4
 			print:break-inside-avoid`}
+	style="min-height: {height}px"
 >
 	<div class="m-auto w-full">
 		<div class="font-bold text-center text-lg">

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ErrorChart.svelte
@@ -3,24 +3,25 @@
 </script>
 
 <script>
+	import { cn } from '$lib/utils.js';
+
 	/** @type {Error} */
 	export let error;
 	/** @type {string} */
 	export let title;
 	/** @type {string} */
-	export let height = '340';
+	export let height = 200;
 </script>
 
 <div
 	width="100%"
-	class="grid grid-rows-auto grid-cols-1 justify-center relative
+	class={`grid grid-rows-auto grid-cols-1 justify-center relative
 			bg-negative/10 text-negative
 			font-ui font-normal
 			rounded border border-negative/50
-			min-h-[200px]
-			h-[{height}px]
+			min-h-[${height}px]
 			py-5 px-8 mt-2 mb-4
-			print:break-inside-avoid"
+			print:break-inside-avoid`}
 >
 	<div class="m-auto w-full">
 		<div class="font-bold text-center text-lg">

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/SearchBar.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/SearchBar.svelte
@@ -11,7 +11,7 @@
 	export let searchFunction;
 </script>
 
-<div class="search-container">
+<div class="search-container mb-1 mr-1">
 	<input
 		class="search-bar"
 		type="text"
@@ -31,7 +31,6 @@
 		display: block;
 		align-items: center;
 		position: relative;
-		margin: 25px 3px 10px 0px;
 		box-sizing: content-box;
 	}
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
@@ -8,6 +8,7 @@
 	import { addBasePath } from '@evidence-dev/sdk/utils/svelte';
 	import Delta from './Delta.svelte';
 	import { getThemeStores } from '../../../themes/themes.js';
+	import { cn } from '$lib/utils.js';
 
 	const { resolveColor } = getThemeStores();
 
@@ -44,6 +45,11 @@
 
 	export let maxWidth = 'none';
 	export let minWidth = '18%';
+
+	// Class override props
+	export let titleClass = undefined;
+	export let valueClass = undefined;
+	export let comparisonClass = undefined;
 
 	/** @type {string | null}*/
 	export let link = null;
@@ -92,17 +98,17 @@
 </script>
 
 <div
-	class="inline-block font-sans pt-2 pb-3 pr-3 pl-0 mr-3 items-center align-top"
+	class={`inline-block font-sans pt-2 pb-3 pl-0 mr-3 items-center align-top`}
 	style={`
         min-width: ${minWidth};
         max-width: ${maxWidth};
-    `}
+		`}
 >
 	{#if error}
 		<BigValueError chartType="Big Value" error={error.message} />
 	{:else}
-		<p class="text-sm">{title}</p>
-		<div class="relative text-xl font-medium my-0.5">
+		<p class={cn("text-sm align-top leading-none",titleClass)}>{title}</p>
+		<div class={cn("relative text-xl font-medium mt-1.5",valueClass)}>
 			{#if link}
 				<a class="hover:bg-base-200" href={addBasePath(link)}>
 					<Value {data} column={value} {fmt} />
@@ -128,7 +134,7 @@
 		</div>
 		{#if comparison}
 			{#if comparisonDelta}
-				<p class="text-xs font-sans">
+				<p class={cn("text-xs font-sans mt-1", comparisonClass)}>
 					<Delta
 						{data}
 						column={comparison}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_BigValue.svelte
@@ -107,8 +107,8 @@
 	{#if error}
 		<BigValueError chartType="Big Value" error={error.message} />
 	{:else}
-		<p class={cn("text-sm align-top leading-none",titleClass)}>{title}</p>
-		<div class={cn("relative text-xl font-medium mt-1.5",valueClass)}>
+		<p class={cn('text-sm align-top leading-none', titleClass)}>{title}</p>
+		<div class={cn('relative text-xl font-medium mt-1.5', valueClass)}>
 			{#if link}
 				<a class="hover:bg-base-200" href={addBasePath(link)}>
 					<Value {data} column={value} {fmt} />
@@ -134,7 +134,7 @@
 		</div>
 		{#if comparison}
 			{#if comparisonDelta}
-				<p class={cn("text-xs font-sans mt-1", comparisonClass)}>
+				<p class={cn('text-xs font-sans mt-1', comparisonClass)}>
 					<Delta
 						{data}
 						column={comparison}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
@@ -52,6 +52,9 @@
 	/** @type {string|undefined} */
 	export let title = undefined;
 
+	/** @type {string|undefined} */
+	export let subtitle = undefined;
+
 	/** @type {string[]|undefined} */
 	export let colorPalette = undefined;
 	$: colorPaletteStore = resolveColorPalette(colorPalette);
@@ -82,6 +85,7 @@
 	{height}
 	{basemap}
 	{title}
+	{subtitle}
 	{legendPosition}
 	{isInitial}
 	{chartType}

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
@@ -3,12 +3,16 @@
 	import ErrorChart from '../core/ErrorChart.svelte';
 	import EmptyChart from '../core/EmptyChart.svelte';
 	import BaseMap from './BaseMap.svelte';
+	import ComponentTitle from '../../viz/core/ComponentTitle.svelte';
 
 	/** @type {import("@evidence-dev/sdk/usql").QueryValue} */
 	export let data;
 
 	/** @type {string|undefined} */
 	export let title = undefined;
+
+	/** @type {string|undefined} */
+	export let subtitle = undefined;
 
 	/** @type {'pass' | 'warn' | 'error' | undefined} */
 	export let emptySet = undefined;
@@ -26,10 +30,9 @@
 </script>
 
 <div style="margin-top: 15px; margin-bottom: 10px;">
-	{#if title}
-		<h4 class="markdown mb-2">{title}</h4>
+	{#if title || subtitle}
+		<ComponentTitle {title} {subtitle} />
 	{/if}
-
 	<QueryLoad {data} let:loaded>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
 		<ErrorChart let:loaded slot="error" title={chartType} error={error ?? loaded.error.message} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_BaseMap.svelte
@@ -3,7 +3,7 @@
 	import ErrorChart from '../core/ErrorChart.svelte';
 	import EmptyChart from '../core/EmptyChart.svelte';
 	import BaseMap from './BaseMap.svelte';
-	import ComponentTitle from '../../viz/core/ComponentTitle.svelte';
+	import ComponentTitle from '../core/ComponentTitle.svelte';
 
 	/** @type {import("@evidence-dev/sdk/usql").QueryValue} */
 	export let data;
@@ -27,13 +27,16 @@
 	export let isInitial = true;
 
 	export let error = undefined;
+
+	export let height = undefined;
 </script>
 
-<div style="margin-top: 15px; margin-bottom: 10px;">
+<div class="mt-2 mb-4">
 	{#if title || subtitle}
 		<ComponentTitle {title} {subtitle} />
 	{/if}
-	<QueryLoad {data} let:loaded>
+
+	<QueryLoad {data} {height} let:loaded>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />
 		<ErrorChart let:loaded slot="error" title={chartType} error={error ?? loaded.error.message} />
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
@@ -15,7 +15,6 @@
 	} from '@evidence-dev/component-utilities/formatting';
 	import InvisibleLinks from '../../../atoms/InvisibleLinks.svelte';
 	import { getThemeStores } from '../../../themes/themes.js';
-	import chroma from 'chroma-js';
 	import { checkDeprecatedColor } from '../../../deprecated-colors.js';
 
 	const { theme, resolveColorPalette, resolveColorScale } = getThemeStores();
@@ -164,10 +163,10 @@
 				},
 				subtextStyle: {
 					fontSize: 13,
-					color: chroma($theme.colors['base-content']).alpha(0.8).css(),
+					color: $theme.colors['base-content-muted'],
 					overflow: 'break'
 				},
-				top: '0%'
+				top: '1px'
 			},
 			textStyle: {
 				fontFamily: 'sans-serif'

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/components/Legend Components/ScalarLegend.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/components/Legend Components/ScalarLegend.svelte
@@ -26,7 +26,7 @@
 		: showLegendStyle} transition-[opacity, max-height, overflow-y] duration-[350ms] ease-in-out w-full"
 >
 	<div class="flex flex-wrap flex-col font-semibold">
-		<span>{legendTitle}</span>
+		<span class="text-xs">{legendTitle}</span>
 	</div>
 	<div class="flex flex-col justify-center overflow-hidden h-8 w-full">
 		<span

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.svelte
@@ -187,7 +187,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} height="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceArea/ReferenceArea.svelte
@@ -187,7 +187,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} minHeight="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50px" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
@@ -224,7 +224,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} minHeight="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50px" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
@@ -224,7 +224,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} height="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
@@ -199,7 +199,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} minHeight="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50px" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
@@ -199,7 +199,7 @@
 {/if}
 
 {#if $store.error}
-	<ErrorChart error={$store.error} height="50px" title={chartType} />
+	<ErrorChart error={$store.error} height="50" title={chartType} />
 {:else}
 	<QueryLoad {data}>
 		<EmptyChart slot="empty" {emptyMessage} {emptySet} {chartType} {isInitial} />

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -6,7 +6,7 @@
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { convertColumnToDate } from '@evidence-dev/component-utilities/dateParsing';
 	import ErrorChart from '../core/ErrorChart.svelte';
-	import ComponentTitle from '../../viz/core/ComponentTitle.svelte';
+	import ComponentTitle from '../core/ComponentTitle.svelte';
 	import SearchBar from '../core/SearchBar.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import DownloadData from '../../ui/DownloadData.svelte';
@@ -42,7 +42,6 @@
 	export let data;
 	export let queryID = undefined;
 	export let rows = 10; // number of rows to show
-
 	$: rows = Number.parseInt(rows);
 
 	/** @type {string | undefined}*/
@@ -102,10 +101,6 @@
 	$: paginated = data.length > rows && !groupBy;
 
 	let hovering = false;
-
-	let marginTop = '1.5em';
-	let marginBottom = '1em';
-	let paddingBottom = '0em';
 
 	export let generateMarkdown = false;
 	$: generateMarkdown = generateMarkdown === 'true' || generateMarkdown === true;
@@ -553,11 +548,8 @@
 	<div
 		data-testid={isFullPage ? undefined : `DataTable-${data?.id ?? 'no-id'}`}
 		role="none"
-		class="table-container"
+		class="table-container mt-2 {paginated ? 'mb-5' : 'mb-2'}"
 		transition:slide|local
-		style:margin-top={marginTop}
-		style:margin-bottom={marginBottom}
-		style:padding-bottom={paddingBottom}
 		on:mouseenter={() => (hovering = true)}
 		on:mouseleave={() => (hovering = false)}
 	>
@@ -764,7 +756,7 @@
 				{/if}
 			</div>
 		{:else}
-			<div class="table-footer">
+			<div class="table-footer mt-3">
 				{#if downloadable}
 					<DownloadData class="download-button" data={tableData} {queryID} display={hovering} />
 				{/if}
@@ -829,7 +821,7 @@
 		user-select: none;
 		text-align: right;
 		margin-top: 0.5em;
-		margin-bottom: 1.8em;
+		margin-bottom: 0;
 		font-variant-numeric: tabular-nums;
 	}
 
@@ -882,7 +874,6 @@
 		display: flex;
 		justify-content: flex-end;
 		align-items: center;
-		margin: 10px 0px;
 		font-size: 12px;
 		height: 9px;
 	}

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -6,6 +6,7 @@
 	import getColumnSummary from '@evidence-dev/component-utilities/getColumnSummary';
 	import { convertColumnToDate } from '@evidence-dev/component-utilities/dateParsing';
 	import ErrorChart from '../core/ErrorChart.svelte';
+	import ComponentTitle from '../../viz/core/ComponentTitle.svelte';
 	import SearchBar from '../core/SearchBar.svelte';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import DownloadData from '../../ui/DownloadData.svelte';
@@ -43,6 +44,12 @@
 	export let rows = 10; // number of rows to show
 
 	$: rows = Number.parseInt(rows);
+
+	/** @type {string | undefined}*/
+	export let title = undefined;
+
+	/** @type {string | undefined}*/
+	export let subtitle = undefined;
 
 	export let rowNumbers = false;
 	$: rowNumbers = rowNumbers === 'true' || rowNumbers === true;
@@ -554,6 +561,10 @@
 		on:mouseenter={() => (hovering = true)}
 		on:mouseleave={() => (hovering = false)}
 	>
+		{#if title || subtitle}
+			<ComponentTitle {title} {subtitle} />
+		{/if}
+
 		{#if search}
 			<SearchBar bind:value={searchValue} searchFunction={() => {}} />
 		{/if}

--- a/sites/docs/pages/components/charts/line-chart/index.md
+++ b/sites/docs/pages/components/charts/line-chart/index.md
@@ -15,12 +15,20 @@ group by all
 
 <DocTab>
     <div slot='preview'>
+        <Grid>
         <LineChart 
             data={orders_by_month}
             x=month
             y=sales_usd0k 
             yAxisTitle="Sales per Month"
+            title="Title"
+            subtitle="Subtitle"
         />
+        <DataTable data={orders_by_month} 
+                    title="Title"
+            subtitle="Subtitle"/>
+        </Grid>
+        
     </div>
 
 ```svelte

--- a/sites/docs/pages/components/charts/line-chart/index.md
+++ b/sites/docs/pages/components/charts/line-chart/index.md
@@ -15,20 +15,12 @@ group by all
 
 <DocTab>
     <div slot='preview'>
-        <Grid>
         <LineChart 
             data={orders_by_month}
             x=month
-            y=sales_usd0k 
+            y=sales_usd0k
             yAxisTitle="Sales per Month"
-            title="Title"
-            subtitle="Subtitle"
-        />
-        <DataTable data={orders_by_month} 
-                    title="Title"
-            subtitle="Subtitle"/>
-        </Grid>
-        
+        />        
     </div>
 
 ```svelte

--- a/sites/docs/pages/components/data/data-table/index.md
+++ b/sites/docs/pages/components/data/data-table/index.md
@@ -15,7 +15,7 @@ limit 100
 
 <DocTab>
     <div slot='preview'>
-        <DataTable data={orders_summary} title="Title" subtitle="Subtitle"/>
+        <DataTable data={orders_summary}/>
     </div>
 
 ```svelte

--- a/sites/docs/pages/components/data/data-table/index.md
+++ b/sites/docs/pages/components/data/data-table/index.md
@@ -15,7 +15,7 @@ limit 100
 
 <DocTab>
     <div slot='preview'>
-        <DataTable data={orders_summary}/>
+        <DataTable data={orders_summary} title="Title" subtitle="Subtitle"/>
     </div>
 
 ```svelte
@@ -1259,6 +1259,22 @@ Query name, wrapped in curly braces
 >
 
 Number of rows to show in the table before paginating results. Use `rows=all` to show all rows in the table.
+
+</PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the table
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
 
 </PropListing>
 <PropListing

--- a/sites/docs/pages/components/inputs/dimension-grid/index.md
+++ b/sites/docs/pages/components/inputs/dimension-grid/index.md
@@ -23,7 +23,7 @@ group by all
 
 <DocTab>
     <div slot='preview'>
-        <DimensionGrid data={orders} metric='sum(sales)' name=selected_dimensions /> 
+        <DimensionGrid data={orders} metric='sum(sales)' name=selected_dimensions/> 
 
         <LineChart data={monthly_sales} handleMissing=zero/> 
     </div>
@@ -133,6 +133,22 @@ SQL aggregate which could be applied to `data` e.g. 'sum(sales)'
 >
 
 Name of the dimension grid, used to reference the selected value elsewhere as `{inputs.name}`
+
+</PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the dimension grid
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
 
 </PropListing>
 <PropListing 

--- a/sites/docs/pages/components/maps/area-map/index.md
+++ b/sites/docs/pages/components/maps/area-map/index.md
@@ -590,6 +590,22 @@ options="format string"
 >
 Format string for displaying the value.
 </PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the map
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
+
+</PropListing>
 
 ### Color Scale
 

--- a/sites/docs/pages/components/maps/base-map/index.md
+++ b/sites/docs/pages/components/maps/base-map/index.md
@@ -315,6 +315,22 @@ defaultValue="300"
 >
 Height of the map in pixels.
 </PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the map
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
+
+</PropListing>
 
 ## Layer Options
 

--- a/sites/docs/pages/components/maps/bubble-map/index.md
+++ b/sites/docs/pages/components/maps/bubble-map/index.md
@@ -515,6 +515,22 @@ options="column name"
 >
 Column containing the names/labels of the points - by default, this is shown as the title of the tooltip.
 </PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the map
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
+
+</PropListing>
 
 ### Color Scale
 

--- a/sites/docs/pages/components/maps/point-map/index.md
+++ b/sites/docs/pages/components/maps/point-map/index.md
@@ -420,6 +420,22 @@ options="column name"
 >
 Column containing the names/labels of the points - by default, this is shown as the title of the tooltip.
 </PropListing>
+<PropListing
+    name=title
+    options="string"
+>
+
+Title for the map
+
+</PropListing>
+<PropListing
+    name=subtitle
+    options="string"
+>
+
+Subtitle - appears under the title
+
+</PropListing>
 
 ### Color Scale
 


### PR DESCRIPTION
### Description
Updates spacing across the component library to make them more consistent and aligned when placed side by side.

Adds title and subtitle for components to match the title and subtitles available in charts.

### New Title and Subtitle Props
![CleanShot 2025-01-02 at 18 49 21@2x](https://github.com/user-attachments/assets/ab34481b-f4c2-4837-a319-28dc058e31cf)
![CleanShot 2025-01-02 at 18 48 20@2x](https://github.com/user-attachments/assets/ce0475e4-88ae-4303-b55a-dc53ba2de39f)
![CleanShot 2025-01-02 at 18 47 37@2x](https://github.com/user-attachments/assets/c3f74409-efa8-4a9a-91a5-23d6684b8284)

### Spacing and Alignment
![CleanShot 2025-01-03 at 11 08 06@2x](https://github.com/user-attachments/assets/5de540e0-3305-4c59-9844-09d7adbea50b)
![CleanShot 2025-01-03 at 11 07 56@2x](https://github.com/user-attachments/assets/978decbf-28f3-4fe4-a519-76af3806fb0d)
![CleanShot 2025-01-03 at 11 06 57@2x](https://github.com/user-attachments/assets/d9a12664-344d-4f65-9d4d-58e3c7b2a1a2)


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
