### PR TITLE
Update default color values from 'grey' to 'base-content-muted' in Annotations, and SankeyDiagram

### DIFF
--- a/.changeset/itchy-carrots-chew.md
+++ b/.changeset/itchy-carrots-chew.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+replace deprecated colors

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferenceLine/ReferenceLine.svelte
@@ -44,9 +44,9 @@
 
 	/**
 	 * @type {string}
-	 * @default "grey"
+	 * @default "base-content-muted"
 	 */
-	export let color = 'grey';
+	export let color = 'base-content-muted';
 	$: color = checkDeprecatedColor('ReferenceLine', 'color', color);
 	$: colorStore = resolveColor(color);
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/references/ReferencePoint/ReferencePoint.svelte
@@ -40,9 +40,9 @@
 
 	/**
 	 * @type {string}
-	 * @default "grey"
+	 * @default "base-content-muted"
 	 */
-	export let color = 'grey';
+	export let color = 'base-content-muted';
 	$: color = checkDeprecatedColor(chartType, 'color', color);
 	$: colorStore = resolveColor(color);
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/sankey/_SankeyDiagram.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/sankey/_SankeyDiagram.svelte
@@ -54,7 +54,7 @@
 
 	export let depthOverride; // object like: {'node name': 1, 'node name 2': 2} where number is depth level (0-based)
 
-	export let linkColor = 'grey'; // grey (default), source, target, gradient
+	export let linkColor = 'base-content-muted'; // base-content-muted (default), source, target, gradient
 	$: linkColorStore = resolveColor(linkColor);
 
 	// Data Formatting

--- a/sites/docs/pages/components/charts/annotations/index.md
+++ b/sites/docs/pages/components/charts/annotations/index.md
@@ -1052,7 +1052,7 @@ where sales_diff < -2000
         name=color
         description="Color to override default line and label colors"
         options="CSS name | hexademical | RGB | HSL"
-        defaultValue=grey
+        defaultValue=base-content-muted
     />
     <PropListing
         name=labelColor
@@ -1356,7 +1356,7 @@ where sales_diff < -2000
         name=color
         description="Color to override default line and label colors"
         options="CSS name | hexademical | RGB | HSL"
-        defaultValue=grey
+        defaultValue=base-content-muted
     />
     <PropListing
         name=labelColor

--- a/sites/docs/pages/components/charts/sankey-diagram/index.md
+++ b/sites/docs/pages/components/charts/sankey-diagram/index.md
@@ -355,7 +355,7 @@ Requires `percentCol` to show percentage beside value
       targetCol=target 
       valueCol=amount 
       percentCol=percent 
-      linkColor=grey
+      linkColor=base-content-muted
       colorPalette={['#ad4940', '#3d8cc4', '#1b5218', '#ebb154']}
     />
   </div>
@@ -367,7 +367,7 @@ Requires `percentCol` to show percentage beside value
   targetCol=target 
   valueCol=amount 
   percentCol=percent 
-  linkColor=grey
+  linkColor=base-content-muted
   colorPalette={['#ad4940', '#3d8cc4', '#1b5218', '#ebb154']}
 />
 ```
@@ -376,7 +376,7 @@ Requires `percentCol` to show percentage beside value
 
 ## Link Colors
 
-### `linkColor=grey` (default)
+### `linkColor=base-content-muted` (default)
 
 <DocTab>
   <div slot='preview'>
@@ -386,7 +386,7 @@ Requires `percentCol` to show percentage beside value
       targetCol=target 
       valueCol=amount 
       percentCol=percent 
-      linkColor=grey
+      linkColor=base-content-muted
       colorPalette={['#ad4940', '#3d8cc4', '#1b5218', '#ebb154']}
     />
   </div>
@@ -398,7 +398,7 @@ Requires `percentCol` to show percentage beside value
   targetCol=target 
   valueCol=amount 
   percentCol=percent 
-  linkColor=grey
+  linkColor=base-content-muted
   colorPalette={['#ad4940', '#3d8cc4', '#1b5218', '#ebb154']}
 />
 ```
@@ -697,8 +697,8 @@ Array of custom colours to use for the chart. E.g., `{['#cf0d06','#eb5752','#e88
 </PropListing>
 <PropListing
     name="linkColor"
-    options={['grey', 'source', 'target', 'gradient']}
-    defaultValue="grey"
+    options={['base-content-muted', 'source', 'target', 'gradient']}
+    defaultValue="base-content-muted"
 >
 
 Color to use for the links between nodes in the diagram


### PR DESCRIPTION
### Description

A few explicit color names hanging around, now removed.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
