### PR TITLE
[hotfix] chore: override process warnings from node

### DIFF
--- a/.changeset/fluffy-apples-talk.md
+++ b/.changeset/fluffy-apples-talk.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/evidence': patch
+---
+
+Mute a warning that is caused by ESM/CJS interactions. There is an upcoming fix for this issue

--- a/packages/evidence/scripts/build-template.js
+++ b/packages/evidence/scripts/build-template.js
@@ -55,6 +55,18 @@ fsExtra.outputFileSync(
 	import { log } from "@evidence-dev/sdk/logger";
 	import { evidenceThemes } from '@evidence-dev/tailwind/vite-plugin';
 
+
+	process.removeAllListeners('warning');
+	process.on('warning', (warning) => {
+	  if (warning.name === 'ExperimentalWarning' && 
+	      warning.message.includes('CommonJS module') && 
+	      warning.message.includes('ES Module')) {
+	    return;
+	  }
+	  console.warn(warning);
+	});
+
+
 	const logger = createLogger();
 
     const strictFs = (process.env.NODE_ENV === 'development') ? false : true;


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

This mutes an error that popped up with a version upgrade:

```
(node:52040) ExperimentalWarning: CommonJS module /home/brian/code/evidence/template/.evidence/template/t
ailwind.config.cjs is loading ES Module /home/brian/code/evidence/template/node_modules/@evidence-dev/tai
lwind/src/config/config.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

### Checklist

- [ ] ~~For UI or styling changes, I have added a screenshot or gif showing before & after~~
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] ~~I have added to the docs where applicable~~
- [ ] ~~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~~
