### PR TITLE
Fix mobile usage issue for Info component

### DIFF
--- a/.changeset/tiny-trees-judge.md
+++ b/.changeset/tiny-trees-judge.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix mobile usage issue for Info component

--- a/packages/ui/core-components/src/lib/atoms/hover-card/HoverCard.svelte
+++ b/packages/ui/core-components/src/lib/atoms/hover-card/HoverCard.svelte
@@ -11,9 +11,10 @@
 	export let sideOffset = 4;
 	export let openDelay = 0;
 	export let closeDelay = 0;
+	export let open = false;
 </script>
 
-<HoverCard {openDelay} {closeDelay}>
+<HoverCard {open} {openDelay} {closeDelay}>
 	<HoverCardTrigger>
 		<slot name="trigger" />
 	</HoverCardTrigger>

--- a/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
@@ -9,27 +9,33 @@
 	import chroma from 'chroma-js';
 	import HoverCard from '../../atoms/hover-card/HoverCard.svelte';
 
-	/** @type {import('@steeze-ui/svelte-icon').IconSource} */
 	let icon = InfoCircled;
-
 	export let description = '';
-
 	export let size = 4;
-
 	export let className = undefined;
-
 	const { resolveColor } = getThemeStores();
 	export let color = 'base-content-muted';
+
 	$: colorStore = resolveColor(color);
 	$: textColor = chroma($colorStore).css();
+
+	// State for manual toggle
+	let isOpen = false;
+
+	function toggleOpen() {
+		isOpen = !isOpen;
+	}
 </script>
 
-<HoverCard align="start" side="right" alignOffset={-8} sideOffset={4}>
+<HoverCard open={isOpen} align="start" side="right" alignOffset={-8} sideOffset={4}>
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 	<span
 		slot="trigger"
 		style:--textColor={textColor}
-		class="inline-block align-middle pb-0.5 pr-1 leading-4 w-fit {className}"
+		class="inline-block align-middle pb-0.5 pr-1 leading-4 w-fit {className} cursor-pointer"
 		role="tooltip"
+		on:click={toggleOpen}
 	>
 		<slot name="handle">
 			<Icon src={icon} class="w-{size} h-{size} text-[--textColor]" />

--- a/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
@@ -28,19 +28,22 @@
 </script>
 
 <HoverCard open={isOpen} align="start" side="right" alignOffset={-8} sideOffset={4}>
-	<!-- svelte-ignore a11y-click-events-have-key-events -->
-	<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 	<span
 		slot="trigger"
 		style:--textColor={textColor}
 		class="inline-block align-middle pb-0.5 pr-1 leading-4 w-fit {className} cursor-pointer"
-		role="tooltip"
+		role="button"
+		aria-expanded={isOpen}
+		aria-label="Toggle tooltip"
+		tabindex="0"
 		on:click={toggleOpen}
+		on:keydown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleOpen()}
 	>
 		<slot name="handle">
 			<Icon src={icon} class="w-{size} h-{size} text-[--textColor]" />
 		</slot>
 	</span>
+
 	<div slot="content" class="bg-base-100 p-2 rounded-md text-base-content text-xs max-w-52">
 		<p class="leading-relaxed text-pretty">
 			{description}


### PR DESCRIPTION
Fixes issue with Info component where on mobile, hover to show tooltip did not work. Now clicks will work in addition to hover.

- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
