### PR TITLE
fix(inputs): stop baking DISTINCT into data-driven option queries

### DIFF
--- a/core/src/user-components/common/option-query-group-by.test.ts
+++ b/core/src/user-components/common/option-query-group-by.test.ts
@@ -94,8 +94,26 @@ describe.each(WAREHOUSES)('options query for data-driven inputs — %s', (wareho
 /**
  * A guard on the call sites themselves: the components build their value column as a
  * template string, so a regression would reintroduce `DISTINCT ${col} as value` without
- * failing any assertion above.
+ * failing any assertion above — the dialect assertions build their own input, so they
+ * can't see what a component chose to pass.
+ *
+ * Matched on the shape of the construction rather than on the argument to
+ * `processColumnExpression`, so that assigning the string to a variable first doesn't
+ * slip past. `ALL` is caught alongside `DISTINCT`: it's the other set quantifier, and
+ * `GROUP BY ALL <expr>` fails in DataFusion exactly the same way.
  */
+const QUANTIFIER_IN_EXPRESSION = [
+	/** A template literal opening with a quantifier: `DISTINCT ${col} as value`. */
+	/`\s*(?:DISTINCT|ALL)\s+\$\{/i,
+	/** The concatenated form: 'DISTINCT ' + col + ' as value'. */
+	/['"]\s*(?:DISTINCT|ALL)\s*['"]\s*\+/i
+];
+
+/** Comments legitimately discuss `DISTINCT` — this file's own call sites do. */
+function stripComments(source: string): string {
+	return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
 describe('data-driven input call sites', () => {
 	const CALL_SITES = [
 		'../tags/dropdown/Dropdown.svelte',
@@ -105,8 +123,12 @@ describe('data-driven input call sites', () => {
 		'../tags/repeat/build-repeat-query-config.ts'
 	];
 
-	it.each(CALL_SITES)('%s does not bake DISTINCT into the value column expression', (relative) => {
-		const source = readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
-		expect(source).not.toMatch(/value:\s*[`'"]\s*DISTINCT\b/i);
+	it.each(CALL_SITES)('%s does not bake a set quantifier into a column expression', (relative) => {
+		const source = stripComments(
+			readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8')
+		);
+		for (const pattern of QUANTIFIER_IN_EXPRESSION) {
+			expect(source).not.toMatch(pattern);
+		}
 	});
 });

--- a/core/src/user-components/common/option-query-group-by.test.ts
+++ b/core/src/user-components/common/option-query-group-by.test.ts
@@ -57,23 +57,37 @@ function optionsQuerySql(dialect: SqlDialect, withLabel: boolean): string {
 	return sql!;
 }
 
+/**
+ * The GROUP BY clause only — deliberately not the whole query. `DISTINCT` is legal
+ * elsewhere: `shouldAddDistinct` exists to put one on the SELECT list, and `IS NOT DISTINCT
+ * FROM` is this codebase's own null-safe equality (`SqlDialect.nullSafeEqual`), which an
+ * author's `where` could contain. Asserting over the whole query would fail on SQL that
+ * isn't broken.
+ */
+function groupByClause(sql: string): string {
+	const match = /\bGROUP BY\b([\s\S]*?)(?=\bHAVING\b|\bQUALIFY\b|\bORDER BY\b|\bLIMIT\b|\bOFFSET\b|$)/i.exec(
+		sql
+	);
+	expect(match, `no GROUP BY in: ${sql}`).not.toBeNull();
+	return match![1];
+}
+
 describe.each(WAREHOUSES)('options query for data-driven inputs — %s', (warehouse) => {
 	const dialect = dialectFor(warehouse);
 
 	it.each([
 		['value only', false],
 		['value and label', true]
-	])('emits no DISTINCT anywhere in the query (%s)', (_label, withLabel) => {
-		const sql = optionsQuerySql(dialect, withLabel as boolean);
-		expect(sql).not.toMatch(/\bDISTINCT\b/i);
+	])('emits no DISTINCT quantifier in the GROUP BY (%s)', (_label, withLabel) => {
+		expect(groupByClause(optionsQuerySql(dialect, withLabel as boolean))).not.toMatch(
+			/\bDISTINCT\b/i
+		);
 	});
 
 	it('still de-duplicates via GROUP BY', () => {
-		const sql = optionsQuerySql(dialect, false);
 		// Either an explicit list or `GROUP BY ALL`, depending on the dialect — but never absent,
 		// since the GROUP BY is the only thing making the options unique.
-		expect(sql).toMatch(/\bGROUP BY\b/i);
-		expect(sql).not.toMatch(/GROUP BY\s+DISTINCT\b/i);
+		expect(groupByClause(optionsQuerySql(dialect, false)).trim()).not.toBe('');
 	});
 });
 

--- a/core/src/user-components/common/option-query-group-by.test.ts
+++ b/core/src/user-components/common/option-query-group-by.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { generateSQLQuery, type SQLQueryConfig } from './sql-options';
+import { processColumnExpression } from './sql-expression-utils';
+import { dialectFor, type SqlDialect, type WarehouseType } from '../../sql-dialect';
+
+/**
+ * Data-driven inputs (dropdown, button_group, input_tabs, table_filter, repeat) list the
+ * values of a column with an options query. That query has no aggregate over the value
+ * column, so `generateSQLQuery` puts the column in the GROUP BY — which is what makes the
+ * options distinct.
+ *
+ * Baking `DISTINCT` into the column expression instead put it in the GROUP BY too
+ * (`GROUP BY DISTINCT store`), because `processColumnExpression` keeps the whole string as
+ * `sqlWithoutAlias` and `hasAgg` doesn't recognise a bare quantifier. Postgres 14+ accepts
+ * that form (it de-duplicates grouping sets), so it went unnoticed; Cube's DataFusion-based
+ * parser rejects it with `Expected: joined table, found: store` and every dropdown rendered
+ * "No options found".
+ */
+
+const WAREHOUSES: WarehouseType[] = [
+	'clickhouse',
+	'snowflake',
+	'bigquery',
+	'fabric',
+	'databricks',
+	'postgres',
+	'cube',
+	'motherduck'
+];
+
+const COLUMN = 'store';
+
+/** The shape every data-driven input builds: value column, optional label, no aggregate. */
+function optionsQuerySql(dialect: SqlDialect, withLabel: boolean): string {
+	const columns = [processColumnExpression({ value: `${COLUMN} as value` }, dialect)];
+	if (withLabel) {
+		columns.push(processColumnExpression({ value: 'store_name as label' }, dialect));
+	}
+	const config: SQLQueryConfig = {
+		tableExpressionName: 'ga4_sessions',
+		columns,
+		where: `${COLUMN} IS NOT NULL`,
+		order: COLUMN,
+		limit: 10000
+	};
+	const { sql, error } = generateSQLQuery(
+		config,
+		undefined,
+		undefined,
+		undefined,
+		'sunday',
+		dialect
+	);
+	expect(error).toBeUndefined();
+	return sql!;
+}
+
+describe.each(WAREHOUSES)('options query for data-driven inputs — %s', (warehouse) => {
+	const dialect = dialectFor(warehouse);
+
+	it.each([
+		['value only', false],
+		['value and label', true]
+	])('emits no DISTINCT anywhere in the query (%s)', (_label, withLabel) => {
+		const sql = optionsQuerySql(dialect, withLabel as boolean);
+		expect(sql).not.toMatch(/\bDISTINCT\b/i);
+	});
+
+	it('still de-duplicates via GROUP BY', () => {
+		const sql = optionsQuerySql(dialect, false);
+		// Either an explicit list or `GROUP BY ALL`, depending on the dialect — but never absent,
+		// since the GROUP BY is the only thing making the options unique.
+		expect(sql).toMatch(/\bGROUP BY\b/i);
+		expect(sql).not.toMatch(/GROUP BY\s+DISTINCT\b/i);
+	});
+});
+
+/**
+ * A guard on the call sites themselves: the components build their value column as a
+ * template string, so a regression would reintroduce `DISTINCT ${col} as value` without
+ * failing any assertion above.
+ */
+describe('data-driven input call sites', () => {
+	const CALL_SITES = [
+		'../tags/dropdown/Dropdown.svelte',
+		'../tags/button_group/ButtonGroup.svelte',
+		'../tags/input_tabs/InputTabs.svelte',
+		'../tags/table_filter/StringValueSelector.svelte',
+		'../tags/repeat/build-repeat-query-config.ts'
+	];
+
+	it.each(CALL_SITES)('%s does not bake DISTINCT into the value column expression', (relative) => {
+		const source = readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
+		expect(source).not.toMatch(/value:\s*[`'"]\s*DISTINCT\b/i);
+	});
+});

--- a/core/src/user-components/tags/button_group/ButtonGroup.svelte
+++ b/core/src/user-components/tags/button_group/ButtonGroup.svelte
@@ -107,8 +107,10 @@
 			return;
 		}
 
+		// Deduplication is the GROUP BY's job — see Dropdown.svelte. A `DISTINCT` in the
+		// expression would be copied into `GROUP BY DISTINCT col`, which Cube rejects.
 		const valueProcessed = processColumnExpression(
-			{ value: `DISTINCT ${valueColumn} as value` },
+			{ value: `${valueColumn} as value` },
 			connection.dialect
 		);
 

--- a/core/src/user-components/tags/dropdown/Dropdown.svelte
+++ b/core/src/user-components/tags/dropdown/Dropdown.svelte
@@ -145,9 +145,12 @@
 			return;
 		}
 
+		// Distinct values come from the GROUP BY that generateSQLQuery emits for every
+		// non-aggregate column — a `DISTINCT` baked into the expression would also land in
+		// that GROUP BY (`GROUP BY DISTINCT col`), which Cube's parser rejects outright.
 		const valueProcessed = processColumnExpression(
 			{
-				value: `DISTINCT ${valueColumn} as value`
+				value: `${valueColumn} as value`
 			},
 			connection.dialect
 		);

--- a/core/src/user-components/tags/input_tabs/InputTabs.svelte
+++ b/core/src/user-components/tags/input_tabs/InputTabs.svelte
@@ -199,8 +199,10 @@
 			return;
 		}
 
+		// Deduplication is the GROUP BY's job — see Dropdown.svelte. A `DISTINCT` in the
+		// expression would be copied into `GROUP BY DISTINCT col`, which Cube rejects.
 		const valueProcessed = processColumnExpression(
-			{ value: `DISTINCT ${valueColumn} as value` },
+			{ value: `${valueColumn} as value` },
 			connection.dialect
 		);
 

--- a/core/src/user-components/tags/repeat/build-repeat-query-config.test.ts
+++ b/core/src/user-components/tags/repeat/build-repeat-query-config.test.ts
@@ -23,7 +23,7 @@ describe('buildRepeatQueryConfig', () => {
 
 		expect(sql).toContain('FROM demo."orders"" UNION ALL SELECT * FROM secrets --"');
 		expect(config.columns[0]?.sqlWithAlias).toBe(
-			String.raw`DISTINCT "category\\"" OR 1=1 --" AS "value"`
+			String.raw`"category\\"" OR 1=1 --" AS "value"`
 		);
 		expect(config.where).toBe(String.raw`"category\\"" OR 1=1 --" IS NOT NULL`);
 		expect(config.order).toBe(String.raw`"category\\"" OR 1=1 --" ASC`);
@@ -66,9 +66,7 @@ describe('buildRepeatQueryConfig', () => {
 			dialect
 		});
 
-		expect(expression.columns[0]?.sqlWithAlias).toBe(
-			'DISTINCT "substring(category, 1, 4)" AS "value"'
-		);
+		expect(expression.columns[0]?.sqlWithAlias).toBe('"substring(category, 1, 4)" AS "value"');
 		expect(expression.where).toBe('"substring(category, 1, 4)" IS NOT NULL');
 		expect(resolveRepeatColumnExpression('{{picker}}', () => 'unknown(category)', dialect)).toBe(
 			'"unknown(category)"'
@@ -96,7 +94,7 @@ describe('buildRepeatQueryConfig', () => {
 			"date_trunc('month', ordered_at)"
 		])
 			expect(resolveRepeatColumnExpression(written, () => 'unused', dialect)).toBe(written);
-		expect(qualified.columns[0]?.sqlWithAlias).toBe('DISTINCT daily_orders.category AS "value"');
+		expect(qualified.columns[0]?.sqlWithAlias).toBe('daily_orders.category AS "value"');
 		expect(qualified.where).toBe('daily_orders.category IS NOT NULL');
 	});
 

--- a/core/src/user-components/tags/repeat/build-repeat-query-config.ts
+++ b/core/src/user-components/tags/repeat/build-repeat-query-config.ts
@@ -51,9 +51,11 @@ export function buildRepeatQueryConfig({
 	where: string | undefined;
 	dialect: SqlDialect;
 }): SQLQueryConfig {
+	// Deduplication is the GROUP BY's job — see Dropdown.svelte. A `DISTINCT` in the
+	// expression would be copied into `GROUP BY DISTINCT col`, which Cube rejects.
 	const valueProcessed = processColumnExpression(
 		{
-			value: `DISTINCT ${column} as value`
+			value: `${column} as value`
 		},
 		dialect
 	);

--- a/core/src/user-components/tags/table_filter/StringValueSelector.svelte
+++ b/core/src/user-components/tags/table_filter/StringValueSelector.svelte
@@ -143,9 +143,11 @@
 		}
 
 		// Process column expressions like the Dropdown component
+		// The COUNT(*) below already forces a GROUP BY on this column, so the rows are
+		// distinct without the keyword — and `GROUP BY DISTINCT col` breaks Cube.
 		const valueProcessed = processColumnExpression(
 			{
-				value: `DISTINCT ${columnName} as value`
+				value: `${columnName} as value`
 			},
 			connection.dialect
 		);

--- a/core/src/user-components/tags/table_filter/StringValueSelector.svelte
+++ b/core/src/user-components/tags/table_filter/StringValueSelector.svelte
@@ -143,8 +143,10 @@
 		}
 
 		// Process column expressions like the Dropdown component
-		// The COUNT(*) below already forces a GROUP BY on this column, so the rows are
-		// distinct without the keyword — and `GROUP BY DISTINCT col` breaks Cube.
+		// Deduplication is the GROUP BY's job — see Dropdown.svelte. A `DISTINCT` in the
+		// expression would be copied into `GROUP BY DISTINCT col`, which Cube rejects.
+		// (The COUNT(*) below is for minimum_records, not for grouping — generateSQLQuery
+		// emits the GROUP BY whether or not an aggregate is present.)
 		const valueProcessed = processColumnExpression(
 			{
 				value: `${columnName} as value`

--- a/core/src/user-components/tags/table_filter/string-value-selector-order.test.ts
+++ b/core/src/user-components/tags/table_filter/string-value-selector-order.test.ts
@@ -6,7 +6,7 @@ import { buildValueQueryOrder } from './filterUtils.svelte';
 
 /**
  * The table-filter value picker (StringValueSelector) lists selectable values with a
- * `SELECT DISTINCT col AS "value", COUNT(*) AS "count" ... ORDER BY …` query. Ordering by
+ * `SELECT col AS "value", COUNT(*) AS "count" ... GROUP BY … ORDER BY …` query. Ordering by
  * the `value`/`count` *aliases* breaks on uppercase-folding warehouses (Snowflake): the
  * alias is emitted quoted-lowercase (`"value"`), but a bare `ORDER BY value` folds to
  * `VALUE` and errors with `invalid identifier 'VALUE'`. The picker must order by the
@@ -32,7 +32,7 @@ function optionsQuerySql(order: string, dialect: SqlDialect): string {
 	const config: SQLQueryConfig = {
 		tableExpressionName: 'orders',
 		columns: [
-			processColumnExpression({ value: `DISTINCT ${COLUMN} as value` }, dialect),
+			processColumnExpression({ value: `${COLUMN} as value` }, dialect),
 			processColumnExpression({ value: 'COUNT(*) as count' }, dialect)
 		],
 		where: `${COLUMN} IS NOT NULL`,


### PR DESCRIPTION
## Personal Message

Hi @hughess posting this PR as a potential fix for an issue I also reported in Slack. When testing the new OSS Evidence I ran into the problem that dropdown filters do not work with the Cube SQL API because the generated SQL adds DISTINCT in the GROUP BY clause which Cube SQL API does not accept. Dropdown values do not populate because of this. Code in this PR is AI-driven but I did confirm locally that dropdowns work correctly after this fix. Let me know if creating PRs this way is desired or if you prefer me to only post issues if I run into future problems. Thanks!

**Everything below AI-generated:**

---

## Problem

Every data-driven input is broken against Cube — dropdowns render "No options found"
and the options query 500s:

```sql
SELECT DISTINCT store AS "value" FROM ga4_sessions
WHERE (store IS NOT NULL)
GROUP BY DISTINCT store          -- SQL Parser Error: Expected: joined table, found: store
ORDER BY store LIMIT 10000
```

## Root cause

The inputs build the value column with the quantifier baked into the string:

```js
processColumnExpression({ value: `DISTINCT ${valueColumn} as value` }, dialect)
```

`processColumnExpression` keeps the remainder as `sqlWithoutAlias` (`DISTINCT store`);
`hasAgg` only matches an aggregate name followed by `(`, so the column is classified as a
plain dimension; and `generateSQLQuery` copies every non-aggregate column's
`sqlWithoutAlias` into the grouping list (`sql-options.ts:583`) — yielding
`GROUP BY DISTINCT store`.

That form is valid in PostgreSQL 14+ (it de-duplicates grouping sets), so most engines
tolerated the redundant clause. Cube's DataFusion parser rejects it. It's also invalid
T-SQL, so Fabric was affected too.

## Fix

```diff
-  value: `DISTINCT ${valueColumn} as value`
+  value: `${valueColumn} as value`
```

The `GROUP BY` was already doing the de-duplication, so the keyword was pure redundancy.
It's emitted unconditionally — `willUseGroupBy = !config.skipGroupBy`
(`sql-options.ts:532`), and only `image/build-image-sql.ts` sets `skipGroupBy` — and every
option config keeps a non-aggregate column, so the clause is never empty.

Applied to all five call sites: `dropdown`, `button_group`, `input_tabs`, `table_filter`
(`StringValueSelector`), and `repeat` (`build-repeat-query-config.ts`). `dimension_grid`
hand-writes its own SQL and is unaffected.

Behaviour is otherwise unchanged: the alias stays `value`, `hasAgg` stays `false`, and
ORDER BY handling is unaffected. On `GROUP BY ALL` dialects (ClickHouse, Snowflake,
BigQuery, Databricks, MotherDuck) only the redundant `SELECT DISTINCT` goes; on explicit
ones (Postgres, Cube, Fabric) the grouping list loses the quantifier.

`SQLQueryConfig.shouldAddDistinct` (declared `:146`, honoured `:679`) would add a
query-level `DISTINCT`, but it's dead code and `SELECT DISTINCT … GROUP BY …` is redundant
by construction, so I left it unused. Happy to wire it up or delete it if maintainers
prefer.

## Testing

New `core/src/user-components/common/option-query-group-by.test.ts` asserts across all
eight dialects that the options query emits a non-empty `GROUP BY` with no set quantifier
in it. Scoped to that clause on purpose: `DISTINCT` is legal elsewhere (`shouldAddDistinct`,
and `IS NOT DISTINCT FROM` from `nullSafeEqual`). A second guard scans the call sites, since
the expression is a template string no SQL assertion can see into; it matches the
construction shape and covers `ALL` too, and is mutation-tested against four evasions.

Expectations updated in `build-repeat-query-config.test.ts` and
`string-value-selector-order.test.ts`.

```
pnpm test    → core 232 files / 3652 passed, 3 skipped; cli 18 files / 340 passed
pnpm check   → core 0 errors
```

## Known follow-up (not in this PR)

`hasAgg` still doesn't recognise a bare quantifier, so an author-written
`<BarChart x="distinct category" />` still produces `GROUP BY distinct category` and the
same Cube error. Closing that class means stripping or rejecting the quantifier at
`sql-options.ts:583` — wider blast radius, so I kept it separate. Glad to follow up.
