### PR TITLE
docs(extension): fix all broken README images

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -8,7 +8,7 @@
 
 This extension provides language support, Evidence project and dev server shortcut commands, and autocomplete for Evidence Markdown files.
 
-![Evidence Side-by-Side](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-sidebyside.gif)
+![Evidence Side-by-Side](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-sidebyside.gif)
 
 ## Features
 
@@ -40,7 +40,7 @@ This extension also depends on [Svelte for VS Code](https://marketplace.visualst
 
 You can install the Evidence extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Evidence.evidence-vscode), or by searching for `Evidence` in the VS Code Extensions tab.
 
-![Evidence Extension Installation](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-extension-install.png)
+![Evidence Extension Installation](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-extension-install.png)
 
 ## Getting Started
 
@@ -49,21 +49,21 @@ To get started with Evidence using VS Code locally, follow these steps:
 1. Open the command palette in VS Code (Cmd/Ctrl + Shift + P)
 2. Search for and click `New Evidence Project`
 3. Select an **empty** folder to create your Evidence project within<br><br>
-   ![Evidence Project Start](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-new-project.gif)
+   ![Evidence Project Start](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-new-project.gif)
 
 4. Click the `Start Evidence` button to install all required dependencies and start the dev server, or use the commands detailed below in the `Commands` section<br><br>
-   ![Evidence Server Start](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-server-start.gif)
+   ![Evidence Server Start](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-server-start.gif)
    <br><br> **Note:** The initial installation and server start can take up to 2 minutes depending on your computer. If you have issues with the startup time, you can use Codespaces (see next section).<br><br>
    At the end of this step, your browser will automatically open to your app preview, which will appear at `localhost:3000`
 
 5. We recommend putting VS Code and your browser side-by-side, like in the screenshot below. This will give you immediate development feedback on your app every time you save a markdown file.<br><br>
-   ![Evidence Side-by-Side](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-sidebyside.gif)
+   ![Evidence Side-by-Side](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-sidebyside.gif)
 
 6. Make changes to your markdown files and save the file to see the changes reflected in your app preview
 
 7. Try the "slash commands" included with the extension by typing `/` - you will see a list of available viz and UI components from our library. Select a component to insert by hitting `Tab` or clicking on the component.<br><br>
    Once the component code has been inserted, you can hit `Tab` again to move through the inputs for a component and fill them in.<br><br>
-   ![Evidence Slash](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-slash.gif)
+   ![Evidence Slash](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-slash.gif)
 
 ## Running Evidence in GitHub Codespaces
 
@@ -73,15 +73,15 @@ You can use the Evidence VS Code extension with [GitHub Codespaces](https://gith
 2. The Evidence extension will be installed automatically
 3. Click the `Start Evidence` button to install all required dependencies and start the dev server, or use the commands detailed below in the `Commands` section
 4. You will get a popup saying `Your application running on port 3000 is available`. Click to open in browser<br><br>
-   ![Running Evidence in GitHub Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-codespaces-server-start.png)
+   ![Running Evidence in GitHub Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-codespaces-server-start.png)
 
 5. Make changes to your markdown files and **save the file** to see the changes reflected in your app preview
 
 6. After making changes to your project, click the `Source Control` icon in the left panel and commit your changes<br><br>
-   ![Make a change in Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/codespaces-make-change.png)
+   ![Make a change in Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/codespaces-make-change.png)
 
 7. Click `Publish Branch` - this will prompt you to create a private or public repo for your Evidence project<br><br>
-   ![Publish repo in Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/codespaces-publish-repo.png)
+   ![Publish repo in Codespaces](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/codespaces-publish-repo.png)
 
 8. From here, you can continue to develop your project in Codespaces, or you can choose to clone your repo locally and work from there
 
@@ -91,7 +91,7 @@ The Evidence extension provides a number of custom VS Code shortcut commands for
 
 You can access the VS Code shortcut commands from the command palette (`Cmd/Ctrl+Shift+P`) by typing `Evidence` in the command search box:
 
-![Evidence Extension Commands](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-commands.png)
+![Evidence Extension Commands](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-commands.png)
 
 | VS Code Command       | Title                      | Description                                                                                         | CLI Command                                                                      |
 | --------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -113,7 +113,7 @@ Create [User or Workspace Settings](https://code.visualstudio.com/docs/getstarte
 
 Open Evidence extension Settings in VS Code by using the `Evidence: VS Code Extension Settings` command, or navigating to `File -> Preferences -> Settings` (`cmd/ctrl+,`) and searching for `Evidence` in the Settings search box.
 
-![Evidence Extension Settings](https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-extension-settings.png)
+![Evidence Extension Settings](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-extension-settings.png)
 
 ### Available Settings
 
@@ -135,7 +135,7 @@ You can also reconfigure Evidence extension settings in `vscode/settings.json` w
 
 Edit your settings in `./vscode/settings.json` by opening the `Command Palette...` with `cmd/ctrl+shift+p`, searching for and selecting `Preferences: Open Workspace Settings (JSON)` command.
 
-![VS Code Settings JSON](https://raw.githubusercontent.com/evidence-dev/evidence-vscode/main/https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-vscode-settings-json.png?raw=true)
+![VS Code Settings JSON](https://raw.githubusercontent.com/evidence-dev/evidence/main/packages/extension/docs/images/evidence-vscode-settings-json.png)
 
 ### Evidence Settings
 


### PR DESCRIPTION
Every image in `packages/extension/README.md` is currently broken — 12 links, 11 unique files. They point at `raw.githubusercontent.com/evidence-dev/evidence/**next**/packages/extension/docs/images/…`, and while the `next` branch still exists it doesn't carry that path, so all of them 404. The same files resolve on `main`.

This is the README published as the [VS Code marketplace listing](https://marketplace.visualstudio.com/items?itemName=Evidence.evidence-vscode), so right now that page shows broken images throughout.

One of the twelve was also malformed — two URLs concatenated:

```
https://raw.githubusercontent.com/evidence-dev/evidence-vscode/main/https://raw.githubusercontent.com/evidence-dev/evidence/next/packages/extension/docs/images/evidence-vscode-settings-json.png?raw=true
```

I verified all 11 rewritten URLs return 200.

**Separate, not fixed here:** `packages/lib/sdk/README.md` has two more 404s — `https://github.com/evidence-dev/sdk/wiki` (that repo doesn't exist) and `.../evidence/tree/main/packages/query-store` (no such package in the tree). I don't know the intended targets; tell me and I'll open a follow-up.