### PR TITLE
fix: make prop-derived chart values reactive (Area label position, Sparkline series type)

### DIFF
--- a/.changeset/reactive-prop-derivations.md
+++ b/.changeset/reactive-prop-derivations.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Make prop-derived chart values reactive: Area's default label position now follows `swapXY`, and Sparkline's series type follows `type`, instead of freezing at their mount-time values.

--- a/.changeset/reactive-prop-derivations.md
+++ b/.changeset/reactive-prop-derivations.md
@@ -2,4 +2,4 @@
 '@evidence-dev/core-components': patch
 ---
 
-Make prop-derived chart values reactive: Area's default label position now follows `swapXY`, and Sparkline's series type follows `type`, instead of freezing at their mount-time values.
+Make prop-derived chart values reactive: Area's and Line's default label positions now follow `swapXY`, and Sparkline's series type follows `type`, instead of freezing at their mount-time values.

--- a/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/area/Area.svelte
@@ -117,7 +117,7 @@
 		middle: 'inside'
 	};
 
-	let defaultLabelPosition = swapXY ? 'right' : 'top';
+	$: defaultLabelPosition = swapXY ? 'right' : 'top';
 	$: labelPosition =
 		(swapXY ? swapXYLabelPositions[labelPosition] : labelPositions[labelPosition]) ??
 		defaultLabelPosition;

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
@@ -37,7 +37,7 @@
 	export let yScale = false; // scale the y axis to the data
 	$: yScale = yScale === 'true' || yScale === true;
 
-	let seriesType = type === 'area' ? 'line' : type;
+	$: seriesType = type === 'area' ? 'line' : type;
 
 	export let connectGroup = undefined; // connects to all other connected sparklines with the same group name (shared tooltip behaviour)
 

--- a/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/line/Line.svelte
@@ -139,7 +139,7 @@
 		middle: 'inside'
 	};
 
-	let defaultLabelPosition = swapXY ? 'right' : 'top';
+	$: defaultLabelPosition = swapXY ? 'right' : 'top';
 	$: labelPosition =
 		(swapXY ? swapXYLabelPositions[labelPosition] : labelPositions[labelPosition]) ??
 		defaultLabelPosition;


### PR DESCRIPTION
Sibling fix to #3310 — same bug class, found by sweeping the other viz components for it.

## Problem

Two chart components derive values from props with plain `let` declarations, freezing them at mount-time while their consumers are reactive:

- `Area.svelte`: `let defaultLabelPosition = swapXY ? 'right' : 'top'` — toggling `swapXY` after mount leaves the reactive `labelPosition` fallback stale (labels fall back to `top` on a swapped chart instead of `right`).
- `_Sparkline.svelte`: `let seriesType = type === 'area' ? 'line' : type` — `seriesType` is consumed inside the `$: try` config block, so mounting as `bar` and switching to `line` keeps rendering bars.

## Fix

Derive both with `$:` so the reactive consumers see current values — the same one-line pattern as the `stacked100` fix in #3310. Changeset included (patch, `@evidence-dev/core-components`).

Deliberately excluded from the sweep: the `isInitial`/`queryID` mount-time captures in `core/*` (intentionally non-reactive — they record initial state), and function-local `let`s.

Note on tests: #3310 establishes the regression-spec pattern for this class on BarChart; these two are the same one-line derivation change. Happy to add per-component specs if you want them — Area mounts inside chart context, so I kept this PR surgical.
