### PR TITLE
docs: Add example for aggregating percentage changes in DataTable

### DIFF
--- a/sites/docs/pages/components/data/data-table/index.md
+++ b/sites/docs/pages/components/data/data-table/index.md
@@ -424,6 +424,30 @@ limit 5
 ```
 </DocTab>
 
+#### Aggregating Percentage Changes
+
+When aggregating percentage changes (like year-over-year growth rates) in a total row, use `totalAgg=weightedMean` with the base metric as the `weightCol`. This ensures the total growth rate is properly weighted by the size of each row.
+
+For example, if you have sales and growth rate by category, use sales as the weight column to get the correct overall growth rate:
+
+<DocTab>
+    <div slot='preview'>
+        <DataTable data={country_example} totalRow=true rows=5>
+          <Column id=country/>
+          <Column id=gdp_usd fmt='$#,##0"B"' totalAgg=sum/>
+          <Column id=gdp_growth fmt='pct1' totalAgg=weightedMean weightCol=gdp_usd/>
+        </DataTable>
+    </div>
+
+```svelte
+<DataTable data={country_example} totalRow=true rows=5>
+  <Column id=country/>
+  <Column id=gdp_usd fmt='$#,##0"B"' totalAgg=sum/>
+  <Column id=gdp_growth fmt='pct1' totalAgg=weightedMean weightCol=gdp_usd/>
+</DataTable>
+```
+</DocTab>
+
 
 ### Conditional Formatting
 


### PR DESCRIPTION
## Description

Fixes #2592

This PR adds a new documentation section showing how to properly aggregate percentage changes (like year-over-year growth rates) in DataTable total rows.

### Problem
When aggregating percentage changes (e.g., growth rates), a simple mean doesn't give the correct overall growth rate because it doesn't account for the different base sizes of each row.

### Solution
Use `totalAgg=weightedMean` with the base metric (e.g., sales, GDP) as the `weightCol`. This ensures the total growth rate is properly weighted by the size of each row.

### Changes
- Added new "Aggregating Percentage Changes" section under Total Row examples
- Included example query and DataTable code showing proper weighted mean usage

### Checklist
- [x] For changes to the documentation website, the changes have been previewed locally
- [ ] If there are any new components, add them to the exports in src/lib/index.ts
- [ ] If there are any changes to the query store, make sure the query store types are properly reflected in TypeScript
- [ ] If there are changes to the CLI, document them in the CLI docs
- [ ] If there are changes to the VSCode extension, update the CHANGELOG