### PR TITLE
fix(DataTable): add null check for data in Column component

### DIFF
--- a/.changeset/fix-datatable-column-null.md
+++ b/.changeset/fix-datatable-column-null.md
@@ -1,0 +1,7 @@
+---
+"@evidence-dev/core-components": patch
+---
+
+Fix DataTable not rendering rows when data is loaded asynchronously
+
+Added null check in Column.svelte's checkColumnName() function to guard against data not being ready during initial render. This fixes an issue where DataTable would show the table container (search box, pagination) but no actual rows when using Query objects or when data loads asynchronously.

--- a/packages/ui/core-components/src/lib/unsorted/viz/table/Column.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/table/Column.svelte
@@ -23,6 +23,10 @@
 	 */
 	function checkColumnName() {
 		try {
+			// Guard against data not being ready yet (e.g., during initial render or when using Query objects)
+			if (!$props.data || !$props.data.length || !$props.data[0]) {
+				return; // Data not ready, skip validation for now - will be called again when data loads
+			}
 			if (!Object.keys($props.data[0]).includes(id)) {
 				error = 'Error in table: ' + id + ' does not exist in the dataset';
 				throw new Error(error);


### PR DESCRIPTION
## Problem                                                                                       
  Added null check in Column.svelte's `checkColumnName()` function to guard against data not being 
  ready during initial render.                                                                     
                                                                                                   
  ## Changes                                                                                       
  ```javascript                                                                                    
  function checkColumnName() {                                                                     
      try {                                                                                        
          // Guard against data not being ready yet                                                
          if (!$props.data || !$props.data.length || !$props.data[0]) {                            
              return; // Data not ready, skip validation for now                                   
          }                                                                                        
          // ... rest of validation                                                                
      }                                                                                            
  }                                                                                                
                                                                                                   
  Testing Notes                                                                                    
                                                                                                   
  While testing this fix, we discovered there may be additional rendering issues in DataTable      
  beyond this null check:                                                                          
                                                                                                   
  - Debug output confirmed data flows correctly through the component:                             
    - columnSummary.length = 7                                                                     
    - props.columns.length = 7                                                                     
    - orderedColumns.length = 7                                                                    
    - displayedData.length = 5                                                                     
  - Despite all data being populated correctly, the table-container div does not render            
  - Raw HTML tables iterating over the same Query data render correctly, confirming data access    
  works                                                                                            
  - Issue reproduced with both inline SQL queries and source data queries                          
                                                                                                   
  This PR addresses the async data guard in checkColumnName(), but the Evidence team may want to   
  investigate the broader table rendering issue where the table container fails to render even when
   all data props are properly populated.                                                          
                                                                                                   
  Environment                                                                                      
                                                                                                   
  - @evidence-dev/core-components: 5.4.0                                                           
  - @evidence-dev/evidence: 40.1.6                                                                 
                                               