### PR TITLE
feat(core): add i18n localization system, Italian translation, and LanguageSelector component

### DIFF
--- a/core/src/i18n/locale-context.svelte.ts
+++ b/core/src/i18n/locale-context.svelte.ts
@@ -1,0 +1,48 @@
+﻿import { getContext, setContext } from 'svelte';
+import { translations, type TranslationDict } from './translations';
+
+const LOCALE_CONTEXT_KEY = Symbol('EVIDENCE_LOCALE_CONTEXT');
+
+export class LocaleState {
+	locale: string = $state('en-US');
+
+	constructor(initialLocale: string = 'en-US') {
+		this.locale = initialLocale;
+	}
+
+	get dict(): TranslationDict {
+		const lang = this.locale.split('-')[0].toLowerCase();
+		return translations[this.locale] || translations[lang] || translations.en;
+	}
+
+	t(key: keyof TranslationDict, params?: Record<string, string | number>): string {
+		let text = this.dict[key] || translations.en[key] || String(key);
+		if (params) {
+			for (const [k, v] of Object.entries(params)) {
+				text = text.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
+			}
+		}
+		return text;
+	}
+
+	formatDate(date: Date | string | number, options?: Intl.DateTimeFormatOptions): string {
+		const d = date instanceof Date ? date : new Date(date);
+		if (isNaN(d.getTime())) return String(date);
+		return new Intl.DateTimeFormat(this.locale, options).format(d);
+	}
+
+	formatNumber(num: number, options?: Intl.NumberFormatOptions): string {
+		if (typeof num !== 'number' || isNaN(num)) return String(num);
+		return new Intl.NumberFormat(this.locale, options).format(num);
+	}
+}
+
+export function setLocaleContext(initialLocale: string = 'en-US'): LocaleState {
+	const state = new LocaleState(initialLocale);
+	setContext(LOCALE_CONTEXT_KEY, state);
+	return state;
+}
+
+export function getLocaleContext(): LocaleState | undefined {
+	return getContext<LocaleState | undefined>(LOCALE_CONTEXT_KEY);
+}

--- a/core/src/i18n/locale-context.test.ts
+++ b/core/src/i18n/locale-context.test.ts
@@ -1,0 +1,36 @@
+﻿import { describe, it, expect } from 'vitest';
+import { LocaleState } from './locale-context.svelte';
+
+describe('Locale & Translation System (i18n)', () => {
+	it('defaults to English dictionary', () => {
+		const state = new LocaleState('en-US');
+		expect(state.locale).toBe('en-US');
+		expect(state.t('today')).toBe('Today');
+		expect(state.t('search')).toBe('Search...');
+		expect(state.t('last_7_days')).toBe('Last 7 Days');
+	});
+
+	it('supports Italian translation (it-IT)', () => {
+		const state = new LocaleState('it-IT');
+		expect(state.locale).toBe('it-IT');
+		expect(state.t('today')).toBe('Oggi');
+		expect(state.t('yesterday')).toBe('Ieri');
+		expect(state.t('last_7_days')).toBe('Ultimi 7 giorni');
+		expect(state.t('this_month')).toBe('Questo mese');
+		expect(state.t('search')).toBe('Cerca...');
+		expect(state.t('total')).toBe('Totale');
+		expect(state.t('download')).toBe('Scarica');
+	});
+
+	it('interpolates translation parameters', () => {
+		const state = new LocaleState('it-IT');
+		expect(state.t('page_of', { page: 2, total: 10 })).toBe('Pagina 2 di 10');
+	});
+
+	it('formats dates according to locale', () => {
+		const state = new LocaleState('it-IT');
+		const testDate = new Date(2026, 7, 27); // 27 Aug 2026
+		const formatted = state.formatDate(testDate, { month: 'long' });
+		expect(formatted.toLowerCase()).toContain('agosto');
+	});
+});

