### PR TITLE
fix(core-components): draw non-interactive sparklines as SVG instead of an ECharts instance per cell

### DIFF
--- a/.changeset/lucky-pandas-shave.md
+++ b/.changeset/lucky-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Draw non-interactive sparklines as plain SVG instead of creating an ECharts instance per sparkline. Fixes multi-second main-thread freezes on pages with many DataTable sparkline columns, which are severe in Safari/WebKit.

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/_Sparkline.svelte
@@ -1,11 +1,17 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import { init, connect } from 'echarts';
+	import chroma from 'chroma-js';
 	import { browser } from '$app/environment';
 	import checkInputs from '@evidence-dev/component-utilities/checkInputs';
 	import ValueError from './ValueError.svelte';
 	import { strictBuild } from '@evidence-dev/component-utilities/chartContext';
-	import { getColumnFormats, getSparklineConfig, validateSize } from './sparkline.js';
+	import {
+		getColumnFormats,
+		getSparklineConfig,
+		getSparklinePaths,
+		validateSize
+	} from './sparkline.js';
 	import { getThemeStores } from '../../../themes/themes.js';
 
 	const { theme, resolveColor } = getThemeStores();
@@ -18,7 +24,6 @@
 
 	let chartContainer;
 	let chartInstance = null;
-	let staticSVG = ''; // Holds the static SVG markup
 
 	export let data = undefined;
 	export let dateCol = undefined;
@@ -44,6 +49,23 @@
 	let staticSVGSSR;
 	let error;
 
+	// Non-interactive sparklines are drawn as plain SVG rather than by creating an
+	// offscreen ECharts instance per sparkline just to call renderToSVGString().
+	// DataTable renders one sparkline per row, and echarts.init() is roughly 30x
+	// slower in WebKit than in V8, so ~100 sparkline cells put Safari into a ~24s
+	// uninterruptible main-thread task (32.6s on an iPhone) where Chrome is fast
+	// enough to hide it. Nothing is lost: a non-interactive sparkline has no
+	// tooltip, no axis labels and no animation. See getSparklinePaths().
+	let staticPaths = null;
+
+	$: lineColor = $colorStore ?? $theme.colors['base-content-muted'];
+	$: areaColor =
+		type === 'area'
+			? $colorStore
+				? chroma($colorStore).brighten(1.5).hex()
+				: $theme.colors['base-300']
+			: 'transparent';
+
 	// Initialize chart for interactive mode
 	function initializeChart() {
 		if (interactive && chartContainer && !chartInstance) {
@@ -56,24 +78,8 @@
 		}
 	}
 
-	// Initialize the static SVG
 	onMount(() => {
-		if (!interactive) {
-			// Generate static SVG for non-interactive mode
-			const offscreenContainer = document.createElement('div');
-			offscreenContainer.style.width = width + 'px';
-			offscreenContainer.style.height = height + 'px';
-			const tempChart = init(offscreenContainer, 'evidence-light', {
-				renderer: 'svg',
-				height,
-				width
-			});
-			tempChart.setOption(config);
-			staticSVG = tempChart.renderToSVGString();
-			tempChart.dispose();
-		} else {
-			initializeChart();
-		}
+		initializeChart();
 	});
 
 	// Cleanup
@@ -120,7 +126,11 @@
 			$theme
 		);
 
