### PR TITLE
added toBoolean to handle abbreviations prop string value

### DIFF
--- a/.changeset/afraid-pumpkins-destroy.md
+++ b/.changeset/afraid-pumpkins-destroy.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+fixed US map abbreviaabbreviations string handling

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/USMap.stories.svelte
@@ -37,3 +37,9 @@
 	{@const data = Query.create(`SELECT * from state_sales`, slowQuery)}
 	<USMap {data} {...args} state="state" value="sales" />
 </Story>
+
+<Story name="No Abb" let:args>
+	{@const data = Query.create(`SELECT * from state_sales`, query)}
+	<USMap {data} {...args} state="state" value="sales" abbreviations="false" />
+	<USMap {data} {...args} state="state" value="sales" abbreviations={false} />
+</Story>

--- a/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/map/_USMap.svelte
@@ -16,6 +16,7 @@
 	import InvisibleLinks from '../../../atoms/InvisibleLinks.svelte';
 	import { getThemeStores } from '../../../themes/themes.js';
 	import { checkDeprecatedColor } from '../../../deprecated-colors.js';
+	import { toBoolean } from '../../../utils.js';
 
 	const { theme, resolveColorPalette, resolveColorScale } = getThemeStores();
 
@@ -95,7 +96,7 @@
 	export let connectGroup = undefined;
 
 	export let abbreviations = false;
-	$: abbreviations = abbreviations === 'true' || abbreviations === true;
+	$: abbreviations = toBoolean(abbreviations);
 
 	let nameProperty = abbreviations ? 'abbrev' : 'name';
 


### PR DESCRIPTION
### Description

Added toBoolean to abbreviation prop in US maps to handle strings, added stories

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
