### PR TITLE
fix(core-components): apply input defaults by value, not by identity (#1479, #2024)

### DIFF
--- a/.changeset/lucky-lions-repeat.md
+++ b/.changeset/lucky-lions-repeat.md
@@ -1,0 +1,9 @@
+---
+'@evidence-dev/core-components': patch
+---
+
+Fix inputs staying unset (and their queries loading forever) when a `defaultValue` written in markdown does not strictly equal the value coming from a query.
+
+Markdown props are always strings, so `defaultValue=2026` never matched the number `2026` returned by a query. `ButtonGroupItem` and the dropdown option store now compare default values by value instead of by identity, and `ButtonGroup` seeds its input synchronously so queries depending on it are not created against an unset input while the button group's own query is still resolving.
+
+Fixes #1479, fixes #2024.

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroup.svelte
@@ -6,6 +6,7 @@
 	import { presets, setButtonGroupContext } from './lib.js';
 	import { writable, readonly } from 'svelte/store';
 	import { getInputContext } from '@evidence-dev/sdk/utils/svelte';
+	import { Unset } from '@evidence-dev/sdk/usql';
 	import { setContext } from 'svelte';
 	import { buildReactiveInputQuery } from '@evidence-dev/component-utilities/buildQuery';
 	import Info from '../../../unsorted/ui/Info.svelte';
@@ -56,6 +57,30 @@
 		// the assignment to $inputs is necessary to trigger the change on SSR
 		$inputs[name] = v?.value ?? null;
 	}, readonly(valueStore));
+
+	/*
+		A data-driven ButtonGroup only renders its <ButtonGroupItem>s once its own
+		query has resolved, so `defaultValue` is applied long after the queries that
+		depend on this input have been created. Those queries see an unset input,
+		are created with `noResolve`, and never leave their loading state.
+
+		Seed the input synchronously at init instead. The matching ButtonGroupItem
+		still runs later and overwrites this with the correctly typed value from the
+		query; until then the input at least holds the value the author asked for
+		rather than nothing at all.
+
+		Only seed when the input is genuinely unset, so a value restored from another
+		component or from a previous selection is never clobbered.
+	*/
+	if (name && defaultValue !== undefined) {
+		const currentInput = $inputs[name];
+		const inputIsUnset =
+			currentInput === undefined || currentInput === null || currentInput[Unset] === true;
+		if (inputIsUnset) {
+			$valueStore = { value: defaultValue, valueLabel: String(defaultValue) };
+			$inputs[name] = defaultValue;
+		}
+	}
 
 	/////
 	// Query-Related Things

--- a/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/button-group/ButtonGroupItem.svelte
@@ -5,6 +5,7 @@
 <script>
 	import { getButtonGroupContext } from './lib.js';
 	import { getContext } from 'svelte';
+	import { inputValuesMatch } from '../inputValue.js';
 	/** @type {string} */
 	import TabDisplay from '../../../unsorted/ui/Tabs/TabDisplay.svelte';
 	import { getThemeStores } from '../../../themes/themes.js';
@@ -34,7 +35,11 @@
 		update({ valueLabel, value });
 	}
 
