### PR TITLE
fix: correct regex for folder names containing 'index'

### DIFF
--- a/sites/example-project/src/pages/api/[...route]/evidencemeta.json/+server.js
+++ b/sites/example-project/src/pages/api/[...route]/evidencemeta.json/+server.js
@@ -18,7 +18,7 @@ export const entries = async () => {
 		// Example Project is special
 		const removal = isExampleProject ? '/+page.md' : '.md';
 		let result = filepath.slice(0, -removal.length);
-		if (filepath.endsWith('index.md')) result = result.replaceAll(/\/?index/g, '');
+		if (filepath.endsWith('index.md')) result = result.replace(/\/?index$/, '');
 		return { route: result };
 	});
 


### PR DESCRIPTION
## Bug Description
When a page folder name contains the word "index" (e.g., something-momentum-index), the build fails because the route generation logic incorrectly strips "index" from the folder name, not just from the index.md filename.

## Root Cause
The regex `/\/?index/g` removes all occurrences of "index" from the entire path, not just the trailing `/index` from the filename.

## Solution
Changed the regex from `/\/?index/g` to `/\/?index$/` to only match `/index` at the end of the path.

## Changes
- Modified `sites/example-project/src/pages/api/[...route]/evidencemeta.json/+server.js` to fix the regex

Fixes #3263