### PR TITLE
Fix runtime error handling for MSSQL data source

### DIFF
--- a/.changeset/bright-trainers-tan.md
+++ b/.changeset/bright-trainers-tan.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/mssql': minor
+---
+
+Fix runtime error handling for MSSQL data source

--- a/packages/datasources/mssql/index.cjs
+++ b/packages/datasources/mssql/index.cjs
@@ -144,18 +144,51 @@ const runQuery = async (queryString, database = {}, batchSize = 100000) => {
 
 		const request = new mssql.Request();
 		request.stream = true;
+
+		// Promise that resolves when recordset is emitted or rejects on request error
+		const recordsetPromise = new Promise((resolve, reject) => {
+			request.once('recordset', resolve);
+			request.once('error', reject);
+		});
+
+		// Start the streaming query
 		request.query(queryString);
 
-		const columns = await new Promise((res) => request.once('recordset', res));
+		try {
+			const columns = await recordsetPromise;
 
-		const stream = request.toReadableStream();
-		const results = await asyncIterableToBatchedAsyncGenerator(stream, batchSize, {
-			closeConnection: () => pool.close()
-		});
-		results.columnTypes = mapResultsToEvidenceColumnTypes(columns);
-		results.expectedRowCount = expected_row_count;
+			const stream = request.toReadableStream();
 
-		return results;
+			// Ensure any stream errors are handled to avoid unhandled 'error' events
+			stream.on('error', async (streamErr) => {
+				try {
+					await pool.close();
+				} catch (_) {
+					// ignore close errors
+				}
+				// Nothing else to do here; the asyncIterableToBatchedAsyncGenerator
+				// consumer will observe the error as a rejection when iterating.
+			});
+
+			const results = await asyncIterableToBatchedAsyncGenerator(stream, batchSize, {
+				closeConnection: () => pool.close()
+			});
+			results.columnTypes = mapResultsToEvidenceColumnTypes(columns);
+			results.expectedRowCount = expected_row_count;
+
+			return results;
+		} catch (err) {
+			// Close pool when we hit errors from the request/stream and normalize the error
+			try {
+				await pool.close();
+			} catch (_) {}
+
+			if (err && err.message) {
+				throw err.message.replace(/\n|\r/g, ' ');
+			} else {
+				throw ('' + err).replace(/\n|\r/g, ' ');
+			}
+		}
 	} catch (err) {
 		if (err.message) {
 			throw err.message.replace(/\n|\r/g, ' ');

--- a/packages/datasources/mssql/test/test.js
+++ b/packages/datasources/mssql/test/test.js
@@ -156,7 +156,10 @@ test('runQuery returns normalized error on SQL syntax error', async () => {
 		assert.unreachable('Expected runQuery to throw');
 	} catch (e) {
 		// The function normalizes errors to strings
-		assert.ok(typeof e === 'string' || e instanceof String || e.message, 'error should be string or have message');
+		assert.ok(
+			typeof e === 'string' || e instanceof String || e.message,
+			'error should be string or have message'
+		);
 		const msg = typeof e === 'string' ? e : e.message || String(e);
 		// Message should be non-empty and mention syntax/select or be an error code
 		assert.ok(msg && msg.length > 0, 'error message should be non-empty');


### PR DESCRIPTION
### Description

This is a small quality-of-life fix to the MSSQL data connection. 

Currently, this connector doesn't handle connection errors, leading to the `dev` environment to crash if there is a syntax error in a SQL source.

This PR adds a way to capture these errors and emit a cli error without crashing the whole process.

I also added a test for this behavior to prevent a regression in the future.

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [X] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [ ] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
