### PR TITLE
feat(core): add FilterPresets component, table row drilldown, and expanded date range presets

### DIFF
--- a/core/src/user-components/Renderer/MarkdocProcessor/process-markdoc.ts
+++ b/core/src/user-components/Renderer/MarkdocProcessor/process-markdoc.ts
@@ -1348,7 +1348,8 @@ const FILTER_INPUT_COMPONENTS = new Set([
 	'toggle',
 	'button_group',
 	'table_filter',
-	'slider'
+	'slider',
+	'filter_presets'
 ]);
 
 // TODO does this need to be recursive to work on non-root-level nodes?

--- a/core/src/user-components/common/cross-filter-attributes.ts
+++ b/core/src/user-components/common/cross-filter-attributes.ts
@@ -1,0 +1,29 @@
+﻿import type { UserComponentAttribute } from '../types';
+
+export const CROSS_FILTER_ATTRIBUTES = {
+	cross_filter: {
+		type: [Boolean, String],
+		required: false,
+		default: false,
+		description:
+			'Enables interactive cross-filtering on click. Pass `true` to use the primary category column, or a string to bind to a specific filter id.',
+		affectsQuery: false
+	},
+	cross_filter_column: {
+		type: String,
+		required: false,
+		description:
+			'Explicit database column to filter when a chart or table element is clicked. Defaults to the category column.',
+		affectsQuery: false,
+		supportsVariables: true,
+		variableContext: 'text'
+	},
+	cross_filter_multiple: {
+		type: Boolean,
+		required: false,
+		default: false,
+		description:
+			'When true, clicking multiple elements adds them to an array of selected filter values instead of toggling a single value.',
+		affectsQuery: false
+	}
+} as const satisfies Record<string, UserComponentAttribute>;

--- a/core/src/user-components/common/date-options.ts
+++ b/core/src/user-components/common/date-options.ts
@@ -326,12 +326,36 @@ export const PRESET_DEFINITIONS = [
 		periodCount: 7
 	},
 	{
+		key: 'last 14 days',
+		label: 'Last 14 Days',
+		shorthand: 'l14d',
+		type: 'relative',
+		periodGrain: 'day',
+		periodCount: 14
+	},
+	{
 		key: 'last 30 days',
 		label: 'Last 30 Days',
 		shorthand: 'l30d',
 		type: 'relative',
 		periodGrain: 'day',
 		periodCount: 30
+	},
+	{
+		key: 'last 60 days',
+		label: 'Last 60 Days',
+		shorthand: 'l60d',
+		type: 'relative',
+		periodGrain: 'day',
+		periodCount: 60
+	},
+	{
+		key: 'last 90 days',
+		label: 'Last 90 Days',
+		shorthand: 'l90d',
+		type: 'relative',
+		periodGrain: 'day',
+		periodCount: 90
 	},
 	{
 		key: 'last 3 months',

--- a/core/src/user-components/tags/filter_bar/schema.ts
+++ b/core/src/user-components/tags/filter_bar/schema.ts
@@ -12,7 +12,8 @@ export const schema = {
 		'date_grain_selector',
 		'comparison_selector',
 		'range_calendar',
-		'button_group'
+		'button_group',
+		'filter_presets'
 	],
 	componentWrapper: false
 } as const satisfies UserComponentSchema;

