### PR TITLE
Expand clickable area of level three sidebar links

### DIFF
--- a/.changeset/olive-walls-clean.md
+++ b/.changeset/olive-walls-clean.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Expand click targets in sidebar level 3

--- a/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/sidebar/Sidebar.svelte
@@ -338,7 +338,7 @@
 										>
 											<a
 												href={addBasePath(thirdLevelFile.href)}
-												class="group inline-block capitalize transition-all duration-200 {active
+												class="group inline-block w-full capitalize transition-all duration-200 {active
 													? 'text-primary'
 													: 'text-base-content-muted hover:text-base-content'}"
 											>


### PR DESCRIPTION
### Description

Make level three links in the sidebar click-able for the full width of the sidebar, rather than just the width of the text. Aligns the behaviour to level two links. 
