### PR TITLE
docs: Add example for aggregating percentage changes in DataTable

### DIFF
--- a/sites/docs/pages/components/data/data-table/index.md
+++ b/sites/docs/pages/components/data/data-table/index.md
@@ -368,6 +368,25 @@ limit 5
 ```
 </DocTab>
 
+#### Aggregating Percentage Changes
+
+When aggregating percentage changes (e.g., year-over-year growth rates) in a total row, a simple average can be misleading. Instead, use `totalAgg=weightedMean` with a `weightCol` to calculate a properly weighted average.
+
+For example, to aggregate growth rates weighted by the size of each entity (e.g., GDP):
+
+```svelte
+<DataTable data={sales_data} totalRow=true>
+  <Column id=region/>
+  <Column id=revenue fmt=usd/>
+  <Column id=growth_rate 
+          title="Y/Y Growth" 
+          fmt=pct2 
+          totalAgg=weightedMean 
+          weightCol=revenue/>
+</DataTable>
+```
+
+In this example, regions with higher revenue contribute more to the overall growth rate calculation, giving you an accurate weighted average.
 
 
 #### Custom Aggregations Values


### PR DESCRIPTION
## Description

This PR adds documentation explaining how to properly aggregate percentage changes (e.g., year-over-year growth rates) in DataTable total rows.

### Problem
Users needed guidance on how to correctly aggregate percentage changes. A simple average can be misleading when aggregating growth rates across entities of different sizes.

### Solution
Added a new "Aggregating Percentage Changes" section to the DataTable documentation that:
- Explains why weighted mean is preferred over simple average for percentage changes
- Shows how to use \totalAgg=weightedMean\ with \weightCol\ to calculate properly weighted averages
- Provides a clear code example demonstrating the pattern

### Changes
- Added new documentation section with explanation and example
- Shows how to weight growth rates by revenue/size for accurate aggregation

Fixes #2592