### PR TITLE
fix(DateInput.svelte): avoid off-by-one day east of UTC in DateInput

### DIFF
--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.svelte
@@ -5,14 +5,13 @@
 <script>
 	import DateInput from './_DateInput.svelte';
 	// import { Query } from '@evidence-dev/sdk/usql';
-	import { getLocalTimeZone } from '@internationalized/date';
 	import HiddenInPrint from '../shared/HiddenInPrint.svelte';
 	import { page } from '$app/stores';
 	import QueryLoad from '$lib/atoms/query-load/QueryLoad.svelte';
 	import { Skeleton } from '$lib/atoms/skeletons/index.js';
 	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
 	import { toBoolean } from '../../../utils.js';
-	import { dateToYYYYMMDD, formatDateString } from './helpers.js';
+	import { dateToYYYYMMDD, dateValueToDate, formatDateString } from './helpers.js';
 	import { buildQuery } from '@evidence-dev/component-utilities/buildQuery';
 	import InlineError from '../InlineError.svelte';
 	import checkRequiredProps from '../checkRequiredProps.js';
@@ -91,12 +90,16 @@
 	function onSelectedDateInputChange(selectedDateInput) {
 		if (selectedDateInput && (selectedDateInput.start || selectedDateInput.end) && range) {
 			$inputs[name] = {
-				start: dateToYYYYMMDD(selectedDateInput.start?.toDate(getLocalTimeZone()) ?? new Date(0)),
-				end: dateToYYYYMMDD(selectedDateInput.end?.toDate(getLocalTimeZone()) ?? new Date())
+				start: dateToYYYYMMDD(
+					selectedDateInput.start ? dateValueToDate(selectedDateInput.start) : new Date(0)
+				),
+				end: dateToYYYYMMDD(
+					selectedDateInput.end ? dateValueToDate(selectedDateInput.end) : new Date()
+				)
 			};
-		} else if (selectedDateInput && selectedDateInput && !range) {
+		} else if (selectedDateInput && !range) {
 			$inputs[name] = {
-				value: dateToYYYYMMDD(selectedDateInput.toDate(getLocalTimeZone()) ?? new Date(0))
+				value: dateToYYYYMMDD(dateValueToDate(selectedDateInput) ?? new Date(0))
 			};
 		}
 	}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
@@ -276,18 +276,18 @@
 							{/if}
 							<Separator orientation="vertical" class="mx-2 h-4 w-[1px]" />
 						{/if}
