### PR TITLE
Fix datasource ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
   run-tests:
     needs:
       - find-e2e-test-projects
-
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/sites/test-env/evidence.config.yaml
+++ b/sites/test-env/evidence.config.yaml
@@ -10,4 +10,4 @@ plugins:
       @evidence-dev/snowflake: { }
       @evidence-dev/motherduck: { }
       @evidence-dev/mssql: { }
-      @evidence-dev/javascript: { }
+      @evidence-dev/source-javascript: { }


### PR DESCRIPTION
### Description

I renamed @evidence-dev/javascript to @evidence-dev/source-javascript but missed this, which is causing CI to fail