-	if (defaultValue === value) {
+	// `defaultValue` comes from markdown and is therefore always a string, while
+	// `value` keeps the type it had in the query (number / bigint / Date). Compare
+	// them by value, otherwise the default never applies and every query using this
+	// input stays unset -- i.e. loading forever.
+	if (defaultValue !== undefined && inputValuesMatch(defaultValue, value)) {
 		update({ valueLabel, value });
 	}
 </script>
@@ -45,7 +50,7 @@
 		label={valueLabel}
 		color={colorStore}
 		on:click={() => update({ valueLabel, value })}
-		activeId={$currentValue?.value}
+		activeId={inputValuesMatch($currentValue?.value, value) ? value : $currentValue?.value}
 	/>
 {:else if display === 'buttons'}
 	<button
@@ -53,7 +58,9 @@
 		class="flex-none py-1 font-medium px-3 text-xs truncate
 		border-r last:border-none border-base-300
 		hover:bg-base-200 focus:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-base-300
-		{$currentValue?.value === value ? 'z-10 bg-base-200 text-primary' : 'z-0 bg-base-100'}"
+		{inputValuesMatch($currentValue?.value, value)
+			? 'z-10 bg-base-200 text-primary'
+			: 'z-0 bg-base-100'}"
 		on:click={() => update({ valueLabel, value })}
 	>
 		{valueLabel}

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/dropdownOptionStore.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/dropdownOptionStore.js
@@ -3,6 +3,7 @@ import { derived, get, readonly, writable } from 'svelte/store';
 import { batchUp } from '@evidence-dev/sdk/utils';
 import merge from 'lodash/merge';
 import { z } from 'zod';
+import { inputValuesMatch } from '../inputValue.js';
 
 /** @template T @typedef {import("svelte/store").Readable<T>} Readable<T> */
 /** @template T @typedef {import("svelte/store").Writable<T>} Writable<T> */
@@ -82,15 +83,22 @@ export const dropdownOptionStore = (opts = {}) => {
 		? config.defaultValues
 		: [config.defaultValues];
 
-	const defaults = new Set(defaultValues);
-	if (!config.multiselect && defaults.size > 1) {
-		defaults.clear();
-		if (defaultValues?.length) defaults.add(defaultValues[0]);
+	/*
+		Kept as a list (rather than a Set) so defaults can be matched by value instead
+		of by identity: `defaultValue=2026` arrives from markdown as the string "2026"
+		while the option's value comes out of the query as the number 2026. A Set
+		lookup misses, no option is selected, and every query depending on this input
+		stays unset -- loading forever.
+		@type {(string | number | null | undefined)[]}
+	*/
+	let defaults = [...defaultValues];
+	if (!config.multiselect && defaults.length > 1) {
+		defaults = defaultValues.slice(0, 1);
 		console.debug('Single-select dropdowns only accept one default value.');
 	}
 	if ((config.initialOptions?.length ?? 0) > 0) {
 		// We don't apply anything with defaults
-		defaults.clear();
+		defaults = [];
 	}
 
 	let selectFirst =
@@ -125,9 +133,12 @@ export const dropdownOptionStore = (opts = {}) => {
 							}
 
 							// Apply defaults
-							if (option.value !== null && defaults.has(option.value)) {
-								option.selected = true;
-								defaults.delete(option.value);
+							if (option.value !== null) {
+								const defaultIdx = defaults.findIndex((d) => inputValuesMatch(d, option.value));
+								if (defaultIdx !== -1) {
+									option.selected = true;
+									defaults.splice(defaultIdx, 1);
+								}
 							}
 
 							// Apply defaults for option

--- a/packages/ui/core-components/src/lib/atoms/inputs/dropdown/dropdownOptionStore.spec.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/dropdown/dropdownOptionStore.spec.js
@@ -195,6 +195,26 @@ describe('dropdownOptionStore', () => {
 				await vi.advanceTimersByTimeAsync(100);
 				expect(get(options)[0].selected).toBe(false);
 			});
+			it('should select a numeric option from a string defaultValue written in markdown', async () => {
+				// Markdown props are always strings; query values keep their SQL type.
+				const { addOptions, options } = dropdownOptionStore({
+					defaultValues: ['2026']
+				});
+				addOptions({ value: 2025, label: '2025' }, { value: 2026, label: '2026' });
+				await vi.advanceTimersByTimeAsync(100);
+				expect(get(options).find((o) => o.value === 2026)?.selected).toBe(true);
+				expect(get(options).find((o) => o.value === 2025)?.selected).toBe(false);
+			});
+			it('should select multiple numeric options from string defaultValues (multiselect)', async () => {
+				const { addOptions, options } = dropdownOptionStore({
+					defaultValues: ['1', '3'],
+					multiselect: true
+				});
+				addOptions({ value: 1, label: 'a' }, { value: 2, label: 'b' }, { value: 3, label: 'c' });
+				await vi.advanceTimersByTimeAsync(100);
+				const byValue = Object.fromEntries(get(options).map((o) => [o.value, o.selected]));
+				expect(byValue).toEqual({ 1: true, 2: false, 3: true });
+			});
 			it('should select options as they are added if their values are in defaultValues (multiselect)', async () => {
 				const { addOptions, options } = dropdownOptionStore({
 					defaultValues: [1, 2, 3],

--- a/packages/ui/core-components/src/lib/atoms/inputs/inputValue.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/inputValue.js
@@ -1,0 +1,66 @@
+/**
+ * Helpers for matching a `defaultValue` (or any other value written in markdown)
+ * against a value that came out of a query.
+ *
+ * Component props written in markdown are *always* strings: `defaultValue=2026`
+ * arrives as the string `"2026"`. Values coming from a query keep their SQL type,
+ * so the same year arrives as the number `2026` (or a `bigint`, or a `Date`).
+ * Comparing the two with `===` therefore never matches, the input is never set,
+ * and every query that interpolates that input stays `noResolve` forever -- the
+ * "Loading..." that never finishes.
+ *
+ * These helpers compare by value rather than by type, which is what a user writing
+ * `defaultValue=2026` means.
+ */
+
+/**
+ * @param {unknown} v
+ * @returns {number | undefined}
+ */
+const toTime = (v) => {
+	if (v instanceof Date) {
+		const t = v.getTime();
+		return Number.isNaN(t) ? undefined : t;
+	}
+	if (typeof v === 'string' || typeof v === 'number') {
+		const t = new Date(v).getTime();
+		return Number.isNaN(t) ? undefined : t;
+	}
+	return undefined;
+};
+
+/**
+ * Reduce a value to the string a user would have typed for it in markdown.
+ * @param {unknown} v
+ * @returns {string}
+ */
+export const normalizeInputValue = (v) => {
+	if (v instanceof Date) return v.toISOString();
+	if (typeof v === 'bigint') return v.toString();
+	if (typeof v === 'number') return String(v);
+	if (typeof v === 'boolean') return v ? 'true' : 'false';
+	return String(v);
+};
+
+/**
+ * Loose, type-tolerant equality for input values.
+ *
+ * `null`/`undefined` only ever match themselves -- an unset value must not
+ * accidentally match the empty string or `0`.
+ *
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean}
+ */
+export const inputValuesMatch = (a, b) => {
+	if (a === b) return true;
+	if (a === null || a === undefined || b === null || b === undefined) return false;
+
+	if (a instanceof Date || b instanceof Date) {
+		const ta = toTime(a);
+		const tb = toTime(b);
+		return ta !== undefined && ta === tb;
+	}
+
+	return normalizeInputValue(a) === normalizeInputValue(b);
+};

--- a/packages/ui/core-components/src/lib/atoms/inputs/inputValue.spec.js
+++ b/packages/ui/core-components/src/lib/atoms/inputs/inputValue.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { inputValuesMatch, normalizeInputValue } from './inputValue.js';
+
+describe('inputValuesMatch', () => {
+	it('matches a markdown string default against a numeric query value', () => {
+		// The regression this whole fix exists for: defaultValue=2026 in markdown
+		// vs. the number 2026 coming out of the query.
+		expect(inputValuesMatch('2026', 2026)).toBe(true);
+		expect(inputValuesMatch(2026, '2026')).toBe(true);
+	});
+
+	it('matches bigints', () => {
+		expect(inputValuesMatch('2026', 2026n)).toBe(true);
+		expect(inputValuesMatch(2026n, 2026)).toBe(true);
+	});
+
+	it('matches booleans written as strings', () => {
+		expect(inputValuesMatch('true', true)).toBe(true);
+		expect(inputValuesMatch('false', false)).toBe(true);
+		expect(inputValuesMatch('true', false)).toBe(false);
+	});
+
+	it('matches dates against their string representation', () => {
+		const d = new Date('2026-01-01T00:00:00.000Z');
+		expect(inputValuesMatch('2026-01-01', d)).toBe(true);
+		expect(inputValuesMatch(d, '2026-01-01T00:00:00.000Z')).toBe(true);
+		expect(inputValuesMatch('2026-01-02', d)).toBe(false);
+		expect(inputValuesMatch('not a date', d)).toBe(false);
+	});
+
+	it('does not match different values', () => {
+		expect(inputValuesMatch('2026', 2025)).toBe(false);
+		expect(inputValuesMatch('veghel', 'heuts')).toBe(false);
+	});
+
+	it('treats null/undefined as matching only themselves', () => {
+		expect(inputValuesMatch(null, null)).toBe(true);
+		expect(inputValuesMatch(undefined, undefined)).toBe(true);
+		expect(inputValuesMatch(null, undefined)).toBe(false);
+		// crucially: an unset value must not match "" or 0
+		expect(inputValuesMatch(null, '')).toBe(false);
+		expect(inputValuesMatch(undefined, 0)).toBe(false);
+		expect(inputValuesMatch(null, 'null')).toBe(false);
+	});
+
+	it('does not coerce 0 / "" into each other', () => {
+		expect(inputValuesMatch(0, '')).toBe(false);
+		expect(inputValuesMatch(0, '0')).toBe(true);
+		expect(inputValuesMatch(false, 0)).toBe(false);
+	});
+});
+
+describe('normalizeInputValue', () => {
+	it('stringifies by value', () => {
+		expect(normalizeInputValue(2026)).toBe('2026');
+		expect(normalizeInputValue(2026n)).toBe('2026');
+		expect(normalizeInputValue(true)).toBe('true');
+		expect(normalizeInputValue('x')).toBe('x');
+	});
+});


### PR DESCRIPTION
Fixes the "Loading… that never finishes" that blocks any report using an input with a `defaultValue`.

Upstream: [#1479](https://github.com/evidence-dev/evidence/issues/1479), [#2024](https://github.com/evidence-dev/evidence/issues/2024) — both open and untouched.

## Root cause

A component prop written in markdown is always a string, so `defaultValue=2026` is `"2026"`. The option value coming out of a query keeps its SQL type and is the number `2026`. `ButtonGroupItem` compared them with `===`:

```js
if (defaultValue === value) update({ valueLabel, value }); // never true
```

The default was therefore never applied and the input stayed *unset*. Evidence deliberately freezes any query interpolating an unset input (`noResolve`, see #1479), so every dependent query hangs in its loading state forever. `dropdownOptionStore` has the same bug via `defaults.has(option.value)` on a `Set`.

Related but distinct: a data-driven `<ButtonGroup>` only renders its items inside `QueryLoad`, i.e. after its *own* query resolves — so even a matching default lands long after the dependent queries were created against the unset input (#2024).

## Changes

- **new** `atoms/inputs/inputValue.js` — `inputValuesMatch()`, value-based comparison across the markdown/SQL boundary (string, number, bigint, boolean, Date). `null`/`undefined` match only themselves, so `""` and `0` are never mistaken for "unset".
- `ButtonGroupItem` — applies `defaultValue` and highlights the active button by value.
- `dropdownOptionStore` — matches `defaultValues` by value instead of via a `Set` lookup, so `<Dropdown defaultValue=2026 />` over a numeric column works too.
- `ButtonGroup` — seeds its input synchronously at init when the input is still unset, so dependent queries are not created against an unset input while its own options query is still resolving. Only when unset, so a restored or user-picked value is never clobbered; the matching item still overwrites the seed with the correctly typed value once options arrive.

Deliberately *not* changed: the "unset input freezes the query" behaviour itself. That is intentional upstream, and the real defect is inputs staying unset when they shouldn't.

## Tests

- new `inputValue.spec.js` (type crossings, dates, the null/`""`/`0` edges)
- two new cases in `dropdownOptionStore.spec.js` for string defaults against numeric options
- full `core-components` suite: 127 passed, 3 skipped

## Verified against a real report

Built `@evidence-dev/core-components` with this change and ran a production Evidence report (BigQuery source, `<ButtonGroup data={jaren} name=jaar value=jaar defaultValue=2026 />` plus ~20 queries on `${inputs.jaar}`):

- before: every KPI and chart on `Loading…`, no button selected
- after: everything renders, 2026 selected, zero `Loading…` on the page; clicking 2025 swaps the figures, so reactivity is intact
