### PR TITLE
fix print preview in dark mode

### DIFF
--- a/.changeset/selfish-coins-wash.md
+++ b/.changeset/selfish-coins-wash.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixes print preview in dark mode

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -135,7 +135,8 @@
 		console.debug('[fix-tprotocol-service-worker] Service Worker registered', { registration });
 	});
 
-	const { syncDataThemeAttribute, cycleAppearance } = getThemeStores();
+	const { syncDataThemeAttribute, cycleAppearance, selectedAppearance, setAppearance } =
+		getThemeStores();
 
 	onMount(() => {
 		/** @param {KeyboardEvent} e */
@@ -149,6 +150,32 @@
 	});
 
 	onMount(() => syncDataThemeAttribute(document.querySelector('html')));
+
+	//handles printing in dark mode
+	onMount(() => {
+		let currentTheme;
+
+		//add event listner for print, switch darkmode to light mode
+		window.addEventListener('beforeprint', () => {
+			currentTheme = $selectedAppearance;
+			if ($selectedAppearance === 'dark') {
+				setAppearance('light');
+			}
+		});
+		//when finished printing return to previous mode
+		window.addEventListener('afterprint', () => {
+			if (currentTheme === 'dark') {
+				setAppearance('dark');
+			} else if (currentTheme === 'system') {
+				setAppearance('system');
+			}
+		});
+
+		return () => {
+			window.removeEventListener('beforeprint', () => {});
+			window.removeEventListener('afterprint', () => {});
+		};
+	});
 </script>
 
 <slot />

--- a/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
+++ b/packages/ui/core-components/src/lib/organisms/layout/EvidenceDefaultLayout.svelte
@@ -135,8 +135,13 @@
 		console.debug('[fix-tprotocol-service-worker] Service Worker registered', { registration });
 	});
 
-	const { syncDataThemeAttribute, cycleAppearance, selectedAppearance, setAppearance } =
-		getThemeStores();
+	const {
+		syncDataThemeAttribute,
+		cycleAppearance,
+		selectedAppearance,
+		setAppearance,
+		activeAppearance
+	} = getThemeStores();
 
 	onMount(() => {
 		/** @param {KeyboardEvent} e */
@@ -155,25 +160,25 @@
 	onMount(() => {
 		let currentTheme;
 
-		//add event listner for print, switch darkmode to light mode
-		window.addEventListener('beforeprint', () => {
-			currentTheme = $selectedAppearance;
+		const beforePrintHandler = () => {
+			currentTheme = $activeAppearance;
 			if ($selectedAppearance === 'dark') {
 				setAppearance('light');
 			}
-		});
-		//when finished printing return to previous mode
-		window.addEventListener('afterprint', () => {
+		};
+
+		const afterPrintHandler = () => {
 			if (currentTheme === 'dark') {
 				setAppearance('dark');
-			} else if (currentTheme === 'system') {
-				setAppearance('system');
 			}
-		});
+		};
+
+		window.addEventListener('beforeprint', beforePrintHandler);
+		window.addEventListener('afterprint', afterPrintHandler);
 
 		return () => {
-			window.removeEventListener('beforeprint', () => {});
-			window.removeEventListener('afterprint', () => {});
+			window.removeEventListener('beforeprint', beforePrintHandler);
+			window.removeEventListener('afterprint', afterPrintHandler);
 		};
 	});
 </script>


### PR DESCRIPTION
### Description

Ensures when in `Dark mode` or `System: Dark Mode` that print preview will have `light mode` styling



https://github.com/user-attachments/assets/fb54c5d8-ee44-4293-9eca-f134263a11c1



Something I noticed that `system: dark mode` takes care of print preview in `light mode`, whilst keeping the page with `dark mode` styling. It would be ideal if `dark mode` did the same, but couldn't find a way to make that happen.


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- ~~[ ] I have added to the docs where applicable~~
- ~~[ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
