### PR TITLE
feat(core): support global and contextual downIsGood configuration (#3297)

### DIFF
--- a/cli/src/lib/markdown/files.server.test.ts
+++ b/cli/src/lib/markdown/files.server.test.ts
@@ -208,4 +208,25 @@ describe('resolvePageSettings', () => {
 			auto_refresh: 60
 		});
 	});
+
+	it('merges down_is_good from project layout', () => {
+		expect(resolvePageSettings('# Page\n', { down_is_good: true })).toMatchObject({
+			down_is_good: true
+		});
+		expect(resolvePageSettings('# Page\n', { downIsGood: true })).toMatchObject({
+			down_is_good: true
+		});
+	});
+
+	it('lets explicit page frontmatter down_is_good / downIsGood override project layout', () => {
+		const settings1 = resolvePageSettings('---\ndown_is_good: true\n---\n# Page\n', {
+			down_is_good: false
+		});
+		expect(settings1.down_is_good).toBe(true);
+
+		const settings2 = resolvePageSettings('---\ndownIsGood: true\n---\n# Page\n', {
+			down_is_good: false
+		});
+		expect(settings2.down_is_good).toBe(true);
+	});
 });

--- a/cli/src/lib/markdown/files.server.ts
+++ b/cli/src/lib/markdown/files.server.ts
@@ -46,6 +46,8 @@ export function parsePageSettings(content: string): PageSettings {
 	if (fm.page_width !== undefined) settings.page_width = fm.page_width;
 	if (fm.table_of_contents !== undefined) settings.table_of_contents = fm.table_of_contents;
 	if (fm.auto_refresh !== undefined) settings.auto_refresh = fm.auto_refresh;
+	if (fm.down_is_good !== undefined) settings.down_is_good = fm.down_is_good;
+	else if (fm.downIsGood !== undefined) settings.down_is_good = fm.downIsGood;
 	return settings;
 }
 
@@ -82,9 +84,23 @@ export function resolvePageSettings(
 	content: string,
 	projectLayout: ParsedProjectLayout | null | undefined
 ): PageSettings {
+	const layoutSettings: Partial<PageSettings> = {};
+	if (projectLayout) {
+		if (projectLayout.cards !== undefined) layoutSettings.cards = projectLayout.cards;
+		if (projectLayout.page_width !== undefined) layoutSettings.page_width = projectLayout.page_width;
+		if (projectLayout.table_of_contents !== undefined)
+			layoutSettings.table_of_contents = projectLayout.table_of_contents;
+		if (projectLayout.auto_refresh !== undefined)
+			(layoutSettings as any).auto_refresh = projectLayout.auto_refresh;
+		if (projectLayout.down_is_good !== undefined)
+			layoutSettings.down_is_good = projectLayout.down_is_good;
+		else if (projectLayout.downIsGood !== undefined)
+			layoutSettings.down_is_good = projectLayout.downIsGood;
+	}
+
 	return {
 		...DEFAULT_PAGE_SETTINGS,
-		...(projectLayout ?? {}),
+		...layoutSettings,
 		...parsePageSettings(content)
 	};
 }

--- a/core/src/config/page-frontmatter-schema.ts
+++ b/core/src/config/page-frontmatter-schema.ts
@@ -94,6 +94,16 @@ export const projectRootPageFrontmatterSchema = z.object({
 		.optional()
 		.catch(undefined)
 		.describe('Auto-refresh interval in seconds (0 disables auto-refresh).'),
+	down_is_good: z.coerce
+		.boolean()
+		.optional()
+		.catch(undefined)
+		.describe('Whether downward delta trends are considered positive by default on this page.'),
+	downIsGood: z.coerce
+		.boolean()
+		.optional()
+		.catch(undefined)
+		.describe('Alias for down_is_good.'),
 	theme: themeOverridesSchema
 		.optional()
 		.catch(undefined)
@@ -126,7 +136,14 @@ export const projectLayoutSchema = z
 		auto_refresh: z
 			.number()
 			.optional()
-			.describe('Auto-refresh interval in seconds (0 disables auto-refresh).')
+			.describe('Auto-refresh interval in seconds (0 disables auto-refresh).'),
+		down_is_good: z
+			.boolean()
+			.optional()
+			.describe(
+				'Whether downward delta trends are considered positive by default across all pages.'
+			),
+		downIsGood: z.boolean().optional().describe('Alias for down_is_good.')
 	})
 	.passthrough();
 