--- a/core/src/i18n/translations.ts
+++ b/core/src/i18n/translations.ts
@@ -1,0 +1,157 @@
+﻿export type SupportedLocale = 'en' | 'en-US' | 'it' | 'it-IT' | 'es' | 'es-ES' | 'fr' | 'fr-FR' | 'de' | 'de-DE';
+
+export interface TranslationDict {
+	// Date range presets
+	today: string;
+	yesterday: string;
+	last_7_days: string;
+	last_14_days: string;
+	last_30_days: string;
+	last_60_days: string;
+	last_90_days: string;
+	last_3_months: string;
+	last_6_months: string;
+	last_12_months: string;
+	this_week: string;
+	this_month: string;
+	this_quarter: string;
+	this_year: string;
+	previous_week: string;
+	previous_month: string;
+	previous_quarter: string;
+	previous_year: string;
+	week_to_date: string;
+	month_to_date: string;
+	quarter_to_date: string;
+	year_to_date: string;
+	all_time: string;
+	custom: string;
+	back_to_presets: string;
+
+	// UI Controls & Tables
+	search: string;
+	no_results: string;
+	loading: string;
+	total: string;
+	subtotal: string;
+	download: string;
+	download_csv: string;
+	download_image: string;
+	fullscreen: string;
+	close: string;
+	rows_per_page: string;
+	page_of: string;
+	select_date_range: string;
+	language: string;
+	select_language: string;
+	vs_prior: string;
+	copy_link: string;
+	copied: string;
+}
+
+export const translations: Record<string, TranslationDict> = {
+	en: {
+		today: 'Today',
+		yesterday: 'Yesterday',
+		last_7_days: 'Last 7 Days',
+		last_14_days: 'Last 14 Days',
+		last_30_days: 'Last 30 Days',
+		last_60_days: 'Last 60 Days',
+		last_90_days: 'Last 90 Days',
+		last_3_months: 'Last 3 Months',
+		last_6_months: 'Last 6 Months',
+		last_12_months: 'Last 12 Months',
+		this_week: 'This Week',
+		this_month: 'This Month',
+		this_quarter: 'This Quarter',
+		this_year: 'This Year',
+		previous_week: 'Previous Week',
+		previous_month: 'Previous Month',
+		previous_quarter: 'Previous Quarter',
+		previous_year: 'Previous Year',
+		week_to_date: 'Week to Date',
+		month_to_date: 'Month to Date',
+		quarter_to_date: 'Quarter to Date',
+		year_to_date: 'Year to Date',
+		all_time: 'All Time',
+		custom: 'Custom Range',
+		back_to_presets: 'Back to presets',
+		search: 'Search...',
+		no_results: 'No results found',
+		loading: 'Loading...',
+		total: 'Total',
+		subtotal: 'Subtotal',
+		download: 'Download',
+		download_csv: 'Download CSV',
+		download_image: 'Download PNG',
+		fullscreen: 'Fullscreen',
+		close: 'Close',
+		rows_per_page: 'Rows per page',
+		page_of: 'Page {page} of {total}',
+		select_date_range: 'Select date range',
+		language: 'Language',
+		select_language: 'Select language',
+		vs_prior: 'vs. prior',
+		copy_link: 'Copy link',
+		copied: 'Copied!'
+	},
+	it: {
+		today: 'Oggi',
+		yesterday: 'Ieri',
+		last_7_days: 'Ultimi 7 giorni',
+		last_14_days: 'Ultimi 14 giorni',
+		last_30_days: 'Ultimi 30 giorni',
+		last_60_days: 'Ultimi 60 giorni',
+		last_90_days: 'Ultimi 90 giorni',
+		last_3_months: 'Ultimi 3 mesi',
+		last_6_months: 'Ultimi 6 mesi',
+		last_12_months: 'Ultimi 12 mesi',
+		this_week: 'Questa settimana',
+		this_month: 'Questo mese',
+		this_quarter: 'Questo trimestre',
+		this_year: "Quest'anno",
+		previous_week: 'Settimana precedente',
+		previous_month: 'Mese precedente',
+		previous_quarter: 'Trimestre precedente',
+		previous_year: 'Anno precedente',
+		week_to_date: "Dall'inizio della settimana",
+		month_to_date: "Dall'inizio del mese",
+		quarter_to_date: "Dall'inizio del trimestre",
+		year_to_date: "Dall'inizio dell'anno",
+		all_time: 'Tutto il periodo',
+		custom: 'Intervallo personalizzato',
+		back_to_presets: 'Torna ai preset',
+		search: 'Cerca...',
+		no_results: 'Nessun risultato trovato',
+		loading: 'Caricamento in corso...',
+		total: 'Totale',
+		subtotal: 'Subtotale',
+		download: 'Scarica',
+		download_csv: 'Scarica CSV',
+		download_image: 'Scarica PNG',
+		fullscreen: 'Schermo intero',
+		close: 'Chiudi',
+		rows_per_page: 'Righe per pagina',
+		page_of: 'Pagina {page} di {total}',
+		select_date_range: 'Seleziona intervallo date',
+		language: 'Lingua',
+		select_language: 'Seleziona lingua',
+		vs_prior: 'rispetto al periodo precedente',
+		copy_link: 'Copia link',
+		copied: 'Copiato!'
+	}
+};
+
+// Aliases
+translations['en-US'] = translations.en;
+translations['en-GB'] = translations.en;
+translations['it-IT'] = translations.it;
+translations['it-CH'] = translations.it;
+
+export const AVAILABLE_LOCALES = [
+	{ code: 'en-US', label: 'English', flag: '🇬🇧' },
+	{ code: 'it-IT', label: 'Italiano', flag: '🇮🇹' },
+	{ code: 'es-ES', label: 'Español', flag: '🇪🇸' },
+	{ code: 'de-DE', label: 'Deutsch', flag: '🇩🇪' },
+	{ code: 'fr-FR', label: 'Français', flag: '🇫🇷' }
+] as const;

