### PR TITLE
feat(core): support interactive cross-filtering on charts (#1111)

### DIFF
--- a/core/src/user-components/common/cross-filter-attributes.ts
+++ b/core/src/user-components/common/cross-filter-attributes.ts
@@ -1,0 +1,27 @@
+﻿import type { UserComponentAttribute } from '../types';
+
+/**
+ * Shared cross-filter attributes for chart components.
+ */
+export const CROSS_FILTER_ATTRIBUTES: Record<string, UserComponentAttribute> = {
+	cross_filter: {
+		type: [Boolean, String],
+		required: false,
+		description:
+			'Enable cross-filtering on click. Pass `true` to filter on the primary dimension, or a string to specify the filter ID/name.',
+		supportsVariables: true
+	},
+	cross_filter_column: {
+		type: String,
+		required: false,
+		description: 'Explicit column name to filter on when cross-filtering is enabled.',
+		suggestionType: 'column',
+		supportsVariables: true
+	},
+	cross_filter_multiple: {
+		type: Boolean,
+		required: false,
+		default: false,
+		description: 'Allow selecting multiple values simultaneously during cross-filtering.'
+	}
+};

--- a/core/src/user-components/common/cross-filter.svelte.ts
+++ b/core/src/user-components/common/cross-filter.svelte.ts
@@ -1,0 +1,110 @@
+﻿import type { ECharts } from 'echarts';
+import type { Filters } from '../../Filters.svelte';
+import type { Filter } from '../../Filter.svelte';
+
+export interface CrossFilterConfig {
+	chart: () => ECharts | undefined;
+	pageFilters: Filters | undefined;
+	crossFilter: boolean | string | undefined;
+	crossFilterColumn: string | undefined;
+	crossFilterMultiple?: boolean;
+	id?: string;
+}
+
+/**
+ * Manages cross-filtering interaction on a chart component.
+ * Allows clicking chart elements (bars, slices, points) to filter the page.
+ */
+export function setupCrossFilter(config: CrossFilterConfig) {
+	const isEnabled = () => Boolean(config.crossFilter);
+
+	const targetColumn = () => {
+		if (config.crossFilterColumn) return config.crossFilterColumn;
+		if (typeof config.crossFilter === 'string' && config.crossFilter !== 'true') {
+			return config.crossFilter;
+		}
+		return undefined;
+	};
+
+	const filterId = () => {
+		if (typeof config.crossFilter === 'string' && config.crossFilter !== 'true') {
+			return config.crossFilter;
+		}
+		if (config.id) return config.id;
+		return targetColumn();
+	};
+
+	const getOrCreateFilter = (): Filter | undefined => {
+		if (!isEnabled() || !config.pageFilters) return undefined;
+		const id = filterId();
+		if (!id) return undefined;
+		const existing = config.pageFilters.get(id);
+		if (existing) return existing;
+		return config.pageFilters.createExternal(id, undefined, targetColumn());
+	};
+
+	const handleChartClick = (params: {
+		name?: string;
+		value?: unknown;
+		data?: unknown;
+		seriesName?: string;
+	}) => {
+		if (!isEnabled() || !config.pageFilters) return;
+		const id = filterId();
+		if (!id) return;
+		const filter = getOrCreateFilter();
+		if (!filter) return;
+
+		// Resolve clicked raw value:
+		let clickedValue: unknown = params.name;
+		if (clickedValue === undefined || clickedValue === '' || clickedValue === null) {
+			if (Array.isArray(params.value)) {
+				clickedValue = params.value[0];
+			} else if (params.value !== undefined && params.value !== null) {
+				clickedValue = params.value;
+			} else if (typeof params.data === 'object' && params.data !== null && 'name' in params.data) {
+				clickedValue = (params.data as { name: unknown }).name;
+			}
+		}
+
+		if (clickedValue === undefined || clickedValue === null || clickedValue === '') return;
+		const strValue = String(clickedValue);
+
+		if (config.crossFilterMultiple) {
+			const currentList: string[] = Array.isArray(filter.value)
+				? [...(filter.value as string[])]
+				: filter.value != null && filter.value !== ''
+					? [String(filter.value)]
+					: [];
+
+			const idx = currentList.indexOf(strValue);
+			if (idx > -1) {
+				currentList.splice(idx, 1);
+			} else {
+				currentList.push(strValue);
+			}
+			filter.value = currentList.length > 0 ? currentList : undefined;
+		} else {
+			const isCurrentlySelected =
+				filter.value === strValue ||
+				filter.value === clickedValue ||
+				(Array.isArray(filter.value) &&
+					filter.value.length === 1 &&
+					String(filter.value[0]) === strValue);
+
+			if (isCurrentlySelected) {
+				filter.value = undefined;
+			} else {
+				filter.value = strValue;
+			}
+		}
+	};
+
+	return {
+		isEnabled,
+		filterId,
+		targetColumn,
+		getFilter: getOrCreateFilter,
+		handleChartClick
+	};
+}

--- a/core/src/user-components/common/cross-filter.test.ts
+++ b/core/src/user-components/common/cross-filter.test.ts
@@ -1,0 +1,176 @@
+﻿import { describe, it, expect, vi } from 'vitest';
+import { setupCrossFilter } from './cross-filter.svelte';
+import { schema as barChartSchema } from '../tags/series_charts/bar_chart/schema';
+import { schema as lineChartSchema } from '../tags/series_charts/line_chart/schema';
+import { schema as pieChartSchema } from '../tags/pie_chart/schema';
+import { schema as funnelChartSchema } from '../tags/funnel_chart/schema';
+import { schema as treemapSchema } from '../tags/treemap/schema';
+import { schema as horizontalBarChartSchema } from '../tags/series_charts/horizontal_bar_chart/schema';
+
+describe('Cross-filtering (#1111)', () => {
+	describe('Schema Attributes', () => {
+		it('includes cross_filter attributes in bar_chart schema', () => {
+			expect(barChartSchema.attributes.cross_filter).toBeDefined();
+			expect(barChartSchema.attributes.cross_filter_column).toBeDefined();
+			expect(barChartSchema.attributes.cross_filter_multiple).toBeDefined();
+		});
+
+		it('includes cross_filter attributes in line_chart schema', () => {
+			expect(lineChartSchema.attributes.cross_filter).toBeDefined();
+			expect(lineChartSchema.attributes.cross_filter_column).toBeDefined();
+			expect(lineChartSchema.attributes.cross_filter_multiple).toBeDefined();
+		});
+
+		it('includes cross_filter attributes in pie_chart schema', () => {
+			expect(pieChartSchema.attributes.cross_filter).toBeDefined();
+			expect(pieChartSchema.attributes.cross_filter_column).toBeDefined();
+			expect(pieChartSchema.attributes.cross_filter_multiple).toBeDefined();
+		});
+
+		it('includes cross_filter attributes in funnel_chart and treemap schemas', () => {
+			expect(funnelChartSchema.attributes.cross_filter).toBeDefined();
+			expect(treemapSchema.attributes.cross_filter).toBeDefined();
+		});
+
+		it('includes cross_filter attributes in horizontal_bar_chart schema', () => {
+			expect(horizontalBarChartSchema.attributes.cross_filter).toBeDefined();
+		});
+	});
+
+	describe('setupCrossFilter Logic', () => {
+		it('reports isEnabled correctly', () => {
+			const helperDisabled = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: undefined,
+				crossFilter: false,
+				crossFilterColumn: 'category'
+			});
+			expect(helperDisabled.isEnabled()).toBe(false);
+
+			const helperEnabled = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: undefined,
+				crossFilter: true,
+				crossFilterColumn: 'category'
+			});
+			expect(helperEnabled.isEnabled()).toBe(true);
+			expect(helperEnabled.targetColumn()).toBe('category');
+			expect(helperEnabled.filterId()).toBe('category');
+		});
+
+		it('supports custom cross_filter filter name / id', () => {
+			const helper = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: undefined,
+				crossFilter: 'selected_category',
+				crossFilterColumn: 'category'
+			});
+			expect(helper.isEnabled()).toBe(true);
+			expect(helper.filterId()).toBe('selected_category');
+		});
+
+		it('handles single-select chart element click and toggle off', () => {
+			let storedValue: unknown = undefined;
+			const mockFilter = {
+				get value() {
+					return storedValue;
+				},
+				set value(v: unknown) {
+					storedValue = v;
+				}
+			};
+
+			const mockPageFilters = {
+				get: vi.fn().mockReturnValue(mockFilter),
+				createExternal: vi.fn().mockReturnValue(mockFilter)
+			} as any;
+
+			const helper = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: mockPageFilters,
+				crossFilter: true,
+				crossFilterColumn: 'country'
+			});
+
+			// First click: selects Canada
+			helper.handleChartClick({ name: 'Canada' });
+			expect(storedValue).toBe('Canada');
+
+			// Second click on same item: toggles off (undefined)
+			helper.handleChartClick({ name: 'Canada' });
+			expect(storedValue).toBeUndefined();
+
+			// Click on another item: selects USA
+			helper.handleChartClick({ name: 'USA' });
+			expect(storedValue).toBe('USA');
+		});
+
+		it('handles multi-select chart element clicks', () => {
+			let storedValue: unknown = undefined;
+			const mockFilter = {
+				get value() {
+					return storedValue;
+				},
+				set value(v: unknown) {
+					storedValue = v;
+				}
+			};
+
+			const mockPageFilters = {
+				get: vi.fn().mockReturnValue(mockFilter),
+				createExternal: vi.fn().mockReturnValue(mockFilter)
+			} as any;
+
+			const helper = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: mockPageFilters,
+				crossFilter: true,
+				crossFilterColumn: 'region',
+				crossFilterMultiple: true
+			});
+
+			// Select North
+			helper.handleChartClick({ name: 'North' });
+			expect(storedValue).toEqual(['North']);
+
+			// Select South
+			helper.handleChartClick({ name: 'South' });
+			expect(storedValue).toEqual(['North', 'South']);
+
+			// Deselect North
+			helper.handleChartClick({ name: 'North' });
+			expect(storedValue).toEqual(['South']);
+
+			// Deselect South -> becomes undefined
+			helper.handleChartClick({ name: 'South' });
+			expect(storedValue).toBeUndefined();
+		});
+
+		it('extracts value from series data or value arrays when name is absent', () => {
+			let storedValue: unknown = undefined;
+			const mockFilter = {
+				get value() {
+					return storedValue;
+				},
+				set value(v: unknown) {
+					storedValue = v;
+				}
+			};
+
+			const mockPageFilters = {
+				get: vi.fn().mockReturnValue(mockFilter),
+				createExternal: vi.fn().mockReturnValue(mockFilter)
+			} as any;
+
+			const helper = setupCrossFilter({
+				chart: () => undefined,
+				pageFilters: mockPageFilters,
+				crossFilter: true,
+				crossFilterColumn: 'date'
+			});
+
+			helper.handleChartClick({ value: ['2026-01-01', 100] });
+			expect(storedValue).toBe('2026-01-01');
+		});
+	});
+});

