### PR TITLE
Fix/2683 no legend strings

### DIFF
--- a/.changeset/fuzzy-jokes-know.md
+++ b/.changeset/fuzzy-jokes-know.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed legend false prop to respect strings

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.stories.svelte
@@ -149,3 +149,16 @@ ORDER BY 1;
 	/>
 	<div class="h-32"></div>
 </Story>
+<Story name="No Legend" parameters={{ chromatic: { disableSnapshot: true } }}>
+	<AreaMap
+		legendType="categorical"
+		legendPosition="bottomLeft"
+		data={grouped_locations}
+		lat="lat"
+		long="long"
+		value="Category"
+		geoId="ZCTA5CE10"
+		areaCol="zip_code"
+		legend="false"
+	/>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/AreaMap.svelte
@@ -6,6 +6,7 @@
 	import Areas from './components/Areas.svelte';
 	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
+	import { toBoolean } from '../../../utils.js';
 
 	/** @type {'pass' | 'warn' | 'error' | undefined} */
 	export let emptySet = undefined;
@@ -61,6 +62,8 @@
 	export let legendType = undefined;
 	/** @type {boolean} */
 	export let legend = true;
+
+	$: legend = toBoolean(legend);
 
 	/** @type {string|undefined} */
 	export let attribution = undefined;

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.stories.svelte
@@ -284,3 +284,20 @@ ORDER BY 1;
 		/>
 	</BaseMap>
 </Story>
+<Story name="no legend">
+	<BaseMap title="My Map" height="300" legend={false}>
+		<Points data={la_locations} lat="lat" long="long" color="purple" z="1" value="sales" />
+		<Bubbles
+			data={la_locations}
+			lat="lat"
+			long="long"
+			pointName="point_name"
+			value="sales"
+			size="sales"
+			tooltipType="hover"
+			opacity="0.6"
+			color="blue"
+			z="2"
+		/>
+	</BaseMap>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BaseMap.svelte
@@ -11,6 +11,7 @@
 	import { mapContextKey } from './constants.js';
 	import Skeleton from '../../../atoms/skeletons/Skeleton.svelte';
 	import Legend from './components/Legend.svelte';
+	import { toBoolean } from '../../../utils.js';
 
 	let mapElement;
 
@@ -42,6 +43,11 @@
 
 	/** @type {string|undefined} */
 	export let attribution = undefined;
+
+	/** @type {string|boolean} */
+	export let legend = true;
+
+	$: legend = toBoolean(legend);
 
 	const evidenceMap = new EvidenceMap();
 	setContext(mapContextKey, evidenceMap);
@@ -105,7 +111,7 @@
 			<div on:dispatcherror={(e) => (error = e.detail)}>
 				<slot />
 			</div>
-			{#if $legendData}
+			{#if $legendData && legend}
 				<Legend {legendData} {legendPosition} {height} />
 			{/if}
 		</div>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.stories.svelte
@@ -126,3 +126,7 @@
 	/>
 	<div class="h-32"></div>
 </Story>
+
+<Story name="No legend" parameters={{ chromatic: { disableSnapshot: true } }}>
+	<BubbleMap data={la_locations} lat="lat" long="long" size="sales" value="sales" legend="false" />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/BubbleMap.svelte
@@ -7,6 +7,7 @@
 	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
 	import { getThemeStores } from '../../../themes/themes.js';
+	import { toBoolean } from '../../../utils.js';
 
 	const { resolveColorPalette } = getThemeStores();
 
@@ -69,6 +70,8 @@
 
 	/** @type {boolean} */
 	export let legend = true;
+
+	$: legend = toBoolean(legend);
 
 	/** @type {string|undefined} */
 	export let attribution = undefined;

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.stories.svelte
@@ -287,3 +287,21 @@
 	/>
 	<div class="h-32"></div>
 </Story>
+<Story name="no legend" parameters={{ chromatic: { disableSnapshot: true } }}>
+	<PointMap
+		title="legend false as string"
+		data={la_locations}
+		lat="lat"
+		long="long"
+		value="sales"
+		legend="false"
+	/>
+	<PointMap
+		title="legend false as boolean"
+		data={la_locations}
+		lat="lat"
+		long="long"
+		value="sales"
+		legend={false}
+	/>
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/PointMap.svelte
@@ -7,6 +7,7 @@
 	import BaseMap from './_BaseMap.svelte';
 	import { Query } from '@evidence-dev/sdk/usql';
 	import { getThemeStores } from '../../../themes/themes.js';
+	import { toBoolean } from '../../../utils.js';
 
 	const { resolveColorPalette } = getThemeStores();
 
@@ -66,6 +67,8 @@
 
 	/** @type {boolean} */
 	export let legend = true;
+
+	$: legend = toBoolean(legend);
 
 	/** @type {string|undefined} */
 	export let attribution = undefined;


### PR DESCRIPTION
### Description

Added toBoolean checks to maps legend prop to respect `"false"` strings

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