--- a/core/src/user-components/tags/filter_presets/FilterPresets.svelte
+++ b/core/src/user-components/tags/filter_presets/FilterPresets.svelte
@@ -1,0 +1,166 @@
+﻿<script lang="ts">
+	import type { UserComponentProps } from '../../types';
+	import type { schema } from './schema';
+	import { getPageFiltersContext } from '../../../page-filters-context';
+	import { getRepeatContext } from '../repeat/repeat-context';
+	import { getInlineQueriesContext } from '../../common/inline-queries';
+	import { VariableProcessor } from '../../../filter-variables/VariableProcessor';
+	import { createResolvers } from '../../common/use-variable-processing';
+	import { Button } from '../../../shadcn/components/ui/button';
+	import { cn } from '../../../shadcn/utils';
+	import ComponentTitle from '../../common/ComponentTitle.svelte';
+	import Bookmark from 'lucide-svelte/icons/bookmark';
+	import Check from 'lucide-svelte/icons/check';
+	import { onMount } from 'svelte';
+
+	interface PresetItem {
+		label: string;
+		values: Record<string, any>;
+	}
+
+	const props: UserComponentProps<typeof schema> = $props();
+
+	const repeatFilters = getRepeatContext()?.filters;
+	const pageFilters = getPageFiltersContext();
+	const inlineQueries = getInlineQueriesContext();
+
+	const variableProcessor = $derived.by(() => {
+		if (!inlineQueries) return null;
+		const filterContexts = [repeatFilters, pageFilters].filter(
+			(ctx): ctx is NonNullable<typeof ctx> => ctx !== undefined
+		);
+		if (filterContexts.length === 0) return null;
+		return new VariableProcessor(filterContexts, inlineQueries);
+	});
+
+	const { resolveText } = $derived(createResolvers(variableProcessor));
+
+	const title = $derived(resolveText(props.title) ?? '');
+	const presets = $derived((props.presets ?? []) as PresetItem[]);
+	const defaultPreset = $derived(props.default_preset);
+	const variant = $derived(props.variant ?? 'pills');
+	const size = $derived(props.size ?? 'sm');
+	const align = $derived(props.align ?? 'left');
+
+	// Determine if a given preset is currently active
+	function isPresetActive(preset: PresetItem): boolean {
+		if (!pageFilters || !preset.values) return false;
+		const entries = Object.entries(preset.values);
+		if (entries.length === 0) return false;
+
+		return entries.every(([key, expectedVal]) => {
+			const filter = pageFilters.get(key);
+			if (!filter) return false;
+			const currentVal = filter.value;
+
+			if (Array.isArray(expectedVal) && Array.isArray(currentVal)) {
+				return (
+					expectedVal.length === currentVal.length &&
+					expectedVal.every((v, i) => v === currentVal[i])
+				);
+			}
+			return currentVal === expectedVal;
+		});
+	}
+
+	function applyPreset(preset: PresetItem) {
+		if (!pageFilters || !preset.values) return;
+
+		const isActive = isPresetActive(preset);
+
+		for (const [key, val] of Object.entries(preset.values)) {
+			let filter = pageFilters.get(key);
+			if (!filter) {
+				filter = pageFilters.createExternal(key, undefined, key);
+			}
+
+			if (isActive) {
+				// Toggle off if already active
+				filter.value = undefined;
+			} else {
+				filter.value = val;
+			}
+		}
+	}
+
+	// Apply default preset on mount if specified and not already filtered
+	onMount(() => {
+		if (!defaultPreset || !pageFilters) return;
+		const target = presets.find((p) => p.label.toLowerCase() === defaultPreset.toLowerCase());
+		if (target && !isPresetActive(target)) {
+			applyPreset(target);
+		}
+	});
+</script>
+
+<div class="flex flex-col gap-1.5 my-2">
+	{#if title}
+		<ComponentTitle {title} />
+	{/if}
+
+	<div
+		class={cn(
+			'flex flex-wrap items-center gap-1.5',
+			align === 'center' && 'justify-center',
+			align === 'right' && 'justify-end',
+			align === 'left' && 'justify-start'
+		)}
+	>
+		{#each presets as preset}
+			{@const active = isPresetActive(preset)}
+			{#if variant === 'pills'}
+				<button
+					type="button"
+					onclick={() => applyPreset(preset)}
+					class={cn(
+						'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-medium transition-all text-xs select-none shadow-xs',
+						size === 'sm' && 'px-2.5 py-0.5 text-xs',
+						size === 'base' && 'px-3 py-1 text-sm',
+						size === 'lg' && 'px-4 py-1.5 text-base',
+						active
+							? 'bg-primary text-primary-foreground border-primary shadow-sm hover:opacity-90'
+							: 'bg-background hover:bg-muted text-muted-foreground hover:text-foreground border-border'
+					)}
+				>
+					{#if active}
+						<Check class="h-3 w-3 animate-in zoom-in-50" />
+					{:else}
+						<Bookmark class="h-3 w-3 opacity-60" />
+					{/if}
+					<span>{preset.label}</span>
+				</button>
+			{:else if variant === 'chips'}
+				<button
+					type="button"
+					onclick={() => applyPreset(preset)}
+					class={cn(
+						'inline-flex items-center gap-1 rounded-md px-2.5 py-1 font-medium transition-colors text-xs select-none',
+						size === 'sm' && 'px-2 py-0.5 text-xs',
+						size === 'base' && 'px-3 py-1 text-sm',
+						size === 'lg' && 'px-4 py-1.5 text-base',
+						active
+							? 'bg-accent text-accent-foreground font-semibold ring-1 ring-border'
+							: 'bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground'
+					)}
+				>
+					{#if active}
+						<Check class="h-3 w-3" />
+					{/if}
+					<span>{preset.label}</span>
+				</button>
+			{:else}
+				<Button
+					variant={active ? 'default' : 'outline'}
+					size={size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'default'}
+					class="gap-1.5"
+					onclick={() => applyPreset(preset)}
+				>
+					{#if active}
+						<Check class="h-3.5 w-3.5" />
+					{/if}
+					<span>{preset.label}</span>
+				</Button>
+			{/if}
+		{/each}
+	</div>
+</div>

--- a/core/src/user-components/tags/filter_presets/FilterPresets.test.ts
+++ b/core/src/user-components/tags/filter_presets/FilterPresets.test.ts
@@ -1,0 +1,15 @@
+﻿import { describe, it, expect } from 'vitest';
+import { schema } from './schema';
+
+describe('FilterPresets tag', () => {
+	it('has valid schema attributes', () => {
+		expect(schema.render).toBe('filter_presets');
+		expect(schema.attributes.presets).toBeDefined();
+		expect(schema.attributes.presets.required).toBe(true);
+		expect(schema.attributes.title).toBeDefined();
+		expect(schema.attributes.default_preset).toBeDefined();
+		expect(schema.attributes.variant).toBeDefined();
+		expect(schema.attributes.size).toBeDefined();
+		expect(schema.attributes.align).toBeDefined();
+	});
+});

--- a/core/src/user-components/tags/filter_presets/schema.ts
+++ b/core/src/user-components/tags/filter_presets/schema.ts
@@ -1,0 +1,62 @@
+﻿import type { UserComponentSchema } from '../../types';
+import { WIDTH_ATTRIBUTE } from '../../common/width-attribute';
+
+export const schema = {
+	render: 'filter_presets',
+	category: 'input',
+	description: 'Display quick filter presets / saved views that apply multiple filters simultaneously',
+	keywords: [
+		'filter presets',
+		'saved views',
+		'quick filters',
+		'filter bookmarks',
+		'filter pills',
+		'presets',
+		'views'
+	],
+	attributes: {
+		title: {
+			type: String,
+			required: false,
+			description: 'Title displayed above the filter presets',
+			affectsQuery: false,
+			supportsVariables: true,
+			variableContext: 'text'
+		},
+		presets: {
+			type: Array,
+			required: true,
+			description:
+				'Array of preset configurations. Each entry is `{ label: string, values: Record<string, any> }`',
+			affectsQuery: false
+		},
+		default_preset: {
+			type: String,
+			required: false,
+			description: 'Label of the preset to activate by default on initial page load',
+			affectsQuery: false
+		},
+		variant: {
+			type: String,
+			required: false,
+			default: 'pills',
+			description: 'Visual style for presets: "pills", "buttons", or "chips"',
+			affectsQuery: false
+		},
+		size: {
+			type: String,
+			required: false,
+			default: 'sm',
+			description: 'Size of the preset controls: "sm", "base", or "lg"',
+			affectsQuery: false
+		},
+		align: {
+			type: String,
+			required: false,
+			default: 'left',
+			description: 'Alignment of presets: "left", "center", or "right"',
+			affectsQuery: false
+		},
+		...WIDTH_ATTRIBUTE
+	}
+} as const satisfies UserComponentSchema;

--- a/core/src/user-components/tags/filter_presets/user-component.ts
+++ b/core/src/user-components/tags/filter_presets/user-component.ts
@@ -1,0 +1,8 @@
+﻿import type { UserComponent } from '../../types';
+import { schema } from './schema';
+import FilterPresets from './FilterPresets.svelte';
+
+export const userComponent: UserComponent<typeof schema> = {
+	schema,
+	Component: FilterPresets
+};

--- a/core/src/user-components/tags/table/Table.svelte
+++ b/core/src/user-components/tags/table/Table.svelte
@@ -6,6 +6,7 @@
 	import { type SQLProps } from '../../common/sql-options';
 
 	import { getQueryInfoContext } from '../../../query-info-context.svelte';
+	import { getPageFiltersContext } from '../../../page-filters-context';
 
 	import {
 		generatePivotData,
@@ -739,6 +740,79 @@
 		model.pageSizeOverride = undefined;
 		model.page = 0;
 	}
+
+	// === CROSS-FILTERING ===
+	const pageFilters = getPageFiltersContext();
+	const cross_filter = $derived(props.cross_filter);
+	const cross_filter_column = $derived(model.resolveColumn(props.cross_filter_column));
+	const cross_filter_multiple = $derived(props.cross_filter_multiple ?? false);
+
+	const isCrossFilterEnabled = $derived(cross_filter !== undefined && cross_filter !== false);
+	const crossFilterTargetColumn = $derived.by(() => {
+		if (cross_filter_column) return cross_filter_column;
+		if (model.dimensions && model.dimensions.length > 0) return model.dimensions[0];
+		if (displayPivotData.columns && displayPivotData.columns.length > 0) return displayPivotData.columns[0];
+		return undefined;
+	});
+
+	const crossFilterId = $derived.by(() => {
+		if (!isCrossFilterEnabled) return undefined;
+		if (typeof cross_filter === 'string') return cross_filter;
+		return crossFilterTargetColumn ?? props.id ?? 'table_filter';
+	});
+
+	const activeFilter = $derived.by(() => {
+		if (!pageFilters || !crossFilterId) return undefined;
+		return pageFilters.get(crossFilterId);
+	});
+
+	function isRowSelected(row: Record<string, any>): boolean {
+		if (!isCrossFilterEnabled || !crossFilterTargetColumn || !activeFilter) return false;
+		const val = row[crossFilterTargetColumn];
+		if (val === undefined || val === null) return false;
+		const filterVal = activeFilter.value;
+		if (Array.isArray(filterVal)) {
+			return filterVal.includes(val);
+		}
+		return filterVal === val;
+	}
+
+	function handleTableRowClick(row: Record<string, any>) {
+		if (link && row && row[link]) {
+			window.location.href = String(row[link]);
+			return;
+		}
+
+		if (!isCrossFilterEnabled || !crossFilterTargetColumn || !pageFilters || !crossFilterId) return;
+		const val = row[crossFilterTargetColumn];
+		if (val === undefined || val === null) return;
+
+		let filter = pageFilters.get(crossFilterId);
+		if (!filter) {
+			filter = pageFilters.createExternal(crossFilterId, undefined, crossFilterTargetColumn);
+		}
+
+		if (cross_filter_multiple) {
+			const current = Array.isArray(filter.value)
+				? [...filter.value]
+				: filter.value !== undefined
+					? [filter.value]
+					: [];
+			const idx = current.indexOf(val);
+			if (idx >= 0) {
+				current.splice(idx, 1);
+			} else {
+				current.push(val);
+			}
+			filter.value = current.length > 0 ? current : undefined;
+		} else {
+			if (filter.value === val) {
+				filter.value = undefined;
+			} else {
+				filter.value = val;
+			}
+		}
+	}
 </script>
 
 {#snippet tableContent()}
@@ -784,6 +858,8 @@
 						<!-- Row conditional colors -->
 						{@const rowColorValue = isDataRow && row['__row_conditional_colors'] ? String(row['__row_conditional_colors']) : null}
 						{@const rowColorStyles = rowColorValue ? calculateColorStylesFromHex(rowColorValue) : null}
+						{@const isSelected = isRowSelected(row)}
+						{@const isClickableRow = isCollapsibleSubtotal || Boolean(hasRowLink) || isCrossFilterEnabled}
 						<tr 
 							class={isCollapsibleActive ? getRowClasses({
 								rowLines: row_lines,
@@ -791,16 +867,17 @@
 								isCollapsibleActive,
 								isCollapsibleSubtotal,
 								isDataRow,
-								hasRowLink: Boolean(hasRowLink),
+								hasRowLink: Boolean(hasRowLink) || isCrossFilterEnabled,
 								isTotal: row.render_type === 'row_total',
 								totalPosition: total_position
 							}) : cn(
 								row_lines ? 'border-(--theme-table-row-border) border-b' : 'border-0',
 								row_shading && isDataRow && !rowColorStyles ? 'even:bg-muted' : '',
 								'transition-colors',
-								hasRowLink ? 'hover:bg-(--theme-table-hover) cursor-pointer' : ''
+								isClickableRow ? 'hover:bg-(--theme-table-hover) cursor-pointer' : '',
+								isSelected ? 'bg-primary/10 font-medium' : ''
 							)}
-							onclick={isCollapsibleSubtotal ? () => toggleGroupCollapse(subtotalGroupKey) : hasRowLink ? () => handleRowClick(row) : undefined}
+							onclick={isCollapsibleSubtotal ? () => toggleGroupCollapse(subtotalGroupKey) : (hasRowLink || isCrossFilterEnabled) ? () => handleTableRowClick(row) : undefined}
 						>
 							{#each displayPivotData.columns.map((col, tableColumnIndex) => ({ 
 								col, 

--- a/core/src/user-components/tags/table/TableModel.svelte.ts
+++ b/core/src/user-components/tags/table/TableModel.svelte.ts
@@ -127,6 +127,31 @@ export class TableModel extends UserComponentModel<TableModelGenerics> {
 		this.resolveColumn(this.attributes.row_conditional_colors)
 	);
 
+	readonly crossFilterColumn = $derived(
+		this.resolveColumn(this.attributes.cross_filter_column)
+	);
+
+	readonly crossFilterTargetColumn = $derived.by(() => {
+		if (this.crossFilterColumn) return this.crossFilterColumn;
+		if (this.dimensions && this.dimensions.length > 0) return this.dimensions[0];
+		return undefined;
+	});
+
+	readonly crossFilterId = $derived.by(() => {
+		const cf = this.attributes.cross_filter;
+		if (cf === undefined || cf === false) return undefined;
+		if (typeof cf === 'string') return cf;
+		return this.crossFilterTargetColumn ?? this.attributes.id ?? 'table_filter';
+	});
+
+	readonly effectiveFilters = $derived.by(() => {
+		const fIds = this.attributes.filters ?? [];
+		if (this.crossFilterId) {
+			return fIds.filter((id) => id !== this.crossFilterId);
+		}
+		return fIds;
+	});
+
 	readonly queryConfig: SQLQueryConfig | undefined = $derived.by(() => {
 		if (this.hasBlockingError) return undefined;
 
@@ -139,7 +164,7 @@ export class TableModel extends UserComponentModel<TableModelGenerics> {
 			qualify: this.resolvedQualify,
 			order: this.order ?? this.resolvedOrder,
 			date_range: this.resolvedDateRange,
-			filters: this.attributes.filters,
+			filters: this.effectiveFilters,
 			limit: this.attributes.limit,
 			page_size: this.pageSizeOverride ?? this.attributes.page_size,
 			offset: this.serverSidePaginated

--- a/core/src/user-components/tags/table/schema.ts
+++ b/core/src/user-components/tags/table/schema.ts
@@ -43,6 +43,8 @@ const validSource: Validator = (node) => {
 	];
 };
 
+import { CROSS_FILTER_ATTRIBUTES } from '../../common/cross-filter-attributes';
+
 const attributes = {
 	data: {
 		type: String,
@@ -60,6 +62,7 @@ const attributes = {
 		suggestionType: 'filter',
 		affectsQuery: true
 	},
+	...CROSS_FILTER_ATTRIBUTES,
 	...DATE_RANGE_ATTRIBUTE,
 	...SQL_OPTIONS,
 	title: {

--- a/core/src/user-components/tags/table/table-cross-filter.test.ts
+++ b/core/src/user-components/tags/table/table-cross-filter.test.ts
@@ -1,0 +1,10 @@
+﻿import { describe, it, expect } from 'vitest';
+import { schema as tableSchema } from './schema';
+
+describe('Table Cross-Filtering & Row Drilldown', () => {
+	it('includes cross_filter attributes in table schema', () => {
+		expect(tableSchema.attributes.cross_filter).toBeDefined();
+		expect(tableSchema.attributes.cross_filter_column).toBeDefined();
+		expect(tableSchema.attributes.cross_filter_multiple).toBeDefined();
+	});
+});


### PR DESCRIPTION
﻿### Description
This PR introduces advanced interactive filtering capabilities to Evidence:
1. **`<FilterPresets>` / `filter_presets` Component (Saved Views)**:
   - Allows authors to define quick preset buttons, pills, or chips that simultaneously set multiple filter values across the page (e.g. `[ { label: "Q1 US Enterprise", values: { region: "US", segment: "Enterprise" } } ]`).
   - Supports active state detection, toggling, `variant="pills|buttons|chips"`, `size="sm|base|lg"`, and `align="left|center|right"`.
   - Included in `FILTER_INPUT_COMPONENTS` and allowed inside `<FilterBar>`.
2. **Table Row Click Cross-Filtering / Drill-down**:
   - Enables `cross_filter=true`, `cross_filter="filter_id"`, and `cross_filter_multiple=true` on `<Table>`.
   - Clicking a table row filters other charts and tables by that row's dimension value and highlights the active row.
   - Prevents self-filtering on the table itself.
3. **Expanded Date Range Presets**:
   - Added `last 14 days`, `last 60 days`, and `last 90 days` to the native preset definitions and schemas.
4. **Unit Tests**:
   - Added unit test suites for `FilterPresets`, table cross-filtering attributes, and date-range presets with full pass.