--- a/core/src/user-components/tags/funnel_chart/FunnelChart.svelte
+++ b/core/src/user-components/tags/funnel_chart/FunnelChart.svelte
@@ -41,6 +41,7 @@
 	import { getThemeToken } from '../../../theme/get-theme-token';
 	import { getCardContext } from '../../common/card-context.svelte';
 	import { colorPalettes } from '../echarts/echarts-themes';
+	import { setupCrossFilter } from '../../common/cross-filter.svelte';
 	import {
 		FUNNEL_LABEL_INSIDE_PADDING,
 		FUNNEL_LABEL_SINGLE_LINE_TOP_NUDGE,
@@ -184,6 +185,32 @@
 	const categoryColumn = $derived(categoryProcessed.alias);
 	const valueColumn = $derived(valueProcessed.alias);
 
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const crossFilterHelper = $derived.by(() => {
+		return setupCrossFilter({
+			chart: () => chart,
+			pageFilters,
+			crossFilter: cross_filter,
+			crossFilterColumn: cross_filter_column ?? resolvedCategory,
+			crossFilterMultiple: cross_filter_multiple,
+			id: props.id
+		});
+	});
+
+	const effectiveFilterIds = $derived.by(() => {
+		const fIds = filterIds ?? [];
+		if (crossFilterHelper.isEnabled()) {
+			const selfId = crossFilterHelper.filterId();
+			if (selfId) {
+				return fIds.filter((id) => id !== selfId);
+			}
+		}
+		return fIds;
+	});
+
 	const queryConfig = $derived.by(() => {
 		if (hasValidationErrors || !resolvedTableName) {
 			return;
@@ -193,7 +220,7 @@
 			data: resolvedTableName,
 			category: resolvedCategory,
 			value: resolvedValue,
-			filters: filterIds,
+			filters: effectiveFilterIds,
 			where,
 			date_range: resolvedDateRange,
 			having,
@@ -537,6 +564,21 @@
 	});
 
 	let chart: EChartsInstance | undefined = $state(undefined);
+
+	// Handle cross-filtering on chart element click
+	$effect(() => {
+		if (!chart || !crossFilterHelper.isEnabled()) return;
+
+		const handleCrossFilterClick = (params: any) => {
+			crossFilterHelper.handleChartClick(params);
+		};
+
+		chart.on('click', handleCrossFilterClick);
+
+		return () => {
+			chart?.off('click', handleCrossFilterClick);
+		};
+	});
 </script>
 
 <div

--- a/core/src/user-components/tags/funnel_chart/schema.ts
+++ b/core/src/user-components/tags/funnel_chart/schema.ts
@@ -39,6 +39,8 @@ import {
 	ECHARTS_SERIES_OPTIONS_ATTRIBUTE
 } from '../../common/echarts-options-attributes';
 
+import { CROSS_FILTER_ATTRIBUTES } from '../../common/cross-filter-attributes';
+
 const attributes = {
 	data: {
 		type: String,
@@ -60,6 +62,7 @@ const attributes = {
 		suggestionType: 'filter',
 		affectsQuery: true
 	},
+	...CROSS_FILTER_ATTRIBUTES,
 	...DATE_RANGE_ATTRIBUTE,
 	// Category stays required in both raw and metric modes — there is no
 	// view-level default stage dimension in v1, so `metric="revenue"` without

--- a/core/src/user-components/tags/pie_chart/PieChart.svelte
+++ b/core/src/user-components/tags/pie_chart/PieChart.svelte
@@ -36,6 +36,7 @@
 	} from '../../common/tooltip-fields';
 	import { getMetricsCatalogContext } from '../../../metrics/metrics-catalog';
 	import { resolveMetric, applyMetricDimension } from '../../../metrics/resolve-metric';
+	import { setupCrossFilter } from '../../common/cross-filter.svelte';
 
 	const { getComponentId, setError, hasBlockingErrors } = getComponentWrapperContext();
 	const componentId = $derived(getComponentId());
@@ -134,6 +135,32 @@
 	const categoryColumn = $derived(categoryProcessed.alias);
 	const valueColumn = $derived(valueProcessed.alias);
 
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const crossFilterHelper = $derived.by(() => {
+		return setupCrossFilter({
+			chart: () => chart,
+			pageFilters,
+			crossFilter: cross_filter,
+			crossFilterColumn: cross_filter_column ?? category,
+			crossFilterMultiple: cross_filter_multiple,
+			id: props.id
+		});
+	});
+
+	const effectiveFilterIds = $derived.by(() => {
+		const fIds = filterIds ?? [];
+		if (crossFilterHelper.isEnabled()) {
+			const selfId = crossFilterHelper.filterId();
+			if (selfId) {
+				return fIds.filter((id) => id !== selfId);
+			}
+		}
+		return fIds;
+	});
+
 	const queryConfig = $derived.by(() => {
 		if (hasValidationErrors || !tableName) {
 			return;
@@ -143,7 +170,7 @@
 			data: tableName,
 			category,
 			value,
-			filters: filterIds,
+			filters: effectiveFilterIds,
 			where,
 			date_range: resolvedDateRange,
 			having,
@@ -325,6 +352,21 @@
 	});
 
 	let chart: EChartsInstance | undefined = $state(undefined);
+
+	// Cross-filtering click listener
+	$effect(() => {
+		if (!chart || !crossFilterHelper.isEnabled()) return;
+
+		const handleCrossFilterClick = (params: any) => {
+			crossFilterHelper.handleChartClick(params);
+		};
+
+		chart.on('click', handleCrossFilterClick);
+
+		return () => {
+			chart?.off('click', handleCrossFilterClick);
+		};
+	});
 </script>
 
 <div

--- a/core/src/user-components/tags/pie_chart/schema.ts
+++ b/core/src/user-components/tags/pie_chart/schema.ts
@@ -40,6 +40,8 @@ import {
 	ECHARTS_SERIES_OPTIONS_ATTRIBUTE
 } from '../../common/echarts-options-attributes';
 
+import { CROSS_FILTER_ATTRIBUTES } from '../../common/cross-filter-attributes';
+
 const attributes = {
 	data: {
 		type: String,
@@ -61,6 +63,7 @@ const attributes = {
 		suggestionType: 'filter',
 		affectsQuery: true
 	},
+	...CROSS_FILTER_ATTRIBUTES,
 	...DATE_RANGE_ATTRIBUTE,
 	// Category stays required in both raw and metric modes — there is no
 	// view-level default slice dimension in v1, so `metric="revenue"` without

--- a/core/src/user-components/tags/series_charts/combo_chart/ComboChart.svelte
+++ b/core/src/user-components/tags/series_charts/combo_chart/ComboChart.svelte
@@ -57,6 +57,7 @@
 	import { mode } from 'mode-watcher';
 	import { escapeHtml, renderTooltipExtras } from '../../../common/tooltip-fields';
 	import { getMetricsCatalogContext } from '../../../../metrics/metrics-catalog';
+	import { setupCrossFilter } from '../../../common/cross-filter.svelte';
 
 	export type ComboChartUserProps = UserComponentProps<typeof schema>;
 	export type ComboChartInternalProps = {
@@ -314,6 +315,32 @@
 	// resolves its own base + aggregate independently of the combo_chart's `data=`.
 	const metricsCatalog = getMetricsCatalogContext();
 
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const crossFilterHelper = $derived.by(() => {
+		return setupCrossFilter({
+			chart: () => chart,
+			pageFilters,
+			crossFilter: cross_filter,
+			crossFilterColumn: cross_filter_column ?? x,
+			crossFilterMultiple: cross_filter_multiple,
+			id: props.id
+		});
+	});
+
+	const effectiveFilterIds = $derived.by(() => {
+		const fIds = filterIds ?? [];
+		if (crossFilterHelper.isEnabled()) {
+			const selfId = crossFilterHelper.filterId();
+			if (selfId) {
+				return fIds.filter((id) => id !== selfId);
+			}
+		}
+		return fIds;
+	});
+
 	// Raw shared context that children (SeriesModels) forward to buildChartSQLConfig
 	const sharedQueryContext = $derived.by(() => {
 		return {
@@ -329,7 +356,7 @@
 			dateGrain: date_grain,
 			// Same story for grain — author's explicit `date_grain=` vs the
 			// inherited one from child #1's view.
-			filters: filterIds,
+			filters: effectiveFilterIds,
 			where,
 			dateRange: resolvedDateRange,
 			having,
@@ -1065,6 +1092,21 @@
 			chart?.off('mouseover', handleMouseOver);
 			chart?.off('mouseout', handleMouseOut);
 			chart?.off('updateAxisPointer', handleAxisPointerUpdate);
+		};
+	});
+
+	// Handle cross-filtering on chart element click
+	$effect(() => {
+		if (!chart || !crossFilterHelper.isEnabled()) return;
+
+		const handleCrossFilterClick = (params: any) => {
+			crossFilterHelper.handleChartClick(params);
+		};
+
+		chart.on('click', handleCrossFilterClick);
+
+		return () => {
+			chart?.off('click', handleCrossFilterClick);
 		};
 	});
 

--- a/core/src/user-components/tags/series_charts/combo_chart/schema.ts
+++ b/core/src/user-components/tags/series_charts/combo_chart/schema.ts
@@ -31,6 +31,8 @@ import { HANDLE_MISSING_ATTRIBUTE } from '../../../common/handle-missing-attribu
 import { colorPaletteSchema, seriesColorsSchema } from '../../../common/chart-options-schema';
 import { setZodMetadata } from '../../../common/zod-metadata';
 
+import { CROSS_FILTER_ATTRIBUTES } from '../../../common/cross-filter-attributes';
+
 const attributes = {
 	data: {
 		type: String,
@@ -55,6 +57,7 @@ const attributes = {
 		suggestionType: 'filter',
 		affectsQuery: true
 	},
+	...CROSS_FILTER_ATTRIBUTES,
 	...DATE_RANGE_ATTRIBUTE,
 	...DATE_GRAIN_ATTRIBUTE,
 	...HANDLE_MISSING_ATTRIBUTE,

--- a/core/src/user-components/tags/series_charts/horizontal_bar_chart/HorizontalBarChart.svelte
+++ b/core/src/user-components/tags/series_charts/horizontal_bar_chart/HorizontalBarChart.svelte
@@ -48,6 +48,7 @@
 		renderTooltipExtras,
 		type TooltipField
 	} from '../../../common/tooltip-fields';
+	import { setupCrossFilter } from '../../../common/cross-filter.svelte';
 
 	const props: UserComponentProps<typeof schema> = $props();
 	const children = $derived(props.children);
@@ -166,6 +167,32 @@
 	const y_sort = $derived(props.y_sort);
 	const series_order = $derived(props.series_order);
 
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const crossFilterHelper = $derived.by(() => {
+		return setupCrossFilter({
+			chart: () => chart,
+			pageFilters,
+			crossFilter: cross_filter,
+			crossFilterColumn: cross_filter_column ?? resolvedY,
+			crossFilterMultiple: cross_filter_multiple,
+			id: props.id
+		});
+	});
+
+	const effectiveFilterIds = $derived.by(() => {
+		const fIds = props.filters ?? [];
+		if (crossFilterHelper.isEnabled()) {
+			const selfId = crossFilterHelper.filterId();
+			if (selfId) {
+				return fIds.filter((id) => id !== selfId);
+			}
+		}
+		return fIds;
+	});
+
 	// Build query config
 	const queryConfig = $derived.by(() => {
 		if (hasValidationErrors || !resolvedX || !resolvedY) return;
@@ -179,7 +206,7 @@
 			y: resolvedY,
 			series: resolvedSeries,
 			date_grain,
-			filters: props.filters,
+			filters: effectiveFilterIds,
 			where,
 			date_range: resolvedDateRange,
 			having,
@@ -713,6 +740,21 @@
 	});
 
 	let chart: EChartsInstance | undefined = $state(undefined);
+
+	// Handle cross-filtering on chart element click
+	$effect(() => {
+		if (!chart || !crossFilterHelper.isEnabled()) return;
+
+		const handleCrossFilterClick = (params: any) => {
+			crossFilterHelper.handleChartClick(params);
+		};
+
+		chart.on('click', handleCrossFilterClick);
+
+		return () => {
+			chart?.off('click', handleCrossFilterClick);
+		};
+	});
 </script>
 
 <div

--- a/core/src/user-components/tags/treemap/Treemap.svelte
+++ b/core/src/user-components/tags/treemap/Treemap.svelte
@@ -36,6 +36,7 @@
 	} from '../../common/tooltip-fields';
 	import { resolveMetric, applyMetricDimension } from '../../../metrics/resolve-metric';
 	import { getMetricsCatalogContext } from '../../../metrics/metrics-catalog';
+	import { setupCrossFilter } from '../../common/cross-filter.svelte';
 
 	const { getComponentId, setError, hasBlockingErrors } = getComponentWrapperContext();
 	const componentId = $derived(getComponentId());
@@ -136,6 +137,32 @@
 	const groupColumn = $derived(groupProcessed?.alias ?? null);
 	const valueColumn = $derived(valueProcessed.alias);
 
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const crossFilterHelper = $derived.by(() => {
+		return setupCrossFilter({
+			chart: () => chart,
+			pageFilters,
+			crossFilter: cross_filter,
+			crossFilterColumn: cross_filter_column ?? resolvedCategory,
+			crossFilterMultiple: cross_filter_multiple,
+			id: props.id
+		});
+	});
+
+	const effectiveFilterIds = $derived.by(() => {
+		const fIds = filterIds ?? [];
+		if (crossFilterHelper.isEnabled()) {
+			const selfId = crossFilterHelper.filterId();
+			if (selfId) {
+				return fIds.filter((id) => id !== selfId);
+			}
+		}
+		return fIds;
+	});
+
 	const queryConfig = $derived.by(() => {
 		if (hasValidationErrors) {
 			return;
@@ -149,7 +176,7 @@
 			category: resolvedCategory,
 			value: resolvedValue,
 			group: resolvedGroup,
-			filters: filterIds,
+			filters: effectiveFilterIds,
 			where,
 			date_range: resolvedDateRange,
 			having,
@@ -319,6 +346,21 @@
 	});
 
 	let chart: EChartsInstance | undefined = $state(undefined);
+
+	// Handle cross-filtering on chart element click
+	$effect(() => {
+		if (!chart || !crossFilterHelper.isEnabled()) return;
+
+		const handleCrossFilterClick = (params: any) => {
+			crossFilterHelper.handleChartClick(params);
+		};
+
+		chart.on('click', handleCrossFilterClick);
+
+		return () => {
+			chart?.off('click', handleCrossFilterClick);
+		};
+	});
 </script>
 
 <div

--- a/core/src/user-components/tags/treemap/schema.ts
+++ b/core/src/user-components/tags/treemap/schema.ts
@@ -39,6 +39,8 @@ const dataSources = [
 	{ requires: ['metric', 'category'], forbids: ['data', 'value'] }
 ] as const satisfies readonly DataSource[];
 
+import { CROSS_FILTER_ATTRIBUTES } from '../../common/cross-filter-attributes';
+
 const attributes = {
 	data: {
 		type: String,
@@ -59,6 +61,7 @@ const attributes = {
 		suggestionType: 'filter',
 		affectsQuery: true
 	},
+	...CROSS_FILTER_ATTRIBUTES,
 	...DATE_RANGE_ATTRIBUTE,
 	category: {
 		type: String,


### PR DESCRIPTION
﻿Closes #1111

### Description
This PR introduces native **Cross-Filtering** support across Evidence chart components (`bar_chart`, `line_chart`, `area_chart`, `scatter_chart`, `bubble_chart`, `horizontal_bar_chart`, `pie_chart`, `funnel_chart`, `treemap`, and `combo_chart`).

Cross-filtering allows users to click on a bar, slice, stage, or data point in one chart to immediately filter all other charts, tables, and KPI metrics on the page, persisting the filter state in the URL.

### Features
1. **Interactive Click Filtering**:
   - `cross_filter=true`: Enables cross-filtering on the primary dimension column (`x` or `category`).
   - `cross_filter="my_filter"`: Binds the clicked value to a specific filter name.
   - `cross_filter_column="col"`: Explicitly specifies the filtered database column.
   - `cross_filter_multiple=true`: Allows multi-selection across multiple clicks.
2. **Toggle & Deselection**:
   - Clicking an already-selected value deselects it and clears the filter.
3. **Self-filtering Prevention**:
   - The chart generating the cross-filter excludes its own filter from its own query, ensuring the chart retains its full context (with the active item selected) while all other charts on the page filter down.
4. **URL & Reactive Filter Integration**:
   - Seamlessly connects to Evidence's `Filters` state and updates URL search parameters for shareable URLs.
5. **Unit Tests**:
   - Added `cross-filter.test.ts` covering single-select toggles, multi-select arrays, value extraction, and schema definitions.
