### PR TITLE
fix download props to handle strings

### DIFF
--- a/.changeset/dull-carrots-invent.md
+++ b/.changeset/dull-carrots-invent.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed downloadable image and data prop

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/Heatmap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/Heatmap.stories.svelte
@@ -28,3 +28,14 @@
 <Story name="All" let:args>
 	<Heatmap {...args} {data} x="x" y="y" value="value" />
 </Story>
+<Story name="disable download" let:args>
+	<Heatmap
+		{...args}
+		{data}
+		x="x"
+		y="y"
+		value="value"
+		downloadableImage="false"
+		downloadableData="false"
+	/>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
@@ -17,6 +17,7 @@
 	import getSortedDistinctValues from '@evidence-dev/component-utilities/getSortedDistinctValues';
 	import getCompletedData from '@evidence-dev/component-utilities/getCompletedData';
 	import { getThemeStores } from '../../../themes/themes.js';
+	import { toBoolean } from '../../../utils.js';
 
 	const { theme, resolveColorScale } = getThemeStores();
 
@@ -83,6 +84,9 @@
 	export let renderer = undefined;
 	export let downloadableData = undefined;
 	export let downloadableImage = undefined;
+
+	$: downloadableData = toBoolean(downloadableData);
+	$: downloadableImage = toBoolean(downloadableImage);
 
 	export let connectGroup = undefined;
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/heatmap/_Heatmap.svelte
@@ -82,8 +82,8 @@
 	export let cellHeight = 30;
 
 	export let renderer = undefined;
-	export let downloadableData = undefined;
-	export let downloadableImage = undefined;
+	export let downloadableData = true;
+	export let downloadableImage = true;
 
 	$: downloadableData = toBoolean(downloadableData);
 	$: downloadableImage = toBoolean(downloadableImage);


### PR DESCRIPTION
### Description

Added toBoolean for `downloadableData` & `downloadableImage` props for Heatmap chart

### Checklist

- [] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