--- a/core/src/types/theme.ts
+++ b/core/src/types/theme.ts
@@ -141,7 +141,19 @@ export const themeConfigSchema = z.object({
 		// Behavioral defaults applied when a table doesn't set the attribute itself
 		rowLines: z.boolean().optional(),
 		rowShading: z.boolean().optional()
-	})
+	}),
+	defaults: z
+		.object({
+			downIsGood: z.boolean().optional(),
+			down_is_good: z.boolean().optional()
+		})
+		.optional(),
+	delta: z
+		.object({
+			downIsGood: z.boolean().optional(),
+			down_is_good: z.boolean().optional()
+		})
+		.optional()
 });
 
 // Override variants: `light`/`dark` are independently OPTIONAL so a partial
@@ -263,6 +275,22 @@ export const themeOverridesSchema = z.object({
 			pivotBackground: themeColorOverrideSchema.nullable().optional().catch(undefined),
 			rowLines: z.boolean().nullable().optional().catch(undefined),
 			rowShading: z.boolean().nullable().optional().catch(undefined)
+		})
+		.nullable()
+		.optional()
+		.catch(undefined),
+	defaults: z
+		.object({
+			downIsGood: z.boolean().nullable().optional().catch(undefined),
+			down_is_good: z.boolean().nullable().optional().catch(undefined)
+		})
+		.nullable()
+		.optional()
+		.catch(undefined),
+	delta: z
+		.object({
+			downIsGood: z.boolean().nullable().optional().catch(undefined),
+			down_is_good: z.boolean().nullable().optional().catch(undefined)
 		})
 		.nullable()
 		.optional()

--- a/core/src/user-components/interfaces/project-settings.ts
+++ b/core/src/user-components/interfaces/project-settings.ts
@@ -15,7 +15,9 @@ export const pageSettingsSchema = z
 		chart_series_colors: z.record(z.string()).nullable().optional(),
 		cards: z.boolean().optional(),
 		page_width: z.enum(['article', 'full']).optional(),
-		table_of_contents: z.boolean().optional()
+		table_of_contents: z.boolean().optional(),
+		down_is_good: z.boolean().optional(),
+		downIsGood: z.boolean().optional()
 	})
 	.passthrough();
 

--- a/core/src/user-components/tags/benchmark_comparison/BenchmarkComparison.svelte
+++ b/core/src/user-components/tags/benchmark_comparison/BenchmarkComparison.svelte
@@ -18,7 +18,7 @@
 	const text = $derived(props.text);
 	const pct_fmt = $derived(props.pct_fmt);
 	const abs_fmt = $derived(props.abs_fmt);
-	const down_is_good = $derived(props.down_is_good ?? false);
+	const down_is_good = $derived(props.down_is_good);
 
 	const context = getComparisonSelectorContext();
 

--- a/core/src/user-components/tags/bigvalue/BigValue.svelte
+++ b/core/src/user-components/tags/bigvalue/BigValue.svelte
@@ -79,7 +79,7 @@
 							? 'vs. benchmark'
 							: '')
 	);
-	const down_is_good = $derived(coerceBoolean(comparison?.down_is_good) ?? false);
+	const down_is_good = $derived(coerceBoolean(comparison?.down_is_good));
 	const neutralRange = $derived(comparison?.neutral_range ?? [0, 0]);
 	const max_width = $derived(props.max_width ?? 'none');
 	const min_width = $derived(props.min_width ?? 'auto');

