### PR TITLE
fix: honor DateInput defaultValue in single-date mode

### DIFF
--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.stories.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/DateInput.stories.svelte
@@ -65,3 +65,6 @@
 	<h1>Data has a query error</h1>
 	<DateInput name="QueryError" data={queryErrorData} />
 </Story>
+<Story name="Single Date Default Value" let:args>
+	<DateInput {...args} name="dateInput_default" defaultValue="2024-12-29" />
+</Story>

--- a/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
+++ b/packages/ui/core-components/src/lib/atoms/inputs/date-input/_DateInput.svelte
@@ -239,7 +239,12 @@
 	}
 
 	function updateDateRange(start, end) {
-		if (selectedPreset) return;
+		if (selectedPreset || selectedDateInput) return;
+
+		if (!range && typeof defaultValue === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(defaultValue)) {
+			selectedDateInput = YYYYMMDDToCalendar(defaultValue);
+			return;
+		}
 
 		if (range) {
 			selectedDateInput = { start, end };


### PR DESCRIPTION
## Summary
- honor an ISO defaultValue for DateInput in single-date mode
- keep the initialized value from being overwritten by the fallback range initialization
- add a Storybook example covering the single-date default value

## Validation
- verified the branch against evidence-dev/evidence:main
- reviewed the GitHub compare diff for the two intended files
- local test suite was not run because the Windows Git HTTPS credential layer could not clone the repository

Closes #3312