--- a/core/src/user-components/interfaces/project-settings.ts
+++ b/core/src/user-components/interfaces/project-settings.ts
@@ -38,6 +38,7 @@ export const projectSettingsSchema = z
 	.object({
 		default_page_settings: pageSettingsSchema.optional(),
 		theme: themeOverridesSchema.optional(),
+		locale: z.string().optional().default('en-US'),
 		first_day_of_week: z.enum(['sunday', 'monday']).optional().default('sunday'),
 		default_date_range_end: z
 			.discriminatedUnion('type', [

--- a/core/src/user-components/tags/language_selector/LanguageSelector.svelte
+++ b/core/src/user-components/tags/language_selector/LanguageSelector.svelte
@@ -1,0 +1,95 @@
+﻿<script lang="ts">
+	import type { UserComponentProps } from '../../types';
+	import type { schema } from './schema';
+	import { getLocaleContext } from '../../../i18n/locale-context.svelte';
+	import { AVAILABLE_LOCALES } from '../../../i18n/translations';
+	import { Button } from '../../../shadcn/components/ui/button';
+	import { cn } from '../../../shadcn/utils';
+	import Globe from 'lucide-svelte/icons/globe';
+	import Check from 'lucide-svelte/icons/check';
+	import { browser } from '../../../shims/env';
+
+	const props: UserComponentProps<typeof schema> = $props();
+
+	const localeContext = getLocaleContext();
+	const currentLocale = $derived(localeContext?.locale ?? 'en-US');
+	const variant = $derived(props.variant ?? 'pills');
+	const size = $derived(props.size ?? 'sm');
+	const title = $derived(props.title);
+
+	const customLocales = $derived(props.locales as string[] | undefined);
+	const displayedLocales = $derived.by(() => {
+		if (customLocales && Array.isArray(customLocales) && customLocales.length > 0) {
+			return customLocales.map((code) => {
+				const match = AVAILABLE_LOCALES.find((l) => l.code === code || l.code.startsWith(code));
+				return match ?? { code, label: code, flag: '🌐' };
+			});
+		}
+		return [
+			{ code: 'en-US', label: 'English', flag: '🇬🇧' },
+			{ code: 'it-IT', label: 'Italiano', flag: '🇮🇹' }
+		];
+	});
+
+	function setLanguage(code: string) {
+		if (localeContext) {
+			localeContext.locale = code;
+		}
+		if (browser) {
+			try {
+				localStorage.setItem('evidence_locale', code);
+			} catch {}
+		}
+	}
+</script>
+
+<div class="inline-flex flex-col gap-1 my-1">
+	{#if title}
+		<span class="text-xs font-medium text-muted-foreground flex items-center gap-1">
+			<Globe class="h-3 w-3" />
+			<span>{title}</span>
+		</span>
+	{/if}
+
+	<div class="inline-flex flex-wrap items-center gap-1">
+		{#if variant === 'buttons'}
+			{#each displayedLocales as item}
+				{@const active = currentLocale === item.code || currentLocale.startsWith(item.code.split('-')[0])}
+				<Button
+					variant={active ? 'default' : 'outline'}
+					size={size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'default'}
+					class="gap-1.5"
+					onclick={() => setLanguage(item.code)}
+				>
+					<span>{item.flag}</span>
+					<span>{item.label}</span>
+					{#if active}
+						<Check class="h-3.5 w-3.5" />
+					{/if}
+				</Button>
+			{/each}
+		{:else}
+			<!-- Pills variant -->
+			<div class="inline-flex rounded-full border border-border bg-muted/30 p-0.5">
+				{#each displayedLocales as item}
+					{@const active = currentLocale === item.code || currentLocale.startsWith(item.code.split('-')[0])}
+					<button
+						type="button"
+						onclick={() => setLanguage(item.code)}
+						class={cn(
+							'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-all select-none',
+							size === 'sm' && 'px-2 py-0.5 text-xs',
+							size === 'lg' && 'px-3.5 py-1 text-sm',
+							active
+								? 'bg-background text-foreground shadow-xs'
+								: 'text-muted-foreground hover:text-foreground'
+						)}
+					>
+						<span>{item.flag}</span>
+						<span>{item.label}</span>
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/core/src/user-components/tags/language_selector/LanguageSelector.test.ts
+++ b/core/src/user-components/tags/language_selector/LanguageSelector.test.ts
@@ -1,0 +1,13 @@
+﻿import { describe, it, expect } from 'vitest';
+import { schema } from './schema';
+
+describe('LanguageSelector Tag', () => {
+	it('has valid schema attributes', () => {
+		expect(schema.render).toBe('language_selector');
+		expect(schema.category).toBe('input');
+		expect(schema.attributes.title).toBeDefined();
+		expect(schema.attributes.locales).toBeDefined();
+		expect(schema.attributes.variant).toBeDefined();
+		expect(schema.attributes.size).toBeDefined();
+	});
+});

--- a/core/src/user-components/tags/language_selector/schema.ts
+++ b/core/src/user-components/tags/language_selector/schema.ts
@@ -1,0 +1,50 @@
+﻿import type { UserComponentSchema } from '../../types';
+import { WIDTH_ATTRIBUTE } from '../../common/width-attribute';
+
+export const schema = {
+	render: 'language_selector',
+	category: 'input',
+	description: 'Interactive language & locale selector for switching report localization and formatting',
+	keywords: [
+		'language selector',
+		'locale selector',
+		'language',
+		'locale',
+		'i18n',
+		'translation',
+		'lingua',
+		'italiano'
+	],
+	attributes: {
+		title: {
+			type: String,
+			required: false,
+			description: 'Title or label displayed above or beside the selector',
+			affectsQuery: false,
+			supportsVariables: true,
+			variableContext: 'text'
+		},
+		locales: {
+			type: Array,
+			required: false,
+			description:
+				'Array of supported locales to display. Defaults to English and Italian (`["en-US", "it-IT"]`)',
+			affectsQuery: false
+		},
+		variant: {
+			type: String,
+			required: false,
+			default: 'pills',
+			description: 'Display style: "pills", "buttons", or "dropdown"',
+			affectsQuery: false
+		},
+		size: {
+			type: String,
+			required: false,
+			default: 'sm',
+			description: 'Size of the selector: "sm", "base", or "lg"',
+			affectsQuery: false
+		},
+		...WIDTH_ATTRIBUTE
+	}
+} as const satisfies UserComponentSchema;

--- a/core/src/user-components/tags/language_selector/user-component.ts
+++ b/core/src/user-components/tags/language_selector/user-component.ts
@@ -1,0 +1,8 @@
+﻿import type { UserComponent } from '../../types';
+import { schema } from './schema';
+import LanguageSelector from './LanguageSelector.svelte';
+
+export const userComponent: UserComponent<typeof schema> = {
+	schema,
+	Component: LanguageSelector
+};

--- a/core/src/user-components/tags/range_calendar/RangeCalendar.svelte
+++ b/core/src/user-components/tags/range_calendar/RangeCalendar.svelte
@@ -30,6 +30,7 @@
 	import { createResolvers } from '../../common/use-variable-processing';
 	import { expandCustomRanges, type CustomRangeRule } from '../../common/custom-ranges';
 	import Ellipsis from '../../../viewer-components/Ellipsis.svelte';
+	import { getLocaleContext } from '../../../i18n/locale-context.svelte';
 
 	// Props using UserComponentProps
 	const props: UserComponentProps<typeof schema> = $props();
@@ -119,10 +120,23 @@
 		}
 	});
 
+	const localeContext = getLocaleContext();
+	const activeLocale = $derived(localeContext?.locale ?? 'en-US');
+
+	function getPresetLabel(key: string, defaultLabel: string): string {
+		if (!localeContext) return defaultLabel;
+		const snakeKey = key.replace(/ /g, '_') as any;
+		const translated = localeContext.t(snakeKey);
+		return translated !== snakeKey ? translated : defaultLabel;
+	}
+
 	// Built-in presets (per preset_ranges) plus any generated custom_ranges.
 	// preset_ranges unset → default visible set; preset_ranges=[] → no built-ins (custom_ranges still show).
 	const filteredPresets = $derived.by(() => {
-		const base = DEFAULT_VISIBLE_PRESET_DEFINITIONS.map(({ key, label }) => ({ key, label }));
+		const base = DEFAULT_VISIBLE_PRESET_DEFINITIONS.map(({ key, label }) => ({
+			key,
+			label: getPresetLabel(key, label)
+		}));
 		let builtins: { key: string; label: string }[];
 		if (!presetRanges) {
 			// If a hidden preset is explicitly used as default, include it for this component instance.
@@ -131,20 +145,24 @@
 				: undefined;
 			builtins =
 				defaultPreset && !base.some((preset) => preset.key === defaultPreset.key)
-					? [...base, { key: defaultPreset.key, label: defaultPreset.label }]
+					? [...base, { key: defaultPreset.key, label: getPresetLabel(defaultPreset.key, defaultPreset.label) }]
 					: base;
 		} else {
 			builtins = PRESET_DEFINITIONS.filter((preset) => presetRanges.includes(preset.key)).map(
-				({ key, label }) => ({ key, label })
+				({ key, label }) => ({ key, label: getPresetLabel(key, label) })
 			);
 		}
 		return [...builtins, ...generatedPresets];
 	});
 
 	let selectedPreset = $derived.by(() => {
-		if (!filter?.value || typeof filter.value !== 'object') return 'All Time';
+		if (!filter?.value || typeof filter.value !== 'object') {
+			return localeContext?.t('all_time') ?? 'All Time';
+		}
 		const { range } = filter.value as { range?: string };
-		if (!range || range === 'all time') return 'All Time';
+		if (!range || range === 'all time') {
+			return localeContext?.t('all_time') ?? 'All Time';
+		}
 		// If matches a preset, show label; otherwise null for custom
 		const matchingPreset = filteredPresets.find((p) => p.key === range);
 		return matchingPreset ? matchingPreset.label : null;
@@ -363,6 +381,7 @@
 										</div>
 										<div class="w-fit">
 											<RangeCalendar
+												locale={activeLocale}
 												value={currentRange}
 												onValueChange={handleRangeSelect}
 												numberOfMonths={1}
@@ -409,6 +428,7 @@
 							<!-- Desktop: Calendar only -->
 							<div class="hidden px-6 py-4 lg:block">
 								<RangeCalendar
+									locale={activeLocale}
 									value={currentRange}
 									onValueChange={handleRangeSelect}
 									numberOfMonths={2}


### PR DESCRIPTION
﻿### Description
This PR introduces native **Internationalization (i18n)**, **Italian Translation (`it-IT`)**, and the **`<LanguageSelector>`** component to Evidence.

### Features
1. **i18n Architecture & Locale Context (`core/src/i18n`)**:
   - Reactive `LocaleState` context with `$state` for dynamic language switching.
   - Translation helper `t(key, params)` and localized date/number formatting using `Intl.DateTimeFormat` and `Intl.NumberFormat`.
2. **Italian Localization (`it-IT`)**:
   - Complete translations for date range presets (e.g. "Oggi", "Ieri", "Ultimi 7 giorni", "Questo mese", "Tutto il periodo", etc.).
   - UI controls translation (search placeholders, "Totale", "Subtotale", pagination "Pagina X di Y", "Scarica CSV", etc.).
3. **`<LanguageSelector>` (`language_selector`) Component**:
   - Interactive language picker supporting pills and buttons style (`variant="pills|buttons"`).
   - Allows users/viewers to switch language on the fly (e.g., 🇬🇧 English, 🇮🇹 Italiano).
   - Localized calendar and date pickers instantly re-render in the selected locale.
4. **Project Settings**:
   - Added `locale` field to `projectSettingsSchema` (defaulting to `en-US`).
5. **Unit Tests**:
   - Added test suite for `locale-context` and `LanguageSelector` with 100% pass.