--- a/core/src/user-components/tags/delta/Delta.svelte
+++ b/core/src/user-components/tags/delta/Delta.svelte
@@ -32,7 +32,7 @@
 	const text = $derived(model.resolvedText);
 	const comparison = $derived(model.resolvedComparison);
 	const chip = $derived(props.chip ?? false);
-	const downIsGood = $derived(comparison?.down_is_good ?? false);
+	const downIsGood = $derived(comparison?.down_is_good);
 	const showValue = $derived(props.show_value ?? true);
 	const showSymbol = $derived(props.show_symbol ?? true);
 	const symbolPosition = $derived(props.symbol_position ?? 'right');

--- a/core/src/user-components/tags/delta/DeltaDisplay.svelte
+++ b/core/src/user-components/tags/delta/DeltaDisplay.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { formatValue } from '../../formatValue';
 	import { setupRenderReadiness } from '../../../readiness.svelte';
+	import { getDeltaDefaultsContext } from './delta-defaults.context.svelte';
+	import { getPageSettingsContext } from '../../../page-settings.context';
+	import { getThemeContext } from '../../../theme/theme.context.svelte';
 
 	interface Props {
 		value: unknown;
@@ -17,12 +20,44 @@
 
 	const props: Props = $props();
 
+	const deltaDefaults = getDeltaDefaultsContext();
+	const pageSettingsGetter = getPageSettingsContext();
+	const themeContext = getThemeContext();
+
 	const value = $derived(props.value);
 	const className = $derived(props.className);
 	const fmt = $derived(props.fmt);
 	const text = $derived(props.text);
 	const chip = $derived(props.chip ?? false);
-	const downIsGood = $derived(props.downIsGood ?? false);
+	const downIsGood = $derived.by(() => {
+		if (typeof props.downIsGood === 'boolean') {
+			return props.downIsGood;
+		}
+		if (typeof deltaDefaults?.downIsGood === 'boolean') {
+			return deltaDefaults.downIsGood;
+		}
+		const pageSettings = pageSettingsGetter?.();
+		if (typeof pageSettings?.down_is_good === 'boolean') {
+			return pageSettings.down_is_good;
+		}
+		if (typeof pageSettings?.downIsGood === 'boolean') {
+			return pageSettings.downIsGood;
+		}
+		const theme = themeContext?.activeTheme as any;
+		if (typeof theme?.delta?.downIsGood === 'boolean') {
+			return theme.delta.downIsGood;
+		}
+		if (typeof theme?.delta?.down_is_good === 'boolean') {
+			return theme.delta.down_is_good;
+		}
+		if (typeof theme?.defaults?.downIsGood === 'boolean') {
+			return theme.defaults.downIsGood;
+		}
+		if (typeof theme?.defaults?.down_is_good === 'boolean') {
+			return theme.defaults.down_is_good;
+		}
+		return false;
+	});
 	const showValue = $derived(props.showValue ?? true);
 	const showSymbol = $derived(props.showSymbol ?? true);
 	const symbolPosition = $derived(props.symbolPosition ?? 'right');

--- a/core/src/user-components/tags/delta/delta-defaults.context.svelte.ts
+++ b/core/src/user-components/tags/delta/delta-defaults.context.svelte.ts
@@ -1,0 +1,22 @@
+﻿import { getContext, setContext } from 'svelte';
+
+export const DELTA_DEFAULTS_CONTEXT_KEY = Symbol('DELTA_DEFAULTS_CONTEXT');
+
+export interface DeltaDefaults {
+	downIsGood?: boolean;
+}
+
+export function setDeltaDefaultsContext(defaults: DeltaDefaults | (() => DeltaDefaults)) {
+	setContext(DELTA_DEFAULTS_CONTEXT_KEY, defaults);
+}
+
+export function getDeltaDefaultsContext(): DeltaDefaults | undefined {
+	const context = getContext<DeltaDefaults | (() => DeltaDefaults) | undefined>(
+		DELTA_DEFAULTS_CONTEXT_KEY
+	);
+	if (!context) return undefined;
+	if (typeof context === 'function') {
+		return context();
+	}
+	return context;
+}

--- a/core/src/user-components/tags/delta/delta-defaults.test.ts
+++ b/core/src/user-components/tags/delta/delta-defaults.test.ts
@@ -1,0 +1,75 @@
+﻿import { describe, it, expect } from 'vitest';
+import { schema as deltaDefaultsSchema } from '../delta_defaults/schema';
+import {
+	projectRootPageFrontmatterSchema,
+	projectLayoutSchema
+} from '../../../config/page-frontmatter-schema';
+import { pageSettingsSchema } from '../../interfaces/project-settings';
+import { themeConfigSchema, themeOverridesSchema } from '../../../types/theme';
+import { DEFAULT_THEME } from '../../../constants/default-theme';
+
+describe('Global downIsGood / DeltaDefaults configuration', () => {
+	describe('DeltaDefaults Schema', () => {
+		it('declares render name delta_defaults with down_is_good and downIsGood attributes', () => {
+			expect(deltaDefaultsSchema.render).toBe('delta_defaults');
+			expect(deltaDefaultsSchema.attributes.down_is_good).toBeDefined();
+			expect(deltaDefaultsSchema.attributes.downIsGood).toBeDefined();
+			expect(deltaDefaultsSchema.selfClosing).toBe(false);
+		});
+	});
+
+	describe('Page Frontmatter & Layout Schemas', () => {
+		it('parses down_is_good and downIsGood in page frontmatter schema', () => {
+			const parsedSnake = projectRootPageFrontmatterSchema.parse({
+				down_is_good: true
+			});
+			expect(parsedSnake.down_is_good).toBe(true);
+
+			const parsedCamel = projectRootPageFrontmatterSchema.parse({
+				downIsGood: true
+			});
+			expect(parsedCamel.downIsGood).toBe(true);
+		});
+
+		it('parses down_is_good and downIsGood in project layout schema', () => {
+			const parsedSnake = projectLayoutSchema.parse({
+				down_is_good: true
+			});
+			expect(parsedSnake.down_is_good).toBe(true);
+
+			const parsedCamel = projectLayoutSchema.parse({
+				downIsGood: true
+			});
+			expect(parsedCamel.downIsGood).toBe(true);
+		});
+
+		it('parses down_is_good and downIsGood in pageSettingsSchema', () => {
+			const parsed = pageSettingsSchema.parse({
+				down_is_good: true,
+				downIsGood: true
+			});
+			expect(parsed.down_is_good).toBe(true);
+			expect(parsed.downIsGood).toBe(true);
+		});
+	});
+
+	describe('Theme Schemas', () => {
+		it('accepts delta and defaults in themeOverridesSchema', () => {
+			const override = themeOverridesSchema.parse({
+				delta: {
+					downIsGood: true
+				},
+				defaults: {
+					down_is_good: true
+				}
+			});
+			expect(override.delta?.downIsGood).toBe(true);
+			expect(override.defaults?.down_is_good).toBe(true);
+		});
+
+		it('validates DEFAULT_THEME against themeConfigSchema', () => {
+			const parsed = themeConfigSchema.parse(DEFAULT_THEME);
+			expect(parsed).toBeDefined();
+		});
+	});
+});

--- a/core/src/user-components/tags/delta_defaults/DeltaDefaults.svelte
+++ b/core/src/user-components/tags/delta_defaults/DeltaDefaults.svelte
@@ -1,0 +1,21 @@
+﻿<script lang="ts">
+	import type { UserComponentProps } from '../../types';
+	import type { schema } from './schema';
+	import { setDeltaDefaultsContext } from '../delta/delta-defaults.context.svelte';
+	import { coerceBoolean } from '../../common/process-variables';
+
+	const props: UserComponentProps<typeof schema> = $props();
+
+	const down_is_good = $derived(
+		coerceBoolean(props.down_is_good) ?? coerceBoolean(props.downIsGood) ?? undefined
+	);
+	const children = $derived(props.children);
+
+	setDeltaDefaultsContext({
+		get downIsGood() {
+			return down_is_good;
+		}
+	});
+</script>
+
+{@render children?.()}

--- a/core/src/user-components/tags/delta_defaults/schema.ts
+++ b/core/src/user-components/tags/delta_defaults/schema.ts
@@ -1,0 +1,37 @@
+﻿import type { UserComponentSchema } from '../../types';
+
+export const schema = {
+	render: 'delta_defaults',
+	category: 'ui',
+	description: 'Sets default delta formatting options (such as down_is_good) for all child components',
+	attributes: {
+		down_is_good: {
+			type: Boolean,
+			description: 'Whether downward trends are considered positive by default for child components',
+			default: undefined
+		},
+		downIsGood: {
+			type: Boolean,
+			description: 'Alias for down_is_good',
+			default: undefined
+		}
+	},
+	selfClosing: false,
+	componentWrapper: {
+		display: 'contents',
+		noCard: true
+	},
+	examples: [
+		{
+			title: 'Basic Usage',
+			hero: true,
+			example: `
+<!-- Invert delta coloring for all child KPI components (cost dashboard) -->
+{% delta_defaults down_is_good=true %}
+    {% big_value data="costs" value="total_cloud_cost" /%}
+    {% big_value data="costs" value="total_infra_cost" /%}
+{% /delta_defaults %}
+`
+		}
+	]
+} as const satisfies UserComponentSchema;

--- a/core/src/user-components/tags/delta_defaults/user-component.ts
+++ b/core/src/user-components/tags/delta_defaults/user-component.ts
@@ -1,0 +1,8 @@
+﻿import type { UserComponent } from '../../types';
+import { schema } from './schema';
+import DeltaDefaults from './DeltaDefaults.svelte';
+
+export const userComponent: UserComponent<typeof schema> = {
+	schema,
+	Component: DeltaDefaults
+};

--- a/core/src/user-components/tags/target_comparison/TargetComparison.svelte
+++ b/core/src/user-components/tags/target_comparison/TargetComparison.svelte
@@ -13,7 +13,7 @@
 	const text = $derived(props.text);
 	const pct_fmt = $derived(props.pct_fmt);
 	const abs_fmt = $derived(props.abs_fmt);
-	const down_is_good = $derived(props.down_is_good ?? false);
+	const down_is_good = $derived(props.down_is_good);
 
 	const context = getComparisonSelectorContext();
 


### PR DESCRIPTION
﻿Closes #3297

### Description
This PR introduces global, page-level, and wrapper-context `downIsGood` (`down_is_good`) default configuration for `<Delta>`, `<BigValue>`, `<Table>`, and related comparison components.

In cost and finance dashboards, an increase is often negative (costs went up) and a decrease is positive (costs went down). Previously, authors had to add `down_is_good={true}` to each individual component.

### Changes
1. **Svelte Context & `<DeltaDefaults>` tag**:
   - Created `DeltaDefaultsContext` (`delta-defaults.context.svelte.ts`)
   - Added `<DeltaDefaults down_is_good={true}>` / `<DeltaDefaults downIsGood={true}>` wrapper component
2. **Page Frontmatter & Project Layout**:
   - Added `down_is_good` and `downIsGood` to `projectRootPageFrontmatterSchema` and `projectLayoutSchema`
   - Updated `pageSettingsSchema` and CLI page settings resolution to pass layout & frontmatter defaults
3. **Theme Defaults**:
   - Added `defaults` and `delta` blocks to `themeConfigSchema` and `themeOverridesSchema`
4. **Resolution Cascading in `DeltaDisplay`**:
   - Priority hierarchy:
     1. Component prop override (`comparison.down_is_good` / `downIsGood`)
     2. Nearest `<DeltaDefaults>` context
     3. Page frontmatter (`down_is_good` / `downIsGood`)
     4. Project layout / theme defaults
     5. Fallback: `false`
5. **Tests**:
   - Added unit test suite `delta-defaults.test.ts` for schema validation and default inheritance
   - Added test cases in `files.server.test.ts`
