### PR TITLE
ci: skip docs only checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,11 +29,14 @@ jobs:
         id: docs-check
         shell: bash
         run: |
+          # Fetch the base branch
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          
           # Get list of changed files
           CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }})
           
           # Check if any changed files are outside sites/docs/
-          NON_DOCS_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^sites/docs/')
+          NON_DOCS_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^sites/docs/' || true)
 
           if [ -z "$NON_DOCS_CHANGES" ]; then
             echo "only_docs=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: '*'
+    branches: [main, next]
 
 jobs:
   run-tests:
@@ -31,10 +31,10 @@ jobs:
         run: |
           # Fetch the base branch
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          
+
           # Get list of changed files
           CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }})
-          
+
           # Check if any changed files are outside sites/docs/
           NON_DOCS_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^sites/docs/' || true)
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [main, next]
+    branches: '*'
 
 jobs:
   run-tests:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,47 +44,51 @@ jobs:
             echo "only_docs=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Skip Tests for Docs-only Changes
-        if: steps.docs-check.outputs.only_docs == 'true'
-        run: |
-          echo "Skipping tests because only docs were changed."
-          exit 0
-
       - name: Set OS environment variable
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: echo "__E2E_WORKFLOW_OS__=${{ matrix.os }}" >> $GITHUB_ENV
 
       - name: Action Setup (pnpm)
+        if: steps.docs-check.outputs.only_docs != 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
+        if: steps.docs-check.outputs.only_docs != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright and browsers
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm playwright install --with-deps
 
       - name: Run setup
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm --filter "./e2e/*" run --if-present setup
 
       - name: Run sources
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm --filter "./e2e/*" run sources
 
       - name: Run dev mode tests
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm --filter "./e2e/*" --sequential run test:dev
 
       - name: Build
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm --filter "./e2e/*" run build
 
       - name: Run preview mode tests
+        if: steps.docs-check.outputs.only_docs != 'true'
         run: pnpm --filter "./e2e/*" --sequential run test:preview
 
       - name: Upload Playwright reports
-        if: always()
+        if: always() && steps.docs-check.outputs.only_docs != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report__e2e_${{ matrix.os }}_node-${{ matrix.node-version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,7 @@ jobs:
 
           if [ -z "$NON_DOCS_CHANGES" ]; then
             echo "only_docs=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping e2e tests because only docs were changed."
           else
             echo "only_docs=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         node-version: [18.13.0, 20, 22]
-
-        # When not on main, exclude non-latest node version and macOS/Windows
         isMain:
           - ${{ github.base_ref == 'main' }}
         exclude:
@@ -24,11 +22,33 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set OS environment variable
-        run: echo "__E2E_WORKFLOW_OS__=${{ matrix.os }}" >> $GITHUB_ENV
-
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Check if only docs changed
+        id: docs-check
+        shell: bash
+        run: |
+          # Get list of changed files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }})
+          
+          # Check if any changed files are outside sites/docs/
+          NON_DOCS_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^sites/docs/')
+
+          if [ -z "$NON_DOCS_CHANGES" ]; then
+            echo "only_docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only_docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Tests for Docs-only Changes
+        if: steps.docs-check.outputs.only_docs == 'true'
+        run: |
+          echo "Skipping tests because only docs were changed."
+          exit 0
+
+      - name: Set OS environment variable
+        run: echo "__E2E_WORKFLOW_OS__=${{ matrix.os }}" >> $GITHUB_ENV
 
       - name: Action Setup (pnpm)
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
### Description

- Skips full e2e tests if the changes are isolated to the `sites/docs/**` files in the monorepo
- This could be extended to include other CI tests, but these are the slowest ones right now
- The implementation works around [this github limitation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks) around required checks

See this in action: #3072 

![CleanShot 2025-02-04 at 12 33 47@2x](https://github.com/user-attachments/assets/5967245f-9f89-4dd0-9890-aa855549590c)


### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