-		if (!browser) {
+		if (!interactive) {
+			staticPaths = getSparklinePaths(sparklineData, type, width, height, yScale);
+		}
+
+		if (!browser && interactive) {
 			// SSR-specific initialization
 			const tempChart = init(null, 'evidence-light', {
 				ssr: true,
@@ -150,34 +160,54 @@
 	$: if (browser && chartInstance && config) {
 		chartInstance.setOption(config, true); // true forces a complete replacement of the options
 	}
-
-	$: if (browser && !interactive) {
-		// Generate static SVG for non-interactive mode
-		const offscreenContainer = document.createElement('div');
-		offscreenContainer.style.width = width + 'px';
-		offscreenContainer.style.height = height + 'px';
-		const tempChart = init(offscreenContainer, 'evidence-light', {
-			renderer: 'svg',
-			height,
-			width
-		});
-		tempChart.setOption(config);
-		staticSVG = tempChart.renderToSVGString();
-		tempChart.dispose();
-	} else {
-		initializeChart();
-	}
 </script>
 
 {#if error}
 	<ValueError {error} />
+{:else if !interactive}
+	<!-- Identical markup on the server and in the browser, so hydration replaces
+	     like with like instead of rebuilding the chart. -->
+	<div class="inline-block align-baseline" style="width: {width}px; height: {height}px;">
+		{#if staticPaths}
+			<svg
+				{width}
+				{height}
+				viewBox="0 0 {width} {height}"
+				xmlns="http://www.w3.org/2000/svg"
+				role="presentation"
+				aria-hidden="true"
+				style="display: block;"
+			>
+				{#each staticPaths.areaPaths as d}
+					<path {d} fill={areaColor} stroke="none" />
+				{/each}
+				<line
+					x1="0"
+					x2={width}
+					y1={staticPaths.baseline}
+					y2={staticPaths.baseline}
+					stroke={$theme.colors['base-300']}
+					stroke-width="0.75"
+				/>
+				{#each staticPaths.bars as bar}
+					<rect x={bar.x} y={bar.y} width={bar.w} height={bar.h} fill={lineColor} />
+				{/each}
+				{#each staticPaths.linePaths as d}
+					<path
+						{d}
+						fill="none"
+						stroke={lineColor}
+						stroke-width="1"
+						stroke-linejoin="round"
+						stroke-linecap="round"
+					/>
+				{/each}
+			</svg>
+		{/if}
+	</div>
 {:else if !browser}
 	<div class="inline-block align-baseline" style="width: {width}px; height: {height}px;">
 		{@html staticSVGSSR}
-	</div>
-{:else if !interactive}
-	<div class="inline-block align-baseline" style="width: {width}px; height: {height}px;">
-		{@html staticSVG}
 	</div>
 {:else}
 	<div

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.js
@@ -255,3 +255,117 @@ export function getSparklineConfig(
 		animation: false
 	};
 }
+
+const HALF_STROKE = 0.5; // half the 1px series line, so it is never clipped by the viewBox
+
+const round2 = (n) => Math.round(n * 100) / 100;
+
+/**
+ * Geometry for a non-interactive sparkline, drawn as plain SVG instead of an
+ * ECharts instance. A non-interactive sparkline has no tooltip, no axis labels
+ * and no animation, so it does not need a chart engine — and creating one per
+ * cell is prohibitively slow in WebKit (see _Sparkline.svelte).
+ *
+ * Mirrors the layout getSparklineConfig() asks ECharts for: xAxis
+ * `boundaryGap: '2%'`, yAxis `boundaryGap: ['1%', '1%']`, `scale: yScale` (a
+ * value axis with scale:false always includes zero), `connectNulls: false`, and
+ * the x axis line resting on zero whenever zero is in range.
+ *
+ * @param {[unknown, unknown][]} sparklineData date/value pairs, sorted ascending by date
+ * @param {'line' | 'area' | 'bar'} type
+ * @param {number} width
+ * @param {number} height
+ * @param {boolean} yScale scale the y axis to the data instead of anchoring it to zero
+ * @returns {{linePaths: string[], areaPaths: string[], bars: {x: number, y: number, w: number, h: number}[], baseline: number} | null} null when there is nothing renderable
+ */
+export function getSparklinePaths(sparklineData, type, width, height, yScale) {
+	const dates = [];
+	const values = [];
+	for (const [date, value] of sparklineData) {
+		dates.push(date instanceof Date ? date.getTime() : new Date(date).getTime());
+		const n = value === null || value === undefined || value === '' ? NaN : Number(value);
+		values.push(Number.isFinite(n) ? n : null);
+	}
+
+	const present = values.filter((v) => v !== null);
+	if (!present.length || !dates.every((d) => Number.isFinite(d))) return null;
+
+	const dateMin = Math.min(...dates);
+	const dateMax = Math.max(...dates);
+	const xPad = width * 0.02; // xAxis boundaryGap: '2%'
+	const xOf = (d) =>
+		dateMax === dateMin
+			? width / 2
+			: xPad + ((d - dateMin) / (dateMax - dateMin)) * (width - 2 * xPad);
+
+	let valueMin = Math.min(...present);
+	let valueMax = Math.max(...present);
+	if (!yScale) {
+		// an ECharts value axis with scale:false always includes zero
+		valueMin = Math.min(0, valueMin);
+		valueMax = Math.max(0, valueMax);
+	}
+	if (valueMin === valueMax) {
+		// a flat series would divide by zero — centre it instead
+		valueMin -= 1;
+		valueMax += 1;
+	}
+	const yPad = (valueMax - valueMin) * 0.01; // yAxis boundaryGap: ['1%', '1%']
+	valueMin -= yPad;
+	valueMax += yPad;
+	const yOf = (v) =>
+		height - HALF_STROKE - ((v - valueMin) / (valueMax - valueMin)) * (height - 2 * HALF_STROKE);
+
+	const baseline = valueMin <= 0 && valueMax >= 0 ? yOf(0) : height - HALF_STROKE;
+
+	// connectNulls: false — every gap breaks the line into a new run
+	const runs = [];
+	let run = [];
+	for (let i = 0; i < values.length; i++) {
+		if (values[i] === null) {
+			if (run.length) runs.push(run);
+			run = [];
+			continue;
+		}
+		run.push([round2(xOf(dates[i])), round2(yOf(values[i]))]);
+	}
+	if (run.length) runs.push(run);
+
+	const linePaths =
+		type === 'bar'
+			? []
+			: runs.map((r) =>
+					r.length === 1
+						? // a lone point draws nothing as a path — give it a 1px dash
+							`M${round2(r[0][0] - 0.5)},${r[0][1]}L${round2(r[0][0] + 0.5)},${r[0][1]}`
+						: `M${r.map(([x, y]) => `${x},${y}`).join('L')}`
+				);
+
+	const areaPaths =
+		type === 'area'
+			? runs
+					.filter((r) => r.length > 1)
+					.map(
+						(r) =>
+							`M${r.map(([x, y]) => `${x},${y}`).join('L')}` +
+							`L${r[r.length - 1][0]},${round2(baseline)}L${r[0][0]},${round2(baseline)}Z`
+					)
+			: [];
+
+	const bars = [];
+	if (type === 'bar') {
+		const barWidth = Math.max(1, ((width - 2 * xPad) / values.length) * 0.7);
+		for (let i = 0; i < values.length; i++) {
+			if (values[i] === null) continue;
+			const y = yOf(values[i]);
+			bars.push({
+				x: round2(xOf(dates[i]) - barWidth / 2),
+				y: round2(Math.min(y, baseline)),
+				w: round2(barWidth),
+				h: round2(Math.max(Math.abs(baseline - y), 0.5))
+			});
+		}
+	}
+
+	return { linePaths, areaPaths, bars, baseline: round2(baseline) };
+}

--- a/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.spec.js
+++ b/packages/ui/core-components/src/lib/unsorted/viz/core/sparkline.spec.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { getSparklinePaths } from './sparkline.js';
+
+/** @param {(number | null)[]} values */
+const series = (values) => values.map((v, i) => [new Date(Date.UTC(2024, i, 1)), v]);
+
+/** @param {string} path */
+const points = (path) =>
+	path
+		.slice(1)
+		.split('L')
+		.map((p) => p.split(',').map(Number));
+
+const WIDTH = 90;
+const HEIGHT = 19;
+
+describe('getSparklinePaths', () => {
+	it('maps a line series left to right, inverting the y axis', () => {
+		const { linePaths } = getSparklinePaths(series([10, 20, 30, 20]), 'line', WIDTH, HEIGHT, false);
+		expect(linePaths).toHaveLength(1);
+
+		const pts = points(linePaths[0]);
+		expect(pts).toHaveLength(4);
+		// x increases monotonically and stays within the viewBox
+		expect(pts.every(([x], i) => i === 0 || x > pts[i - 1][0])).toBe(true);
+		expect(pts[0][0]).toBeGreaterThanOrEqual(0);
+		expect(pts[3][0]).toBeLessThanOrEqual(WIDTH);
+		// larger values sit higher, i.e. at a smaller y
+		expect(pts[2][1]).toBeLessThan(pts[1][1]);
+		expect(pts[1][1]).toBeLessThan(pts[0][1]);
+	});
+
+	it('anchors the axis to zero by default', () => {
+		// matches an ECharts value axis with scale:false, which always includes zero
+		const { baseline } = getSparklinePaths(series([10, 20, 30]), 'line', WIDTH, HEIGHT, false);
+		expect(baseline).toBeGreaterThan(HEIGHT - 1);
+	});
+
+	it('scales the axis to the data when yScale is set', () => {
+		const { linePaths, baseline } = getSparklinePaths(
+			series([10, 20, 30]),
+			'line',
+			WIDTH,
+			HEIGHT,
+			true
+		);
+		const pts = points(linePaths[0]);
+		expect(pts[0][1]).toBeGreaterThan(HEIGHT - 1); // the minimum reaches the floor
+		expect(pts[2][1]).toBeLessThan(1); // the maximum reaches the ceiling
+		// zero is out of range, so the axis line falls back to the bottom
+		expect(baseline).toBe(HEIGHT - 0.5);
+	});
+
+	it('breaks the line at nulls rather than connecting across them', () => {
+		const { linePaths } = getSparklinePaths(
+			series([1, 2, null, 4, 5]),
+			'line',
+			WIDTH,
+			HEIGHT,
+			false
+		);
+		expect(linePaths).toHaveLength(2);
+		expect(points(linePaths[0])).toHaveLength(2);
+		expect(points(linePaths[1])).toHaveLength(2);
+	});
+
+	it('lifts the baseline off the floor when the series crosses zero', () => {
+		const { baseline, areaPaths } = getSparklinePaths(
+			series([-10, 5, 10, -5]),
+			'area',
+			WIDTH,
+			HEIGHT,
+			false
+		);
+		expect(baseline).toBeGreaterThan(1);
+		expect(baseline).toBeLessThan(HEIGHT - 1);
+		expect(areaPaths).toHaveLength(1);
+		expect(areaPaths[0].endsWith('Z')).toBe(true); // closed back to the baseline
+	});
+
+	it('hangs bars off both sides of the baseline', () => {
+		const { bars, baseline, linePaths } = getSparklinePaths(
+			series([-10, 5, 10, -5]),
+			'bar',
+			WIDTH,
+			HEIGHT,
+			false
+		);
+		expect(linePaths).toHaveLength(0);
+		expect(bars).toHaveLength(4);
+		expect(bars.every((b) => b.w >= 1 && b.h >= 0.5)).toBe(true);
+		expect(bars[0].y).toBeCloseTo(baseline, 1); // negative: starts at the baseline
+		expect(bars[2].y + bars[2].h).toBeCloseTo(baseline, 1); // positive: ends at it
+	});
+
+	it('returns null when there is nothing to draw', () => {
+		expect(getSparklinePaths(series([null, null]), 'line', WIDTH, HEIGHT, false)).toBeNull();
+		expect(getSparklinePaths([], 'line', WIDTH, HEIGHT, false)).toBeNull();
+	});
+
+	it('still renders degenerate series', () => {
+		// a single point would otherwise draw an empty path
+		const single = getSparklinePaths(series([7]), 'line', WIDTH, HEIGHT, false);
+		expect(points(single.linePaths[0])).toHaveLength(2);
+
+		// a flat series would divide by zero, and is centred instead
+		const flat = getSparklinePaths(series([0, 0, 0]), 'line', WIDTH, HEIGHT, true);
+		expect(points(flat.linePaths[0]).every(([, y]) => y === HEIGHT / 2)).toBe(true);
+	});
+
+	it('accepts date strings as well as Date objects', () => {
+		const { linePaths } = getSparklinePaths(
+			[
+				['2024-01-01', 5],
+				['2024-02-01', 9]
+			],
+			'line',
+			WIDTH,
+			HEIGHT,
+			false
+		);
+		expect(points(linePaths[0])).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
### Summary

`_Sparkline.svelte` creates an **offscreen ECharts instance for every non-interactive sparkline**, purely to call `renderToSVGString()` — once in `onMount`, and again in a reactive block that re-runs on every update:

```js
const offscreenContainer = document.createElement('div');
const tempChart = init(offscreenContainer, 'evidence-light', { renderer: 'svg', height, width });
tempChart.setOption(config);
staticSVG = tempChart.renderToSVGString();
tempChart.dispose();
```

`DataTable` renders one sparkline **per row** (`TableRow`, `GroupRow`, `SubtotalRow` and `TotalRow` all pass `interactive="false"`), so a table-heavy page creates hundreds of chart instances.

`echarts.init()` is roughly **30× slower in WebKit than in V8**. On a page with ~100 sparkline cells that becomes a single **~24 s uninterruptible main-thread task** in Safari — 32.6 s on an iPhone. Chrome runs the same code fast enough that nobody notices.

A non-interactive sparkline has no tooltip, no axis labels and no animation. It doesn't need a chart engine.

### The change

- Adds `getSparklinePaths()` to `sparkline.js`: a dependency-free pure function computing the same layout `getSparklineConfig()` asks ECharts for — xAxis `boundaryGap: '2%'`, yAxis `boundaryGap: ['1%','1%']`, `scale: yScale` (a value axis with `scale: false` always includes zero), `connectNulls: false`, 1 px line, and the x axis line resting on zero whenever zero is in range.
- `_Sparkline.svelte` renders that as an inline `<svg>` on the non-interactive path.
- **Interactive sparklines are untouched** and still use ECharts, tooltips and `connectGroup` included.
- `config` is still computed in both cases, so the exported `config` prop keeps its contract.

One incidental improvement: the non-interactive branch now emits **identical markup on the server and in the browser**. Previously SSR prerendered an ECharts SVG and the client immediately discarded it to build another one; now hydration replaces like with like.

### Measurements

Same machine, same build, served from a local static server. The control is a variant page holding all SQL blocks and rows constant (6 DataTables / 106 rows / 4 sparkline columns):

| | before | after |
|---|---|---|
| macOS Safari 26.6 — longest main-thread block | **24.50 s** | **0.37 s** |
| macOS Safari — page settled | 25.17 s | 1.06 s |
| iPhone, iOS 18.7 — longest main-thread block | **32.58 s** | **0.50 s** |
| iPhone — sparklines rendered | 40.56 s | 4.18 s |
| Chrome @6× CPU throttle — load, longest task | 5.51 s | 1.92 s |
| Chrome @6× CPU throttle — period/data change | 0.91 s | 0.28 s |

The cost is per instance, not per row of data: it scales with the number of sparkline **cells** rendered.

### How this was isolated

Variant pages holding all 41 SQL blocks byte-identical while varying only the rendered components, macOS Safari, 3 repeats each (±0.3 s):

| variant | DataTables | rows | sparkline cols | implied main-thread block |
|---|---|---|---|---|
| empty | 0 | 0 | 0 | — |
| 19 BigValues, no tables | 0 | 0 | 0 | — |
| 1 table | 1 | 38 | 1 | ~2.8 s |
| 2 tables | 2 | 73 | 2 | ~13.3 s |
| 4 tables | 4 | 85 | 3 | ~17.7 s |
| 6 tables | 6 | 106 | 4 | ~23.2 s |
| **6 tables, sparkline columns removed** | 6 | 106 | **0** | **—** |

Deleting four `<Column contentType=sparkline>` lines removes a 24-second block and makes the page indistinguishable from an empty one. Roughly 0.25 s per sparkline cell in WebKit.

`BigValue` is not implicated — 19 BigValues with no DataTables behave like an empty page, even though several use `sparkline=`. Consistent with a per-instance cost: 4 instances ≈ 1 s (invisible), ~100 instances ≈ 25 s.

### Testing

- **New unit tests** (`sparkline.spec.js`, 9 cases): axis inversion, zero anchoring vs `yScale`, null-driven line breaks, negative series lifting the baseline off the floor, bars hanging off both sides of it, `null` for nothing-renderable, single-point and flat-series degenerate cases, and date strings as well as `Date` objects. All pass under the repo's vitest.
- **Output parity**: live SVG output was extracted row by row from a before build and an after build of the same page and diffed side by side — visually indistinguishable.
- **In production use**: this change (byte-identical) has been running via patch-package against `@evidence-dev/core-components@5.4.2` in a multi-tenant Evidence deployment, verified through a full `evidence build` including its hydration checks.
- `pnpm run format` clean; changeset included.

### Notes

- Sparkline data flows in as an array per cell, so `getSparklinePaths()` is called per cell too — but it is arithmetic on ~24 points, not a chart engine.
- Happy to adjust naming, file placement, or split the tests differently.