-						{dfMedium.format(selectedDateInput.toDate(getLocalTimeZone()))}
+						{dfMedium.format(dateValueToDate(selectedDateInput))}
 						<Icon src={CalendarIcon} class="ml-2 h-4 w-4 mb-[2px] stroke-[1.8px]" />
 					{:else if selectedDateInput && selectedDateInput.start}
 						{#if selectedDateInput.end}
-							{dfMedium.format(selectedDateInput.start.toDate(getLocalTimeZone()))} - {dfMedium.format(
-								selectedDateInput.end.toDate(getLocalTimeZone())
+							{dfMedium.format(dateValueToDate(selectedDateInput.start))} - {dfMedium.format(
+								dateValueToDate(selectedDateInput.end)
 							)}
 						{:else}
-							{dfMedium.format(selectedDateInput.start.toDate(getLocalTimeZone()))}
+							{dfMedium.format(dateValueToDate(selectedDateInput.start))}
 						{/if}
 					{:else if placeholder}
-						{dfMedium.format(placeholder.toDate(getLocalTimeZone()))}
+						{dfMedium.format(dateValueToDate(placeholder))}
 					{:else}
 						Date Input
 					{/if}
@@ -296,18 +296,18 @@
 					{#if !loaded}
 						Loading...
 					{:else if selectedDateInput && !range}
-						{dfShort.format(selectedDateInput.toDate(getLocalTimeZone()))}
+						{dfShort.format(dateValueToDate(selectedDateInput))}
 						<Icon src={CalendarIcon} class="ml-2 h-4 w-4 mb-[2px] stroke-[1.8px] text-gray-700" />
 					{:else if selectedDateInput && selectedDateInput.start}
 						{#if selectedDateInput.end}
-							{dfShort.format(selectedDateInput.start.toDate(getLocalTimeZone()))} - {dfShort.format(
-								selectedDateInput.end.toDate(getLocalTimeZone())
+							{dfShort.format(dateValueToDate(selectedDateInput.start))} - {dfShort.format(
+								dateValueToDate(selectedDateInput.end)
 							)}
 						{:else}
-							{dfShort.format(selectedDateInput.start.toDate(getLocalTimeZone()))}
+							{dfShort.format(dateValueToDate(selectedDateInput.start))}
 						{/if}
 					{:else if placeholder}
-						{dfShort.format(placeholder.toDate(getLocalTimeZone()))}
+						{dfShort.format(dateValueToDate(placeholder))}
 					{:else}
 						Date Input
 					{/if}

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/helpers.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/helpers.js
@@ -1,5 +1,14 @@
 const YYYYMMDD = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * Convert DateValue to Date
+ * @param {import('@internationalized/date').DateValue} dateValue
+ * @returns Date
+ */
+function dateValueToDate(dateValue) {
+	return dateValue.toDate('utc');
+}
+
 function dateToYYYYMMDD(date) {
 	return date.toISOString().split('T')[0];
 }
@@ -14,4 +23,4 @@ function formatDateString(date) {
 	}
 }
 
-export { dateToYYYYMMDD, formatDateString };
+export { dateToYYYYMMDD, dateValueToDate, formatDateString };

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/helpers.spec.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/helpers.spec.js
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { dateValueToDate } from './helpers.js';
+import { getLocalTimeZone } from '@internationalized/date';
+import { CalendarDate } from '@internationalized/date';
+
+describe.each([
+	({ tz: 'America/Edmonton', isotime: '2025-03-28T00:00:00.000Z' },
+	{ tz: 'UTC', isotime: '2025-03-28T00:00:00.000Z' },
+	{ tz: 'Europe/Berlin', isotime: '2025-03-27T23:00:00.000Z' })
+])('dateValueToDate, using timezone $tz', ({ tz, isotime }) => {
+	/** @type {import('@internationalized/date').DateValue} */
+	let value;
+	beforeEach(() => {
+		process.env.TZ = tz;
+		value = new CalendarDate(2025, 3, 28);
+	});
+	it('ensure timezone mocking works', () => {
+		const actualTz = getLocalTimeZone();
+		expect(actualTz).toEqual(tz);
+		expect(value.toDate(actualTz)).toEqual(new Date(isotime));
+	});
+	it('should return same day', () => {
+		expect(dateValueToDate(value)).toEqual(new Date('2025-03-28T00:00:00.000Z'));
+	});
+});

--- a/packages/ui/core-components/src/lib/atoms/shadcn/calendar/calendar.svelte
+++ b/packages/ui/core-components/src/lib/atoms/shadcn/calendar/calendar.svelte
@@ -16,8 +16,9 @@
 	} from './index.js';
 	import * as Select from '../select/index.js';
 	import { Select as SelectPrimitive } from 'bits-ui';
-	import { DateFormatter, getLocalTimeZone } from '@internationalized/date';
+	import { DateFormatter } from '@internationalized/date';
 
+	import { dateValueToDate } from '../../inputs/date-input/helpers.js';
 	import { cn } from '$lib/utils.js';
 
 	/** @type {import("bits-ui").DateRange | undefined} */
@@ -67,7 +68,7 @@
 		: undefined;
 
 	$: defaultMonth = placeholder
-		? { value: placeholder.month, label: monthFmt.format(placeholder.toDate(getLocalTimeZone())) }
+		? { value: placeholder.month, label: monthFmt.format(dateValueToDate(placeholder)) }
 		: undefined;
 
 	export {

--- a/packages/ui/core-components/src/lib/atoms/shadcn/range-calendar/range-calendar.svelte
+++ b/packages/ui/core-components/src/lib/atoms/shadcn/range-calendar/range-calendar.svelte
@@ -3,7 +3,8 @@
 	import * as RangeCalendar from './index.js';
 	import * as Select from '../select/index.js';
 	import { cn } from '$lib/utils.js';
-	import { DateFormatter, getLocalTimeZone } from '@internationalized/date';
+	import { dateValueToDate } from '../../inputs/date-input/helpers.js';
+	import { DateFormatter } from '@internationalized/date';
 	// required to dodge the styling on the shadcn version
 	import { Select as SelectPrimitive } from 'bits-ui';
 
@@ -57,7 +58,7 @@
 		: undefined;
 
 	$: defaultMonth = placeholder
-		? { value: placeholder.month, label: monthFmt.format(placeholder.toDate(getLocalTimeZone())) }
+		? { value: placeholder.month, label: monthFmt.format(dateValueToDate(placeholder)) }
 		: undefined;
 
 	export {


### PR DESCRIPTION
Fixes #2999

### Description

Converting DateValue to plain Dates must use UTC timezone to avoid causing off-by-one in day value when using a positive offset timezone.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
