### PR TITLE
POC full screen charts

### DIFF
--- a/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/ECharts.svelte
@@ -44,6 +44,10 @@
 	let copying = false;
 	let printing = false;
 	let hovering = false;
+	let fullscreen = false;
+	import Fullscreen from '../../../atoms/fullscreen/Fullscreen.svelte';
+	import EnterFullScreen from '../../../unsorted/viz/table/EnterFullScreen.svelte';
+	export let isFullPage = false;
 </script>
 
 <svelte:window
@@ -145,6 +149,9 @@
 					display={hovering}
 				/>
 			{/if}
+			{#if !isFullPage}
+					<EnterFullScreen on:click={() => (fullscreen = true)} display={hovering} />
+				{/if}
 		</div>
 	{/if}
 
@@ -152,6 +159,14 @@
 		<CodeBlock source={JSON.stringify(config, undefined, 3)} copyToClipboard={true}>
 			{JSON.stringify(config, undefined, 3)}
 		</CodeBlock>
+	{/if}
+
+	{#if !isFullPage}
+		<Fullscreen bind:open={fullscreen}>
+			<div class="pt-4">
+				<svelte:self {...$$props} isFullPage={true} height={`70vh`}></svelte:self>
+			</div>
+		</Fullscreen>
 	{/if}
 </div>
 


### PR DESCRIPTION
### Description


https://github.com/user-attachments/assets/af5f721a-76c5-4cc9-af55-c28c72c6f858

# To Do
- Move EnterFullScreen component to more sane location
- Calculate height more carefully
- Test edge cases
  - title
  - title and subtitle
  - user has custom height for chart
  - graph is in grid

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
