### PR TITLE
fix: correct weightCol for percentage change aggregations in DataTable docs

### DIFF
--- a/sites/docs/pages/components/data/data-table/index.md
+++ b/sites/docs/pages/components/data/data-table/index.md
@@ -368,6 +368,11 @@ limit 5
 ```
 </DocTab>
 
+:::tip Weighted Mean for Percentage Changes
+When aggregating percentage changes (e.g., year-over-year growth rates), use `weightCol` to specify the **baseline/previous value** column, not the current value. This ensures the weighted average is calculated correctly, as percentage changes are relative to their original values.
+
+For example, if you have `sales_change_pct` calculated as `(current_sales - previous_sales) / previous_sales`, the `weightCol` should be `previous_sales`.
+:::
 
 
 #### Custom Aggregations Values

--- a/sites/example-project/src/pages/tables/total-rows/+page.md
+++ b/sites/example-project/src/pages/tables/total-rows/+page.md
@@ -206,9 +206,9 @@ If no `weightCol` is specified, the result will be identical to the result from 
   <Column id=prev_sales_usd0k totalAgg=weightedMean weightCol=sales_usd0k/>
   <Column id=prev_num_orders_num0 totalAgg=weightedMean weightCol=sales_usd0k/>
   <Column id=prev_aov_usd2 totalAgg=weightedMean weightCol=sales_usd0k/>
-  <Column id=sales_change_pct0 totalAgg=weightedMean weightCol=sales_usd0k/>
-  <Column id=num_orders_change_pct0 totalAgg=weightedMean weightCol=sales_usd0k/>
-  <Column id=aov_change_pct0 totalAgg=weightedMean weightCol=sales_usd0k/>
+  <Column id=sales_change_pct0 totalAgg=weightedMean weightCol=prev_sales_usd0k/>
+  <Column id=num_orders_change_pct0 totalAgg=weightedMean weightCol=prev_num_orders_num0/>
+  <Column id=aov_change_pct0 totalAgg=weightedMean weightCol=prev_aov_usd2/>
 </DataTable>
 
 


### PR DESCRIPTION
### Description

re: https://github.com/evidence-dev/evidence/issues/2592

Fixes incorrect `weightCol` values in DataTable documentation examples for percentage change aggregations.

When using `totalAgg=weightedMean` for percentage change columns, the `weightCol` should reference the baseline/previous value column, not the current value. This is because percentage changes are calculated relative to the original value (e.g., `(new - old) / old`).

**Changes:**

- **Example project fix** (`sites/example-project/src/pages/tables/total-rows/+page.md`):
  - `sales_change_pct0`: weightCol=sales_usd0k → weightCol=prev_sales_usd0k
  - `num_orders_change_pct0`: weightCol=sales_usd0k → weightCol=prev_num_orders_num0
  - `aov_change_pct0`: weightCol=sales_usd0k → weightCol=prev_aov_usd2

- **Documentation tip** (`sites/docs/pages/components/data/data-table/index.md`):
  - Added a tip box in the Total Row section explaining the correct usage of `weightCol` for percentage change aggregations

### Checklist

- [ ] For UI or styling changes, I have added a screenshot or gif showing before & after
- [ ] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [ ] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable