### PR TITLE
fix(dropdown): keep query-sourced selections while the options query loads

### DIFF
--- a/core/src/user-components/tags/dropdown/Dropdown.svelte
+++ b/core/src/user-components/tags/dropdown/Dropdown.svelte
@@ -355,9 +355,14 @@
 				selectedOptionsQuery.error !== null);
 		const hasQueryResults = optionsQuery.result !== undefined && !selectedRowsPending;
 		const hasStaticOptions = optionsFromProp.length > 0 || optionsFromChildren.length > 0;
+		// A configured options query that has not produced a result yet. Static
+		// options alone must not switch validation on: a dropdown that mixes a
+		// static "All" entry with `data=` options would otherwise clear every
+		// query-sourced selection on first paint, URL-hydrated values included.
+		const optionsQueryPending = queryConfig !== undefined && optionsQuery.result === undefined;
 
 		const availableValues = new Set(combinedOptions.map((opt) => opt.value));
-		const validationOpts = { hasQueryResults, hasStaticOptions };
+		const validationOpts = { hasQueryResults, hasStaticOptions, optionsQueryPending };
 
 		if (multiple) {
 			// Filter out any selections that are no longer available. `isDropdownValueValid`

--- a/core/src/user-components/tags/dropdown/validation.test.ts
+++ b/core/src/user-components/tags/dropdown/validation.test.ts
@@ -84,6 +84,49 @@ describe('isDropdownValueValid', () => {
 		).toBe(false);
 	});
 
+	it('keeps a query-sourced value while the options query is still pending, despite static options', () => {
+		// The regression this guards: a dropdown that mixes a static
+		// `dropdown_option` (an "All" entry) with `data=` options. Before the
+		// query lands, `availableValues` holds only the static value, so
+		// validating there cleared any legitimate query-sourced selection —
+		// including the one hydrated from the URL, which then vanished from
+		// the query string too, breaking shareable links.
+		expect(
+			isDropdownValueValid('active', new Set(['%']), {
+				hasQueryResults: false,
+				hasStaticOptions: true,
+				optionsQueryPending: true
+			})
+		).toBe(true);
+	});
+
+	it('validates again as soon as the options query settles', () => {
+		expect(
+			isDropdownValueValid('active', new Set(['%']), {
+				hasQueryResults: true,
+				hasStaticOptions: true,
+				optionsQueryPending: false
+			})
+		).toBe(false);
+		expect(
+			isDropdownValueValid('active', new Set(['%', 'active']), {
+				hasQueryResults: true,
+				hasStaticOptions: true,
+				optionsQueryPending: false
+			})
+		).toBe(true);
+	});
+
+	it('leaves dropdowns without a query untouched: no pending state, static options still validate', () => {
+		expect(
+			isDropdownValueValid('not_in_static', new Set(['a', 'b']), {
+				hasQueryResults: false,
+				hasStaticOptions: true,
+				optionsQueryPending: false
+			})
+		).toBe(false);
+	});
+
 	it('keeps empty/undefined values without inspecting options', () => {
 		expect(
 			isDropdownValueValid(undefined, availableValues, {

--- a/core/src/user-components/tags/dropdown/validation.ts
+++ b/core/src/user-components/tags/dropdown/validation.ts
@@ -5,7 +5,17 @@
  * Used by `Dropdown.svelte` to decide whether to clear the underlying filter
  * when the options query result no longer contains the user's selection.
  *
- * Three states matter:
+ * Four states matter:
+ *
+ *   0. **Options query configured but not settled** (`optionsQueryPending`) —
+ *      return true, whatever the static options say. A dropdown can mix a
+ *      static `dropdown_option` (typically an "All" entry) with options coming
+ *      from `data=`. Until the query returns, the only values we know are the
+ *      static ones, so validating against them would clear every legitimate
+ *      query-sourced selection — the URL-hydrated one included. Without this
+ *      state, `hasStaticOptions` alone switched validation on, and a single
+ *      `dropdown_option` child was enough to make `?id=<a query value>` reset
+ *      to empty on first paint.
  *
  *   1. **Still loading** (`!hasQueryResults && !hasStaticOptions`) — return
  *      true. We have no information yet, so don't drop the value. This keeps
@@ -30,9 +40,21 @@
 export function isDropdownValueValid(
 	value: string | undefined,
 	availableValues: Set<string>,
-	opts: { hasQueryResults: boolean; hasStaticOptions: boolean }
+	opts: {
+		hasQueryResults: boolean;
+		hasStaticOptions: boolean;
+		/**
+		 * An options query is configured and has not produced a result yet.
+		 * Treated as "we do not know the option universe", which is also the
+		 * conservative reading when the query errored: keeping a selection we
+		 * cannot check beats clearing one that was valid.
+		 */
+		optionsQueryPending?: boolean;
+	}
 ): boolean {
 	if (!value) return true;
+
+	if (opts.optionsQueryPending) return true;
 
 	const shouldValidate = opts.hasQueryResults || opts.hasStaticOptions;
 	if (!shouldValidate) return true;


### PR DESCRIPTION
### Summary
Prevents single-select and multi-select dropdowns from prematurely clearing query-sourced selections when static `dropdown_option` children (e.g. an "All" option) are present, ensuring URL-hydrated filter values and `initial_value` selections survive initial page hydration while options are loading.

### Problem / Motivation
A dropdown often mixes static `dropdown_option` children (typically an "All" or default entry) with dynamic options populated from `data=`:

```svelte
<Dropdown data={categories} id="category" value_column="code" initial_value="all">
    <DropdownOption value="all" label="All Categories" />
</Dropdown>
```

Currently, `isDropdownValueValid` (`core/src/user-components/tags/dropdown/validation.ts`) switches validation on as soon as static options exist (`hasStaticOptions`). Because the options query has not resolved on first paint, `availableValues` only contains the static options.

**What went wrong:**
- Any query-sourced selection (such as a link opened with `?category=electronics`) fails validation against the static option set alone and is cleared on initial mount.
- The URL filter writer subsequently detects the empty value and strips the query parameter from the browser URL, destroying shareable/bookmarkable links.
- `initial_value` suffers the same failure whenever it refers to a query-sourced value.
- Conversely, dropdowns with *no* static children keep their query-sourced values as expected, which makes this bug particularly confusing and difficult to diagnose.

### Solution
- Introduce an explicit `optionsQueryPending` state (`queryConfig !== undefined && optionsQuery.result === undefined`) indicating that an options query is configured but has not yet produced a result.
- While `optionsQueryPending` is `true`, `isDropdownValueValid` preserves the current selection regardless of static options.
- Once the options query settles, standard validation resumes immediately, ensuring cascading dropdowns still clear genuinely stale selections when dependent parameters change.
- A query that encounters an error is treated conservatively in the same way, consistent with Evidence's existing handling for empty query results: preserving a selection that cannot currently be checked is safer than clearing a valid one.
- Dropdowns without an options query have no pending state and continue validating against static options exactly as before.

### Testing
- [x] Added unit tests in `core/src/user-components/tags/dropdown/validation.test.ts`:
  - `keeps a query-sourced value while the options query is still pending, despite static options`
  - `validates again as soon as the options query settles`
  - `leaves dropdowns without a query untouched: no pending state, static options still validate`
- [x] Ran unit tests via Vitest: 10/10 passed cleanly.
- [x] Ran type checks via `pnpm --filter @evidence/core check`: 0 errors.

### Checklist
- [x] Changes are confined to `core/**` (no files at repository root).
- [x] Follows project code style and conventions.
- [x] Commit message follows Conventional Commits format.