### PR TITLE
docs: update CONTRIBUTING.md to reference main branch instead of next

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Follow these steps to submit a pull request for your changes:
 3. Test your changes to make sure all results are as expected
 4. Format your code to prevent linting errors `pnpm run format`
 5. Add a [changeset](#adding-a-changeset)
-6. Open a pull request against the `next` branch of the `evidence` repo
+6. Open a pull request against the `main` branch of the `evidence` repo
 
 [Here's an example of a pull request](https://github.com/evidence-dev/evidence/pull/165) from a community member who built Evidence's MySQL connector.
 


### PR DESCRIPTION
### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers understand your changes.
-->

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
