### PR TITLE
Fixes issue with openInNewTab for DataTable rows

### DIFF
--- a/.changeset/plenty-rings-nail.md
+++ b/.changeset/plenty-rings-nail.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fixes issue where clicking a table row link with openInNewTab=true did not actually open the link in a new tab

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/TableRow.svelte
@@ -41,9 +41,15 @@
 		await preloadData(url);
 	};
 
-	const navigateToLink = async (row) => {
+	const navigateToLink = async (row, event) => {
 		if (!link || !row[link]) return;
 		const url = row[link];
+
+		// Don't handle the click if it's on a link element that should open in new tab
+		const target = event?.target?.closest('a');
+		if (target?.getAttribute('target') === '_blank') {
+			return;
+		}
 
 		if (isUrlExternal(url)) {
 			window.location = addBasePath(url);
@@ -63,7 +69,7 @@
 		class:hover:bg-base-200={link && row[link]}
 		on:mouseover={() => preloadLink(row)}
 		on:focus={() => preloadLink(row)}
-		on:click={() => navigateToLink(row)}
+		on:click={(event) => navigateToLink(row, event)}
 		class={rowLines ? 'border-b border-base-content-muted/20' : ''}
 	>
 		{#if rowNumbers && groupType !== 'section'}


### PR DESCRIPTION
Fixes issue where clicking a table row link with openInNewTab=true did not actually open the link in a new tab

### Description

There was an issue where setting openInNewTab for a DataTable row would still open the link in the same tab. This can be tested with the example project on the page `/tables/new-table/` by clicking a row in the first table. It opens the link (a Google search) in the same tab even though openInNewTab=true is set. This happens because there is an on:click handler on the TableRow that doesn't take the target=_blank property into account.
