### PR TITLE
test(sdk): await rejects assertions in loadSourceConfig

### DIFF
--- a/packages/lib/sdk/src/plugins/datasources/loadSourceConfig.spec.js
+++ b/packages/lib/sdk/src/plugins/datasources/loadSourceConfig.spec.js
@@ -63,7 +63,7 @@ describe('loadSourceOptions', () => {
 		expect(await loadConnectionOptions('./sources/options')).toEqual({ x: 5 });
 	});
 	it('should throw if an invalid base64 error occurs', async () => {
-		expect(loadConnectionOptions('./sources/invalidB64')).rejects.toThrowError(
+		await expect(loadConnectionOptions('./sources/invalidB64')).rejects.toThrowError(
 			'Error parsing connection.options.yaml file'
 		);
 	});
@@ -100,12 +100,12 @@ describe('loadConnection', () => {
 	});
 
 	it('should throw an error when given a directory with an invalid connection.yaml', async () => {
-		expect(loadConnection('./sources/invalidYaml')).rejects.toThrowError(
+		await expect(loadConnection('./sources/invalidYaml')).rejects.toThrowError(
 			'Error parsing connection.yaml file'
 		);
 	});
 	it('should throw an error when given a directory with a malformed connection.yaml', async () => {
-		expect(loadConnection('./sources/malformedConnection')).rejects.toThrowError(
+		await expect(loadConnection('./sources/malformedConnection')).rejects.toThrowError(
 			'Unable to load connection.yaml'
 		);
 	});


### PR DESCRIPTION
Three tests in `loadSourceConfig.spec.js` assert on a rejected promise without awaiting it:

```js
expect(loadConnection('./sources/invalidYaml')).rejects.toThrowError(
  'Error parsing connection.yaml file'
);
```

The assertion is never awaited, so it does not run before the test ends. All three tests are named "should throw …" and none of them can currently fail. Vitest already flags it when the suite runs:

> Promise returned by `expect(actual).rejects.toThrowError(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3.

So this is also forward-breaking, not just dead coverage.

The neighbouring tests in the same file already use `await` correctly (`expect(await loadConnectionOptions(...)).toEqual(...)`), so this looks like an oversight rather than intent.

**Verification.** All 13 tests in the file pass with the awaits added, and the three Vitest warnings are gone. To confirm the assertions are now actually live, I changed one expected message to a string that cannot match and re-ran: that test failed, as it should. Before the change, the same mutation still passed. Reverted afterwards.

I scanned the rest of the repo for the same pattern and this file was the only occurrence. `prettier --check` passes on the changed file.