### PR TITLE
Fix: mssql datasource auth not working

### DIFF
--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -101,7 +101,10 @@ const buildConfig = function (database) {
 			trustServerCertificate:
 				trust_server_certificate === 'true' || trust_server_certificate === true,
 			encrypt: encrypt === 'true' || encrypt === true
-		}
+		},
+		authentication: {
+			type: database.authenticationType
+ 		}
 	};
 
 	if (database.authenticationType === 'default') {


### PR DESCRIPTION
### Description

If authentication type is not specified it defaults to 'default'.
This specifies it, so now other authentication methods are also working.

### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
