### PR TITLE
Fix case sensitivity of sort in DataTable

### DIFF
--- a/.changeset/odd-cups-attend.md
+++ b/.changeset/odd-cups-attend.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix case sensitivity of sort in DataTable

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/_DataTable.svelte
@@ -366,13 +366,21 @@
 		const forceTopOfAscending = (val) =>
 			val === undefined || val === null || (typeof val === 'number' && isNaN(val));
 
-		const comparator = (a, b) =>
-			(forceTopOfAscending(a[column]) && !forceTopOfAscending(b[column])) || a[column] < b[column]
-				? -1 * sortModifier
-				: (forceTopOfAscending(b[column]) && !forceTopOfAscending(a[column])) ||
-					  a[column] > b[column]
-					? 1 * sortModifier
-					: 0;
+		const comparator = (a, b) => {
+			const valA = a[column];
+			const valB = b[column];
+
+			if (forceTopOfAscending(valA) && !forceTopOfAscending(valB)) return -1 * sortModifier;
+			if (forceTopOfAscending(valB) && !forceTopOfAscending(valA)) return 1 * sortModifier;
+
+			// Ensure values are strings for case-insensitive comparison
+			const normalizedA = typeof valA === 'string' ? valA.toLowerCase() : valA;
+			const normalizedB = typeof valB === 'string' ? valB.toLowerCase() : valB;
+
+			if (normalizedA < normalizedB) return -1 * sortModifier;
+			if (normalizedA > normalizedB) return 1 * sortModifier;
+			return 0;
+		};
 
 		if (groupBy) {
 			const sortedGroupedData = {};


### PR DESCRIPTION
### Description
Fixes issue in DataTable where uppercase strings and lowercase strings were sorted separately, which resulted in situations like:

```
Apple
Banana
apple
banana
```

Post fix, this returns:

```
Apple
apple
Banana
banana
```

### Checklist

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)