### PR TITLE
Date range preset amendment

### DIFF
--- a/.changeset/rotten-wasps-poke.md
+++ b/.changeset/rotten-wasps-poke.md
@@ -1,0 +1,7 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Update Date Range presets with better defaults
+
+Month to Date & Year to Date - now both end on last available date of the data used

--- a/.changeset/rotten-wasps-poke.md
+++ b/.changeset/rotten-wasps-poke.md
@@ -2,6 +2,6 @@
 '@evidence-dev/core-components': patch
 ---
 
-Update Date Range presets with better defaults
+Update Date Range presets with new options
 
-Month to Date & Year to Date - now both end on last available date of the data used
+Month to Today & Year to Today - to end on the last available date of the data used

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
@@ -135,7 +135,7 @@
 			group: 'To Date',
 			range: {
 				start: startOfMonth(calendarEnd),
-				end: endOfMonth(calendarEnd)
+				end: calendarEnd
 			}
 		},
 		{
@@ -143,7 +143,7 @@
 			group: 'To Date',
 			range: {
 				start: startOfYear(calendarEnd),
-				end: endOfYear(calendarEnd)
+				end: calendarEnd
 			}
 		},
 		{

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
@@ -135,11 +135,27 @@
 			group: 'To Date',
 			range: {
 				start: startOfMonth(calendarEnd),
+				end: endOfMonth(calendarEnd)
+			}
+		},
+		{
+			label: 'Month to Today',
+			group: 'To Date',
+			range: {
+				start: startOfMonth(calendarEnd),
 				end: calendarEnd
 			}
 		},
 		{
 			label: 'Year to Date',
+			group: 'To Date',
+			range: {
+				start: startOfYear(calendarEnd),
+				end: endOfYear(calendarEnd)
+			}
+		},
+		{
+			label: 'Year to Today',
 			group: 'To Date',
 			range: {
 				start: startOfYear(calendarEnd),

--- a/sites/docs/pages/components/inputs/date-range/index.md
+++ b/sites/docs/pages/components/inputs/date-range/index.md
@@ -7,6 +7,7 @@ queries:
 ---
 
 Creates a date picker that can be used to filter a query.
+Includes a set of preset ranges for quick selection of common date ranges. These are relative to the supplied end date.
 
 To see how to filter a query using an input component, see [Filters](/core-concepts/filters).
 
@@ -255,7 +256,7 @@ Title to display in the Date Range component
     default=undefined
 >
 
-Customize "Select a Range" drop down, by including present range options. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
+Customize "Select a Range" drop down, by including present range options. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Month to Today'` `'Year to Date'` `'Year to Today'` `'All Time'`
 
 </PropListing>
 <PropListing 
@@ -265,7 +266,7 @@ Customize "Select a Range" drop down, by including present range options. **Rang
 >
 
 
-Accepts preset in string format to apply default value in Date Range picker. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Year to Date'` `'All Time'`
+Accepts preset in string format to apply default value in Date Range picker. **Range options**: `'Last 7 Days'` `'Last 30 Days'` `'Last 90 Days'` `'Last 365 Days'` `'Last 3 Months'` `'Last 6 Months'` `'Last 12 Months'` `'Last Month'` `'Last Year'` `'Month to Date'` `'Month to Today'` `'Year to Date'` `'Year to Today'` `'All Time'`
 
 </PropListing>
 <PropListing 

--- a/sites/docs/queries/orders_by_day.sql
+++ b/sites/docs/queries/orders_by_day.sql
@@ -4,6 +4,7 @@ select
     sum(sales) as sales,
     sum(sales) / count(*) as aov
 from needful_things.orders
-where order_datetime > '2019-01-02'
+where order_datetime > '2019-01-02' 
+  and order_datetime <= '2021-12-20'
 group by 1
 order by 1


### PR DESCRIPTION
### Description

New options to the Date Range UI components presets:
- `Month to Today`
- `Year to Today`

The `... to Date` presets sets the end date to the end of the Month and Year, respectively
These new presets will end the date range on the supplied end date
<img width="370" alt="image" src="https://github.com/user-attachments/assets/86b0e92c-05ac-443d-aca7-3f7bf2e323fd" />
<img width="372" alt="image" src="https://github.com/user-attachments/assets/c857c34f-e70b-40d7-a519-70b9b804ab1e" />


Raised in Bug - https://github.com/evidence-dev/evidence/issues/2450  

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] ~I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable~
