### PR TITLE
add example for how to use seriesColor in bar-chart component

### DIFF
--- a/sites/docs/pages/components/charts/bar-chart/index.md
+++ b/sites/docs/pages/components/charts/bar-chart/index.md
@@ -466,7 +466,7 @@ Use bar or column charts to compare a metric across categories. Bar charts are b
 <PropListing
     name=seriesColors
     description="Apply a specific color to each series in your chart. Unspecified series will receive colors from the built-in palette as normal. Note the double curly braces required in the syntax"
-    options="object with series names and assigned colors"
+    options="object with series names and assigned colors seriesColors={`{{'Canada': 'red', 'US': 'blue'}}`}"
     defaultValue="colors applied by order of series in data"
 />
 <PropListing


### PR DESCRIPTION
Description indicates to 'note the double braces required in the syntax' but there's no example in the bar-chart component. Added example, pulling exactly from area-chart component.

### Description

<!---
Adding one small missing example in documentation. I have not opened a changeset; is this necessary for documentation only changes? Happy to do so if needed but have not actually forked this locally, just did 'edit on Github' button to add small missing documentation piece. 
-->

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ X ] I have added to the docs where applicable
- [ n/a ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
