### PR TITLE
Fix Datatable column header tooltips in fullscreen mode

### DIFF
--- a/.changeset/quick-bugs-press.md
+++ b/.changeset/quick-bugs-press.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix datatable column header tooltips in fullscreen mode

--- a/packages/ui/core-components/src/lib/atoms/fullscreen/Fullscreen.svelte
+++ b/packages/ui/core-components/src/lib/atoms/fullscreen/Fullscreen.svelte
@@ -66,6 +66,7 @@
 
 <dialog
 	use:popup={open}
+	data-portal
 	class="w-[90vw] rounded-lg fixed border border-base-300 text-base-content shadow-lg bg-base-100 {open
 		? 'slideIn'
 		: 'slideOut'}"

--- a/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/ui/Info.svelte
@@ -44,7 +44,10 @@
 		</slot>
 	</span>
 
-	<div slot="content" class="bg-base-100 p-2 rounded-md text-base-content text-xs max-w-52">
+	<div
+		slot="content"
+		class="bg-base-100 p-2 rounded-md text-base-content text-xs max-w-52 text-left font-normal"
+	>
 		<p class="leading-relaxed text-pretty">
 			{description}
 		</p>


### PR DESCRIPTION
### Description

Fixes column header tooltips in Datatable when in full screen mode.

Visible and tested in storybook (http://localhost:6006/?path=/story/viz-datatable--with-search)

#### Before

(You need to imagine a cursor hovering on the info icon after the "Airline" header)

<img width="915" height="454" alt="image" src="https://github.com/user-attachments/assets/d299a44e-6433-490f-842a-29927a97b7d6" />


#### After

<img width="910" height="400" alt="Screenshot 2026-06-15 at 14 43 43" src="https://github.com/user-attachments/assets/22fd0119-96e0-425e-bb23-2036a4a626c9" />


### Checklist

- [x] For UI or styling changes, I have added a screenshot or gif showing before & after
- [x] I have added a [changeset](https://github.com/evidence-dev/evidence/blob/main/CONTRIBUTING.md#adding-a-changeset)
- [x] I have added to the docs where applicable
- [x] I have added to the [VS Code extension](https://github.com/evidence-dev/evidence-vscode) where applicable
